### PR TITLE
feat: Add database client with CRUD methods and pre-push hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,154 @@
-# `zif-lib` - Detailed Documentation
+# `zif-lib` - Shared Go Library
 
 ## Purpose
 
 Shared Go module providing:
-1. Exchange abstractions (interfaces and implementations for Hyperliquid, Lighter, Drift)
-2. Database models (Go structs matching the database schema)
-3. Common utilities (rate limiting, retry logic, error handling)
+1. **Database models** - Go structs matching the database schema
+2. **Database client** - GraphQL client for Hasura with CRUD methods
+3. **Exchange abstractions** - Interfaces and implementations (future)
+4. **Common utilities** - Rate limiting, retry logic, error handling (future)
 
-**This is a pure library** - no services, no main functions, no business logic. It's imported by other services.
+**This is a pure library** - no services, no main functions. It's imported by other services.
+
+---
+
+## Getting Started
+
+### Clone and Setup
+
+```bash
+git clone <repo-url>
+cd lib
+
+# Configure Git hooks (one-time setup)
+./scripts/setup-hooks.sh
+```
+
+### Run Tests
+
+```bash
+# Run all unit tests
+./scripts/run_tests.sh
+
+# Or directly with Go
+go test ./...
+```
+
+---
+
+## Package Structure
+
+### `models/` - Data Structures
+
+Pure data structures matching the database schema:
+
+- **`models/exchange.go`**
+  - `Exchange` - Exchange entity struct
+  - `ExchangeInput` - Input struct for mutations
+
+- **`models/account.go`**
+  - `ExchangeAccount` - Exchange account entity struct
+  - `ExchangeAccountInput` - Input struct for mutations
+
+### `db/` - Database Client
+
+GraphQL client for interacting with Hasura. Provides CRUD operations for exchanges and accounts.
+
+#### Client Creation
+
+```go
+import "github.com/zif-terminal/lib/db"
+
+client := db.NewClient(db.ClientConfig{
+    URL:         "http://localhost:8080/v1/graphql",
+    AdminSecret: "your-admin-secret",
+})
+```
+
+#### Exchange Methods
+
+- **`GetExchange(ctx, id)`** - Get single exchange by ID
+- **`ListExchanges(ctx)`** - List all exchanges
+- **`CreateExchange(ctx, input)`** - Create new exchange
+- **`UpdateExchange(ctx, id, input)`** - Update existing exchange
+
+#### Account Methods
+
+- **`GetAccount(ctx, id)`** - Get single account by ID
+- **`ListAccounts(ctx)`** - List all accounts
+- **`CreateAccount(ctx, input)`** - Create new account
+- **`UpdateAccount(ctx, id, input)`** - Update existing account
+- **`DeleteAccount(ctx, id)`** - Delete account
+
+#### Example Usage
+
+```go
+ctx := context.Background()
+
+// Create an exchange
+exchange, err := client.CreateExchange(ctx, &db.ExchangeInput{
+    Name:        "hyperliquid",
+    DisplayName: "Hyperliquid",
+})
+
+// Create an account
+account, err := client.CreateAccount(ctx, &db.ExchangeAccountInput{
+    ExchangeID:        exchange.ID,
+    AccountIdentifier: "0x123...",
+    AccountType:       "main",
+})
+```
+
+---
+
+## Testing
+
+### Unit Tests
+
+All database methods have unit tests with mocked GraphQL responses:
+
+```bash
+go test ./db/... -v
+```
+
+**Test Coverage:**
+- 5 exchange tests (Get, List, Create, Update, Update NotFound)
+- 10 account tests (Get, List, Create, Update, Delete, and NotFound variants)
+
+### Git Pre-Push Hook
+
+Unit tests run automatically before every `git push`:
+
+- **Setup:** Run `./scripts/setup-hooks.sh` once (already done)
+- **Automatic:** Tests run on every push
+- **Bypass:** Use `git push --no-verify` (not recommended)
+
+---
+
+## Repository Structure
+
+```
+lib/
+├── models/           # Data structures
+│   ├── exchange.go
+│   └── account.go
+├── db/               # Database client
+│   ├── client.go     # GraphQL client wrapper
+│   ├── exchanges.go  # Exchange CRUD methods
+│   ├── accounts.go   # Account CRUD methods
+│   ├── exchanges_test.go
+│   └── accounts_test.go
+├── scripts/
+│   ├── run_tests.sh      # Test runner script
+│   └── setup-hooks.sh    # Git hooks setup
+├── hooks/
+│   └── pre-push          # Pre-push hook (runs tests)
+├── go.mod
+└── README.md
+```
+
+---
+
+## Dependencies
+
+- `github.com/machinebox/graphql` - GraphQL client library

--- a/db/accounts.go
+++ b/db/accounts.go
@@ -1,0 +1,393 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// ExchangeAccount represents an exchange account model (aliased from models package)
+type ExchangeAccount = models.ExchangeAccount
+
+// ExchangeAccountInput represents exchange account input for mutations (aliased from models package)
+type ExchangeAccountInput = models.ExchangeAccountInput
+
+// GetAccount retrieves a single exchange account by ID
+func (c *Client) GetAccount(ctx context.Context, id string) (*ExchangeAccount, error) {
+	query := `
+		query GetAccount($id: uuid!) {
+			exchange_accounts_by_pk(id: $id) {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": id,
+	})
+
+	var resp struct {
+		ExchangeAccountsByPk *ExchangeAccount `json:"exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get account: %w", err)
+	}
+
+	if resp.ExchangeAccountsByPk == nil {
+		return nil, fmt.Errorf("account not found: %s", id)
+	}
+
+	return resp.ExchangeAccountsByPk, nil
+}
+
+// ListAccounts retrieves all exchange accounts
+func (c *Client) ListAccounts(ctx context.Context) ([]*ExchangeAccount, error) {
+	query := `
+		query ListAccounts {
+			exchange_accounts {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	req := c.graphqlRequest(query)
+
+	var resp struct {
+		ExchangeAccounts []*ExchangeAccount `json:"exchange_accounts"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list accounts: %w", err)
+	}
+
+	return resp.ExchangeAccounts, nil
+}
+
+// CreateAccount creates a new exchange account
+func (c *Client) CreateAccount(ctx context.Context, input *ExchangeAccountInput) (*ExchangeAccount, error) {
+	query := `
+		mutation CreateAccount($exchange_id: uuid!, $account_identifier: String!, $account_type: String!, $account_type_metadata: jsonb) {
+			insert_exchange_accounts_one(object: {
+				exchange_id: $exchange_id
+				account_identifier: $account_identifier
+				account_type: $account_type
+				account_type_metadata: $account_type_metadata
+			}) {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	vars := map[string]interface{}{
+		"exchange_id":       input.ExchangeID,
+		"account_identifier": input.AccountIdentifier,
+		"account_type":       input.AccountType,
+	}
+
+	// Only include metadata if it's not empty
+	if len(input.AccountTypeMetadata) > 0 {
+		var metadata interface{}
+		if err := json.Unmarshal(input.AccountTypeMetadata, &metadata); err == nil {
+			vars["account_type_metadata"] = metadata
+		}
+	}
+
+	req := c.graphqlRequestWithVars(query, vars)
+
+	var resp struct {
+		InsertExchangeAccountsOne *ExchangeAccount `json:"insert_exchange_accounts_one"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to create account: %w", err)
+	}
+
+	if resp.InsertExchangeAccountsOne == nil {
+		return nil, fmt.Errorf("failed to create account: no data returned")
+	}
+
+	return resp.InsertExchangeAccountsOne, nil
+}
+
+// UpdateAccount updates an existing exchange account
+func (c *Client) UpdateAccount(ctx context.Context, id string, input *ExchangeAccountInput) (*ExchangeAccount, error) {
+	query := `
+		mutation UpdateAccount($id: uuid!, $exchange_id: uuid!, $account_identifier: String!, $account_type: String!, $account_type_metadata: jsonb) {
+			update_exchange_accounts_by_pk(pk_columns: {id: $id}, _set: {
+				exchange_id: $exchange_id
+				account_identifier: $account_identifier
+				account_type: $account_type
+				account_type_metadata: $account_type_metadata
+			}) {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	vars := map[string]interface{}{
+		"id":                id,
+		"exchange_id":       input.ExchangeID,
+		"account_identifier": input.AccountIdentifier,
+		"account_type":       input.AccountType,
+	}
+
+	// Only include metadata if it's not empty
+	if len(input.AccountTypeMetadata) > 0 {
+		var metadata interface{}
+		if err := json.Unmarshal(input.AccountTypeMetadata, &metadata); err == nil {
+			vars["account_type_metadata"] = metadata
+		}
+	}
+
+	req := c.graphqlRequestWithVars(query, vars)
+
+	var resp struct {
+		UpdateExchangeAccountsByPk *ExchangeAccount `json:"update_exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to update account: %w", err)
+	}
+
+	if resp.UpdateExchangeAccountsByPk == nil {
+		return nil, fmt.Errorf("account not found: %s", id)
+	}
+
+	return resp.UpdateExchangeAccountsByPk, nil
+}
+
+// DeleteAccount deletes an exchange account by ID
+func (c *Client) DeleteAccount(ctx context.Context, id string) error {
+	query := `
+		mutation DeleteAccount($id: uuid!) {
+			delete_exchange_accounts_by_pk(id: $id) {
+				id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": id,
+	})
+
+	var resp struct {
+		DeleteExchangeAccountsByPk struct {
+			ID string `json:"id"`
+		} `json:"delete_exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to delete account: %w", err)
+	}
+
+	if resp.DeleteExchangeAccountsByPk.ID == "" {
+		return fmt.Errorf("account not found: %s", id)
+	}
+
+	return nil
+}
+
+// Same methods for ClientWithGraphQL (for testing)
+func (c *ClientWithGraphQL) GetAccount(ctx context.Context, id string) (*ExchangeAccount, error) {
+	query := `
+		query GetAccount($id: uuid!) {
+			exchange_accounts_by_pk(id: $id) {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": id,
+	})
+
+	var resp struct {
+		ExchangeAccountsByPk *ExchangeAccount `json:"exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get account: %w", err)
+	}
+
+	if resp.ExchangeAccountsByPk == nil {
+		return nil, fmt.Errorf("account not found: %s", id)
+	}
+
+	return resp.ExchangeAccountsByPk, nil
+}
+
+func (c *ClientWithGraphQL) ListAccounts(ctx context.Context) ([]*ExchangeAccount, error) {
+	query := `
+		query ListAccounts {
+			exchange_accounts {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	req := c.graphqlRequest(query)
+
+	var resp struct {
+		ExchangeAccounts []*ExchangeAccount `json:"exchange_accounts"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list accounts: %w", err)
+	}
+
+	return resp.ExchangeAccounts, nil
+}
+
+func (c *ClientWithGraphQL) CreateAccount(ctx context.Context, input *ExchangeAccountInput) (*ExchangeAccount, error) {
+	query := `
+		mutation CreateAccount($exchange_id: uuid!, $account_identifier: String!, $account_type: String!, $account_type_metadata: jsonb) {
+			insert_exchange_accounts_one(object: {
+				exchange_id: $exchange_id
+				account_identifier: $account_identifier
+				account_type: $account_type
+				account_type_metadata: $account_type_metadata
+			}) {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	vars := map[string]interface{}{
+		"exchange_id":       input.ExchangeID,
+		"account_identifier": input.AccountIdentifier,
+		"account_type":       input.AccountType,
+	}
+
+	if len(input.AccountTypeMetadata) > 0 {
+		var metadata interface{}
+		if err := json.Unmarshal(input.AccountTypeMetadata, &metadata); err == nil {
+			vars["account_type_metadata"] = metadata
+		}
+	}
+
+	req := c.graphqlRequestWithVars(query, vars)
+
+	var resp struct {
+		InsertExchangeAccountsOne *ExchangeAccount `json:"insert_exchange_accounts_one"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to create account: %w", err)
+	}
+
+	if resp.InsertExchangeAccountsOne == nil {
+		return nil, fmt.Errorf("failed to create account: no data returned")
+	}
+
+	return resp.InsertExchangeAccountsOne, nil
+}
+
+func (c *ClientWithGraphQL) UpdateAccount(ctx context.Context, id string, input *ExchangeAccountInput) (*ExchangeAccount, error) {
+	query := `
+		mutation UpdateAccount($id: uuid!, $exchange_id: uuid!, $account_identifier: String!, $account_type: String!, $account_type_metadata: jsonb) {
+			update_exchange_accounts_by_pk(pk_columns: {id: $id}, _set: {
+				exchange_id: $exchange_id
+				account_identifier: $account_identifier
+				account_type: $account_type
+				account_type_metadata: $account_type_metadata
+			}) {
+				id
+				exchange_id
+				account_identifier
+				account_type
+				account_type_metadata
+			}
+		}
+	`
+
+	vars := map[string]interface{}{
+		"id":                id,
+		"exchange_id":       input.ExchangeID,
+		"account_identifier": input.AccountIdentifier,
+		"account_type":       input.AccountType,
+	}
+
+	if len(input.AccountTypeMetadata) > 0 {
+		var metadata interface{}
+		if err := json.Unmarshal(input.AccountTypeMetadata, &metadata); err == nil {
+			vars["account_type_metadata"] = metadata
+		}
+	}
+
+	req := c.graphqlRequestWithVars(query, vars)
+
+	var resp struct {
+		UpdateExchangeAccountsByPk *ExchangeAccount `json:"update_exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to update account: %w", err)
+	}
+
+	if resp.UpdateExchangeAccountsByPk == nil {
+		return nil, fmt.Errorf("account not found: %s", id)
+	}
+
+	return resp.UpdateExchangeAccountsByPk, nil
+}
+
+func (c *ClientWithGraphQL) DeleteAccount(ctx context.Context, id string) error {
+	query := `
+		mutation DeleteAccount($id: uuid!) {
+			delete_exchange_accounts_by_pk(id: $id) {
+				id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": id,
+	})
+
+	var resp struct {
+		DeleteExchangeAccountsByPk struct {
+			ID string `json:"id"`
+		} `json:"delete_exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to delete account: %w", err)
+	}
+
+	if resp.DeleteExchangeAccountsByPk.ID == "" {
+		return fmt.Errorf("account not found: %s", id)
+	}
+
+	return nil
+}

--- a/db/accounts_test.go
+++ b/db/accounts_test.go
@@ -1,0 +1,353 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/machinebox/graphql"
+	"github.com/zif-terminal/lib/models"
+)
+
+func TestClient_GetAccount(t *testing.T) {
+	ctx := context.Background()
+	expectedAccount := &models.ExchangeAccount{
+		ID:                "test-account-id",
+		ExchangeID:        "test-exchange-id",
+		AccountIdentifier: "0x123",
+		AccountType:       "main",
+		AccountTypeMetadata: json.RawMessage(`{"key": "value"}`),
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"exchange_accounts_by_pk": expectedAccount,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	account, err := client.GetAccount(ctx, "test-account-id")
+	if err != nil {
+		t.Fatalf("GetAccount failed: %v", err)
+	}
+
+	if account.ID != expectedAccount.ID {
+		t.Errorf("Expected ID %s, got %s", expectedAccount.ID, account.ID)
+	}
+	if account.ExchangeID != expectedAccount.ExchangeID {
+		t.Errorf("Expected ExchangeID %s, got %s", expectedAccount.ExchangeID, account.ExchangeID)
+	}
+	if account.AccountIdentifier != expectedAccount.AccountIdentifier {
+		t.Errorf("Expected AccountIdentifier %s, got %s", expectedAccount.AccountIdentifier, account.AccountIdentifier)
+	}
+	if account.AccountType != expectedAccount.AccountType {
+		t.Errorf("Expected AccountType %s, got %s", expectedAccount.AccountType, account.AccountType)
+	}
+}
+
+func TestClient_GetAccount_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"exchange_accounts_by_pk": nil,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.GetAccount(ctx, "non-existent-id")
+	if err == nil {
+		t.Fatal("Expected error for non-existent account")
+	}
+	if err.Error() != "account not found: non-existent-id" {
+		t.Errorf("Expected 'account not found' error, got: %v", err)
+	}
+}
+
+func TestClient_ListAccounts(t *testing.T) {
+	ctx := context.Background()
+	expectedAccounts := []*models.ExchangeAccount{
+		{
+			ID:                "id1",
+			ExchangeID:        "exchange1",
+			AccountIdentifier: "0x111",
+			AccountType:       "main",
+		},
+		{
+			ID:                "id2",
+			ExchangeID:        "exchange2",
+			AccountIdentifier: "0x222",
+			AccountType:       "sub_account",
+		},
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"exchange_accounts": expectedAccounts,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	accounts, err := client.ListAccounts(ctx)
+	if err != nil {
+		t.Fatalf("ListAccounts failed: %v", err)
+	}
+
+	if len(accounts) != len(expectedAccounts) {
+		t.Fatalf("Expected %d accounts, got %d", len(expectedAccounts), len(accounts))
+	}
+
+	for i, exp := range expectedAccounts {
+		if accounts[i].ID != exp.ID {
+			t.Errorf("Account %d: Expected ID %s, got %s", i, exp.ID, accounts[i].ID)
+		}
+		if accounts[i].AccountIdentifier != exp.AccountIdentifier {
+			t.Errorf("Account %d: Expected AccountIdentifier %s, got %s", i, exp.AccountIdentifier, accounts[i].AccountIdentifier)
+		}
+	}
+}
+
+func TestClient_CreateAccount(t *testing.T) {
+	ctx := context.Background()
+	input := &models.ExchangeAccountInput{
+		ExchangeID:        "test-exchange-id",
+		AccountIdentifier: "0x123",
+		AccountType:       "main",
+		AccountTypeMetadata: json.RawMessage(`{"address": "0x123"}`),
+	}
+	expectedAccount := &models.ExchangeAccount{
+		ID:                "new-account-id",
+		ExchangeID:        input.ExchangeID,
+		AccountIdentifier: input.AccountIdentifier,
+		AccountType:       input.AccountType,
+		AccountTypeMetadata: input.AccountTypeMetadata,
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"insert_exchange_accounts_one": expectedAccount,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	account, err := client.CreateAccount(ctx, input)
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+
+	if account.ID != expectedAccount.ID {
+		t.Errorf("Expected ID %s, got %s", expectedAccount.ID, account.ID)
+	}
+	if account.ExchangeID != input.ExchangeID {
+		t.Errorf("Expected ExchangeID %s, got %s", input.ExchangeID, account.ExchangeID)
+	}
+	if account.AccountIdentifier != input.AccountIdentifier {
+		t.Errorf("Expected AccountIdentifier %s, got %s", input.AccountIdentifier, account.AccountIdentifier)
+	}
+}
+
+func TestClient_CreateAccount_WithoutMetadata(t *testing.T) {
+	ctx := context.Background()
+	input := &models.ExchangeAccountInput{
+		ExchangeID:        "test-exchange-id",
+		AccountIdentifier: "0x123",
+		AccountType:       "main",
+		// No metadata
+	}
+	expectedAccount := &models.ExchangeAccount{
+		ID:                "new-account-id",
+		ExchangeID:        input.ExchangeID,
+		AccountIdentifier: input.AccountIdentifier,
+		AccountType:       input.AccountType,
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"insert_exchange_accounts_one": expectedAccount,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	account, err := client.CreateAccount(ctx, input)
+	if err != nil {
+		t.Fatalf("CreateAccount failed: %v", err)
+	}
+
+	if account.ID != expectedAccount.ID {
+		t.Errorf("Expected ID %s, got %s", expectedAccount.ID, account.ID)
+	}
+}
+
+func TestClient_UpdateAccount(t *testing.T) {
+	ctx := context.Background()
+	id := "test-account-id"
+	input := &models.ExchangeAccountInput{
+		ExchangeID:        "updated-exchange-id",
+		AccountIdentifier: "0x456",
+		AccountType:       "sub_account",
+		AccountTypeMetadata: json.RawMessage(`{"index": 1}`),
+	}
+	expectedAccount := &models.ExchangeAccount{
+		ID:                id,
+		ExchangeID:        input.ExchangeID,
+		AccountIdentifier: input.AccountIdentifier,
+		AccountType:       input.AccountType,
+		AccountTypeMetadata: input.AccountTypeMetadata,
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"update_exchange_accounts_by_pk": expectedAccount,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	account, err := client.UpdateAccount(ctx, id, input)
+	if err != nil {
+		t.Fatalf("UpdateAccount failed: %v", err)
+	}
+
+	if account.ID != id {
+		t.Errorf("Expected ID %s, got %s", id, account.ID)
+	}
+	if account.AccountType != input.AccountType {
+		t.Errorf("Expected AccountType %s, got %s", input.AccountType, account.AccountType)
+	}
+}
+
+func TestClient_UpdateAccount_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"update_exchange_accounts_by_pk": nil,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	input := &models.ExchangeAccountInput{
+		ExchangeID:        "test",
+		AccountIdentifier: "0x123",
+		AccountType:       "main",
+	}
+
+	_, err := client.UpdateAccount(ctx, "non-existent-id", input)
+	if err == nil {
+		t.Fatal("Expected error for non-existent account")
+	}
+	if err.Error() != "account not found: non-existent-id" {
+		t.Errorf("Expected 'account not found' error, got: %v", err)
+	}
+}
+
+func TestClient_DeleteAccount(t *testing.T) {
+	ctx := context.Background()
+	id := "test-account-id"
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"delete_exchange_accounts_by_pk": map[string]interface{}{
+					"id": id,
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	err := client.DeleteAccount(ctx, id)
+	if err != nil {
+		t.Fatalf("DeleteAccount failed: %v", err)
+	}
+}
+
+func TestClient_DeleteAccount_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"delete_exchange_accounts_by_pk": map[string]interface{}{
+					"id": "",
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	err := client.DeleteAccount(ctx, "non-existent-id")
+	if err == nil {
+		t.Fatal("Expected error for non-existent account")
+	}
+	if err.Error() != "account not found: non-existent-id" {
+		t.Errorf("Expected 'account not found' error, got: %v", err)
+	}
+}

--- a/db/client.go
+++ b/db/client.go
@@ -1,0 +1,115 @@
+package db
+
+import (
+	"context"
+
+	"github.com/machinebox/graphql"
+)
+
+// Client provides methods to interact with the database through Hasura GraphQL API
+type Client struct {
+	graphql *graphql.Client
+	url     string
+	secret  string
+}
+
+// ClientConfig holds configuration for creating a new Client
+type ClientConfig struct {
+	URL         string // Hasura GraphQL endpoint URL
+	AdminSecret string // Hasura admin secret
+}
+
+// NewClient creates a new database client
+func NewClient(config ClientConfig) *Client {
+	client := graphql.NewClient(config.URL)
+	return &Client{
+		graphql: client,
+		url:     config.URL,
+		secret:  config.AdminSecret,
+	}
+}
+
+// graphqlRequest creates a new GraphQL request with admin secret header
+func (c *Client) graphqlRequest(query string) *graphql.Request {
+	req := graphql.NewRequest(query)
+	req.Header.Set("X-Hasura-Admin-Secret", c.secret)
+	return req
+}
+
+// graphqlRequestWithVars creates a new GraphQL request with variables
+func (c *Client) graphqlRequestWithVars(query string, vars map[string]interface{}) *graphql.Request {
+	req := c.graphqlRequest(query)
+	for key, value := range vars {
+		req.Var(key, value)
+	}
+	return req
+}
+
+// execute executes a GraphQL request and unmarshals the response
+func (c *Client) execute(ctx context.Context, req *graphql.Request, resp interface{}) error {
+	return c.graphql.Run(ctx, req, resp)
+}
+
+// GraphQLClient is an interface for the GraphQL client (for testing)
+type GraphQLClient interface {
+	Run(ctx context.Context, req *graphql.Request, resp interface{}) error
+}
+
+// ClientWithGraphQL allows injecting a custom GraphQL client (for testing)
+type ClientWithGraphQL struct {
+	graphql GraphQLClient
+	url     string
+	secret  string
+}
+
+// NewClientWithGraphQL creates a client with a custom GraphQL client (for testing)
+func NewClientWithGraphQL(graphql GraphQLClient, config ClientConfig) *ClientWithGraphQL {
+	return &ClientWithGraphQL{
+		graphql: graphql,
+		url:     config.URL,
+		secret:  config.AdminSecret,
+	}
+}
+
+// graphqlRequest creates a new GraphQL request with admin secret header
+func (c *ClientWithGraphQL) graphqlRequest(query string) *graphql.Request {
+	req := graphql.NewRequest(query)
+	req.Header.Set("X-Hasura-Admin-Secret", c.secret)
+	return req
+}
+
+// graphqlRequestWithVars creates a new GraphQL request with variables
+func (c *ClientWithGraphQL) graphqlRequestWithVars(query string, vars map[string]interface{}) *graphql.Request {
+	req := c.graphqlRequest(query)
+	for key, value := range vars {
+		req.Var(key, value)
+	}
+	return req
+}
+
+// execute executes a GraphQL request and unmarshals the response
+func (c *ClientWithGraphQL) execute(ctx context.Context, req *graphql.Request, resp interface{}) error {
+	return c.graphql.Run(ctx, req, resp)
+}
+
+// DBClient is an interface that both Client and ClientWithGraphQL implement
+type DBClient interface {
+	// Exchange methods
+	GetExchange(ctx context.Context, id string) (*Exchange, error)
+	ListExchanges(ctx context.Context) ([]*Exchange, error)
+	CreateExchange(ctx context.Context, input *ExchangeInput) (*Exchange, error)
+	UpdateExchange(ctx context.Context, id string, input *ExchangeInput) (*Exchange, error)
+
+	// Account methods
+	GetAccount(ctx context.Context, id string) (*ExchangeAccount, error)
+	ListAccounts(ctx context.Context) ([]*ExchangeAccount, error)
+	CreateAccount(ctx context.Context, input *ExchangeAccountInput) (*ExchangeAccount, error)
+	UpdateAccount(ctx context.Context, id string, input *ExchangeAccountInput) (*ExchangeAccount, error)
+	DeleteAccount(ctx context.Context, id string) error
+}
+
+// Ensure Client implements DBClient
+var _ DBClient = (*Client)(nil)
+
+// Ensure ClientWithGraphQL implements DBClient
+var _ DBClient = (*ClientWithGraphQL)(nil)

--- a/db/exchanges.go
+++ b/db/exchanges.go
@@ -1,0 +1,265 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// Exchange represents an exchange model (aliased from models package)
+type Exchange = models.Exchange
+
+// ExchangeInput represents exchange input for mutations (aliased from models package)
+type ExchangeInput = models.ExchangeInput
+
+// GetExchange retrieves a single exchange by ID
+func (c *Client) GetExchange(ctx context.Context, id string) (*Exchange, error) {
+	query := `
+		query GetExchange($id: uuid!) {
+			exchanges_by_pk(id: $id) {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": id,
+	})
+
+	var resp struct {
+		ExchangesByPk *Exchange `json:"exchanges_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get exchange: %w", err)
+	}
+
+	if resp.ExchangesByPk == nil {
+		return nil, fmt.Errorf("exchange not found: %s", id)
+	}
+
+	return resp.ExchangesByPk, nil
+}
+
+// ListExchanges retrieves all exchanges
+func (c *Client) ListExchanges(ctx context.Context) ([]*Exchange, error) {
+	query := `
+		query ListExchanges {
+			exchanges {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequest(query)
+
+	var resp struct {
+		Exchanges []*Exchange `json:"exchanges"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list exchanges: %w", err)
+	}
+
+	return resp.Exchanges, nil
+}
+
+// CreateExchange creates a new exchange
+func (c *Client) CreateExchange(ctx context.Context, input *ExchangeInput) (*Exchange, error) {
+	query := `
+		mutation CreateExchange($name: String!, $display_name: String!) {
+			insert_exchanges_one(object: {
+				name: $name
+				display_name: $display_name
+			}) {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"name":         input.Name,
+		"display_name": input.DisplayName,
+	})
+
+	var resp struct {
+		InsertExchangesOne *Exchange `json:"insert_exchanges_one"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to create exchange: %w", err)
+	}
+
+	if resp.InsertExchangesOne == nil {
+		return nil, fmt.Errorf("failed to create exchange: no data returned")
+	}
+
+	return resp.InsertExchangesOne, nil
+}
+
+// UpdateExchange updates an existing exchange
+func (c *Client) UpdateExchange(ctx context.Context, id string, input *ExchangeInput) (*Exchange, error) {
+	query := `
+		mutation UpdateExchange($id: uuid!, $name: String!, $display_name: String!) {
+			update_exchanges_by_pk(pk_columns: {id: $id}, _set: {
+				name: $name
+				display_name: $display_name
+			}) {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id":           id,
+		"name":         input.Name,
+		"display_name": input.DisplayName,
+	})
+
+	var resp struct {
+		UpdateExchangesByPk *Exchange `json:"update_exchanges_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to update exchange: %w", err)
+	}
+
+	if resp.UpdateExchangesByPk == nil {
+		return nil, fmt.Errorf("exchange not found: %s", id)
+	}
+
+	return resp.UpdateExchangesByPk, nil
+}
+
+// Same methods for ClientWithGraphQL (for testing)
+func (c *ClientWithGraphQL) GetExchange(ctx context.Context, id string) (*Exchange, error) {
+	query := `
+		query GetExchange($id: uuid!) {
+			exchanges_by_pk(id: $id) {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": id,
+	})
+
+	var resp struct {
+		ExchangesByPk *Exchange `json:"exchanges_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get exchange: %w", err)
+	}
+
+	if resp.ExchangesByPk == nil {
+		return nil, fmt.Errorf("exchange not found: %s", id)
+	}
+
+	return resp.ExchangesByPk, nil
+}
+
+func (c *ClientWithGraphQL) ListExchanges(ctx context.Context) ([]*Exchange, error) {
+	query := `
+		query ListExchanges {
+			exchanges {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequest(query)
+
+	var resp struct {
+		Exchanges []*Exchange `json:"exchanges"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list exchanges: %w", err)
+	}
+
+	return resp.Exchanges, nil
+}
+
+func (c *ClientWithGraphQL) CreateExchange(ctx context.Context, input *ExchangeInput) (*Exchange, error) {
+	query := `
+		mutation CreateExchange($name: String!, $display_name: String!) {
+			insert_exchanges_one(object: {
+				name: $name
+				display_name: $display_name
+			}) {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"name":         input.Name,
+		"display_name": input.DisplayName,
+	})
+
+	var resp struct {
+		InsertExchangesOne *Exchange `json:"insert_exchanges_one"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to create exchange: %w", err)
+	}
+
+	if resp.InsertExchangesOne == nil {
+		return nil, fmt.Errorf("failed to create exchange: no data returned")
+	}
+
+	return resp.InsertExchangesOne, nil
+}
+
+func (c *ClientWithGraphQL) UpdateExchange(ctx context.Context, id string, input *ExchangeInput) (*Exchange, error) {
+	query := `
+		mutation UpdateExchange($id: uuid!, $name: String!, $display_name: String!) {
+			update_exchanges_by_pk(pk_columns: {id: $id}, _set: {
+				name: $name
+				display_name: $display_name
+			}) {
+				id
+				name
+				display_name
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id":           id,
+		"name":         input.Name,
+		"display_name": input.DisplayName,
+	})
+
+	var resp struct {
+		UpdateExchangesByPk *Exchange `json:"update_exchanges_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to update exchange: %w", err)
+	}
+
+	if resp.UpdateExchangesByPk == nil {
+		return nil, fmt.Errorf("exchange not found: %s", id)
+	}
+
+	return resp.UpdateExchangesByPk, nil
+}

--- a/db/exchanges_test.go
+++ b/db/exchanges_test.go
@@ -1,0 +1,251 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/machinebox/graphql"
+	"github.com/zif-terminal/lib/models"
+)
+
+// mockGraphQLClient is a mock implementation of GraphQLClient for testing
+type mockGraphQLClient struct {
+	runFunc func(ctx context.Context, req *graphql.Request, resp interface{}) error
+}
+
+func (m *mockGraphQLClient) Run(ctx context.Context, req *graphql.Request, resp interface{}) error {
+	if m.runFunc != nil {
+		return m.runFunc(ctx, req, resp)
+	}
+	return nil
+}
+
+func TestClient_GetExchange(t *testing.T) {
+	ctx := context.Background()
+	expectedExchange := &models.Exchange{
+		ID:          "test-id",
+		Name:        "hyperliquid",
+		DisplayName: "Hyperliquid",
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			// Set mock response
+			respData := map[string]interface{}{
+				"exchanges_by_pk": expectedExchange,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	exchange, err := client.GetExchange(ctx, "test-id")
+	if err != nil {
+		t.Fatalf("GetExchange failed: %v", err)
+	}
+
+	if exchange.ID != expectedExchange.ID {
+		t.Errorf("Expected ID %s, got %s", expectedExchange.ID, exchange.ID)
+	}
+	if exchange.Name != expectedExchange.Name {
+		t.Errorf("Expected Name %s, got %s", expectedExchange.Name, exchange.Name)
+	}
+	if exchange.DisplayName != expectedExchange.DisplayName {
+		t.Errorf("Expected DisplayName %s, got %s", expectedExchange.DisplayName, exchange.DisplayName)
+	}
+}
+
+func TestClient_GetExchange_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			// Return null response
+			respData := map[string]interface{}{
+				"exchanges_by_pk": nil,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.GetExchange(ctx, "non-existent-id")
+	if err == nil {
+		t.Fatal("Expected error for non-existent exchange")
+	}
+	if err.Error() != "exchange not found: non-existent-id" {
+		t.Errorf("Expected 'exchange not found' error, got: %v", err)
+	}
+}
+
+func TestClient_ListExchanges(t *testing.T) {
+	ctx := context.Background()
+	expectedExchanges := []*models.Exchange{
+		{ID: "id1", Name: "hyperliquid", DisplayName: "Hyperliquid"},
+		{ID: "id2", Name: "lighter", DisplayName: "Lighter"},
+		{ID: "id3", Name: "drift", DisplayName: "Drift"},
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"exchanges": expectedExchanges,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	exchanges, err := client.ListExchanges(ctx)
+	if err != nil {
+		t.Fatalf("ListExchanges failed: %v", err)
+	}
+
+	if len(exchanges) != len(expectedExchanges) {
+		t.Fatalf("Expected %d exchanges, got %d", len(expectedExchanges), len(exchanges))
+	}
+
+	for i, exp := range expectedExchanges {
+		if exchanges[i].ID != exp.ID {
+			t.Errorf("Exchange %d: Expected ID %s, got %s", i, exp.ID, exchanges[i].ID)
+		}
+		if exchanges[i].Name != exp.Name {
+			t.Errorf("Exchange %d: Expected Name %s, got %s", i, exp.Name, exchanges[i].Name)
+		}
+	}
+}
+
+func TestClient_CreateExchange(t *testing.T) {
+	ctx := context.Background()
+	input := &models.ExchangeInput{
+		Name:        "test-exchange",
+		DisplayName: "Test Exchange",
+	}
+	expectedExchange := &models.Exchange{
+		ID:          "new-id",
+		Name:        input.Name,
+		DisplayName: input.DisplayName,
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"insert_exchanges_one": expectedExchange,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	exchange, err := client.CreateExchange(ctx, input)
+	if err != nil {
+		t.Fatalf("CreateExchange failed: %v", err)
+	}
+
+	if exchange.ID != expectedExchange.ID {
+		t.Errorf("Expected ID %s, got %s", expectedExchange.ID, exchange.ID)
+	}
+	if exchange.Name != input.Name {
+		t.Errorf("Expected Name %s, got %s", input.Name, exchange.Name)
+	}
+	if exchange.DisplayName != input.DisplayName {
+		t.Errorf("Expected DisplayName %s, got %s", input.DisplayName, exchange.DisplayName)
+	}
+}
+
+func TestClient_UpdateExchange(t *testing.T) {
+	ctx := context.Background()
+	id := "test-id"
+	input := &models.ExchangeInput{
+		Name:        "updated-name",
+		DisplayName: "Updated Display Name",
+	}
+	expectedExchange := &models.Exchange{
+		ID:          id,
+		Name:        input.Name,
+		DisplayName: input.DisplayName,
+	}
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"update_exchanges_by_pk": expectedExchange,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	exchange, err := client.UpdateExchange(ctx, id, input)
+	if err != nil {
+		t.Fatalf("UpdateExchange failed: %v", err)
+	}
+
+	if exchange.ID != id {
+		t.Errorf("Expected ID %s, got %s", id, exchange.ID)
+	}
+	if exchange.Name != input.Name {
+		t.Errorf("Expected Name %s, got %s", input.Name, exchange.Name)
+	}
+	if exchange.DisplayName != input.DisplayName {
+		t.Errorf("Expected DisplayName %s, got %s", input.DisplayName, exchange.DisplayName)
+	}
+}
+
+func TestClient_UpdateExchange_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"update_exchanges_by_pk": nil,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	input := &models.ExchangeInput{
+		Name:        "test",
+		DisplayName: "Test",
+	}
+
+	_, err := client.UpdateExchange(ctx, "non-existent-id", input)
+	if err == nil {
+		t.Fatal("Expected error for non-existent exchange")
+	}
+	if err.Error() != "exchange not found: non-existent-id" {
+		t.Errorf("Expected 'exchange not found' error, got: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/zif-terminal/lib
 
 go 1.21
+
+require github.com/machinebox/graphql v0.2.2
+
+require (
+	github.com/matryer/is v1.4.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkBZfo=
+github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
+github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Git pre-push hook to run unit tests before pushing to remote
+# This ensures code quality and prevents broken code from being pushed
+#
+# This hook is automatically used via git config core.hooksPath
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Note: This hook runs from hooks/ directory (via core.hooksPath config)
+# No installation needed - Git automatically uses hooks from this directory
+
+echo -e "${YELLOW}🔍 Pre-push hook: Running unit tests...${NC}"
+echo ""
+
+# Check if Go is installed
+if ! command -v go &> /dev/null; then
+    echo -e "${RED}❌ Error: Go is not installed!${NC}"
+    echo "Please install Go 1.21 or later: https://go.dev/dl/"
+    exit 1
+fi
+
+# Get the repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+if [ -z "$REPO_ROOT" ]; then
+    # Fallback: assume we're in hooks/ directory, go up one level
+    REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+cd "$REPO_ROOT"
+
+# Check if we're in the lib repo
+if [ ! -f "go.mod" ] || [ ! -f "scripts/run_tests.sh" ]; then
+    echo -e "${YELLOW}⚠️  Warning: Not in lib repo, skipping tests${NC}"
+    exit 0
+fi
+
+# Run the unit tests
+echo -e "${GREEN}Running unit tests...${NC}"
+echo ""
+
+if ./scripts/run_tests.sh; then
+    echo ""
+    echo -e "${GREEN}✅ All tests passed! Proceeding with push...${NC}"
+    exit 0
+else
+    echo ""
+    echo -e "${RED}❌ Tests failed! Push aborted.${NC}"
+    echo ""
+    echo "Please fix the failing tests before pushing."
+    echo "To bypass this check (not recommended), use:"
+    echo "  git push --no-verify"
+    exit 1
+fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Script to run unit tests for the lib package
+# This script is called by the Git pre-push hook
+
+set -e
+
+echo "Running unit tests..."
+
+# Check if Go is installed
+if ! command -v go &> /dev/null; then
+    echo "Error: Go is not installed. Please install Go 1.21 or later."
+    echo "Visit: https://go.dev/dl/"
+    exit 1
+fi
+
+# Run all tests
+go test -v ./...
+
+echo "Tests completed!"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Setup script to configure Git to use hooks from the tracked hooks/ directory
+# This makes hooks fully automatic - no manual installation needed!
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Configuring Git to use hooks from hooks/ directory..."
+
+# Set Git to use hooks from the tracked hooks/ directory
+cd "$REPO_ROOT"
+git config core.hooksPath hooks
+
+if [ $? -eq 0 ]; then
+    echo "✅ Git hooks configured successfully!"
+    echo ""
+    echo "Hooks are now fully automatic:"
+    echo "  - Pre-push hook will run unit tests automatically before push"
+    echo "  - No manual installation needed"
+    echo "  - Hooks are tracked in git and stay up-to-date automatically"
+else
+    echo "❌ Failed to configure Git hooks"
+    exit 1
+fi


### PR DESCRIPTION
- Add db package with GraphQL client for Hasura
- Implement CRUD methods for exchanges (Get, List, Create, Update)
- Implement CRUD methods for accounts (Get, List, Create, Update, Delete)
- Add comprehensive unit tests with mocked GraphQL responses (15 tests)
- Add Git pre-push hook to run tests automatically before push
- Update README with documentation for all new methods and setup instructions