### PR TITLE
Fix Hyperliquid API integration: use userFills endpoint and correct r…

### DIFF
--- a/exchange/README.md
+++ b/exchange/README.md
@@ -1,0 +1,461 @@
+# Exchange Interface
+
+This package provides a standardized interface for integrating with cryptocurrency exchanges. It allows the `account_sync` service to fetch trades from multiple exchanges using a consistent API.
+
+## Overview
+
+The exchange interface consists of:
+
+- **`ExchangeClient` interface**: Defines the contract all exchange implementations must satisfy
+- **Exchange implementations**: Specific implementations for each exchange (e.g., `hyperliquid`, `lighter`, `drift`)
+- **Contract tests**: Automated tests that verify implementations satisfy the interface contract
+- **Error types**: Standardized error types (e.g., `RateLimitError`)
+
+## Architecture
+
+```
+exchange/
+├── client.go              # ExchangeClient interface
+├── errors.go              # Error types (RateLimitError, etc.)
+├── contract_test.go       # Contract test suite
+├── README.md              # This file
+├── hyperliquid/
+│   ├── client.go          # Hyperliquid implementation
+│   ├── types.go           # Hyperliquid-specific types
+│   ├── client_test.go     # Unit tests (mocked HTTP)
+│   └── integration_test.go # Integration tests (real API)
+├── lighter/               # Future: Lighter implementation
+└── drift/                 # Future: Drift implementation
+```
+
+## Interface Contract
+
+All exchange implementations must implement the `ExchangeClient` interface:
+
+```go
+type ExchangeClient interface {
+    // Name returns the exchange identifier (e.g., "hyperliquid", "lighter")
+    Name() string
+
+    // FetchTrades fetches trades for a given account since a specific timestamp
+    // Returns trades as TradeInput (ready for database insertion), sorted by timestamp (oldest first)
+    // ctx can be cancelled or have a timeout set by the caller (sync service)
+    FetchTrades(
+        ctx context.Context,
+        account *models.ExchangeAccount,
+        since time.Time,
+    ) ([]*models.TradeInput, error)
+}
+```
+
+### Requirements
+
+1. **Name()**: Must return a non-empty string identifying the exchange
+2. **FetchTrades()**: 
+   - Must respect `context.Context` cancellation and timeouts
+   - Must return trades sorted by timestamp (oldest first) for incremental syncing
+   - Must filter trades where `timestamp >= since` (if `since` is not zero)
+   - Must return `TradeInput` structs ready for database insertion
+   - Must handle rate limits by returning `RateLimitError`
+   - Must handle invalid accounts by returning an error
+
+## Adding a New Exchange Implementation
+
+Follow these steps to add a new exchange:
+
+### 1. Create Exchange Directory
+
+```bash
+mkdir -p exchange/newexchange
+cd exchange/newexchange
+```
+
+### 2. Implement the Client
+
+Create `client.go`:
+
+```go
+package newexchange
+
+import (
+    "context"
+    "net/http"
+    "time"
+    "github.com/google/uuid"
+    "github.com/zif-terminal/lib/exchange"
+    "github.com/zif-terminal/lib/models"
+)
+
+type Client struct {
+    baseURL    string
+    httpClient *http.Client
+}
+
+func NewClient() *Client {
+    return &Client{
+        baseURL:    "https://api.newexchange.com",
+        httpClient: &http.Client{Timeout: 30 * time.Second},
+    }
+}
+
+func (c *Client) Name() string {
+    return "newexchange"
+}
+
+func (c *Client) FetchTrades(
+    ctx context.Context,
+    account *models.ExchangeAccount,
+    since time.Time,
+) ([]*models.TradeInput, error) {
+    // 1. Check context cancellation
+    if ctx.Err() != nil {
+        return nil, ctx.Err()
+    }
+
+    // 2. Parse account ID to UUID
+    accountUUID, err := uuid.Parse(account.ID)
+    if err != nil {
+        return nil, fmt.Errorf("invalid account ID: %w", err)
+    }
+
+    // 3. Extract credentials/identifier from account
+    address := account.AccountIdentifier
+    // Or extract from account.AccountTypeMetadata if needed
+
+    // 4. Build API request
+    // ... (exchange-specific logic)
+
+    // 5. Make HTTP request with context
+    req, err := http.NewRequestWithContext(ctx, "POST", url, body)
+    // ...
+
+    // 6. Check for rate limit (HTTP 429)
+    if resp.StatusCode == http.StatusTooManyRequests {
+        return nil, &exchange.RateLimitError{
+            Exchange:   "newexchange",
+            Message:    "rate limit exceeded",
+            RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+        }
+    }
+
+    // 7. Parse response and transform to []*models.TradeInput
+    // ... (exchange-specific parsing)
+
+    // 8. Filter by since timestamp
+    // ... (filter trades where timestamp >= since)
+
+    // 9. Sort by timestamp (oldest first)
+    sort.Slice(trades, func(i, j int) bool {
+        return trades[i].Timestamp.Before(trades[j].Timestamp)
+    })
+
+    // 10. Return trades
+    return trades, nil
+}
+```
+
+### 3. Transform Exchange-Specific Format
+
+Your implementation must transform the exchange's API response format to `models.TradeInput`:
+
+```go
+func transformTrade(apiTrade exchangeSpecificTrade, accountUUID uuid.UUID) (*models.TradeInput, error) {
+    return &models.TradeInput{
+        TradeID:          apiTrade.TradeID,        // Exchange-specific trade ID
+        OrderID:         apiTrade.OrderID,         // Exchange-specific order ID
+        BaseAsset:        normalizeAsset(...),     // Normalize asset symbol
+        QuoteAsset:       normalizeAsset(...),     // Normalize asset symbol
+        Side:             normalizeSide(...),       // Convert to "buy" or "sell"
+        Price:            convertToString(...),     // Convert to string for precision
+        Quantity:         convertToString(...),     // Convert to string for precision
+        Fee:              convertToString(...),     // Convert to string for precision
+        Timestamp:        parseTimestamp(...),      // Parse to time.Time
+        ExchangeAccountID: accountUUID,
+    }, nil
+}
+```
+
+**Important transformations:**
+
+- **Side**: Must normalize to `"buy"` or `"sell"` (e.g., "B"/"S", "LONG"/"SHORT" → "buy"/"sell")
+- **Assets**: Must extract base and quote assets (e.g., "BTC-USDC" → base: "BTC", quote: "USDC")
+- **Numeric fields**: Convert `price`, `quantity`, `fee` to strings for precision
+- **Timestamp**: Parse exchange timestamp format to `time.Time`
+
+### 4. Write Unit Tests
+
+Create `client_test.go` with mocked HTTP server:
+
+```go
+package newexchange
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    // ...
+)
+
+func TestNewExchangeClient_FetchTrades_Success(t *testing.T) {
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // Mock API response
+        w.Header().Set("Content-Type", "application/json")
+        w.Write([]byte(`{"trades": [...]}`))
+    }))
+    defer server.Close()
+
+    client := &Client{
+        baseURL:    server.URL,
+        httpClient: &http.Client{},
+    }
+
+    // Test FetchTrades...
+}
+
+func TestNewExchangeClient_RateLimit(t *testing.T) {
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusTooManyRequests)
+        w.Header().Set("Retry-After", "60")
+    }))
+    defer server.Close()
+
+    // Test rate limit error...
+}
+
+func TestNewExchangeClient_ContextCancellation(t *testing.T) {
+    // Test context cancellation...
+}
+```
+
+### 5. Write Integration Tests
+
+Create `integration_test.go`:
+
+```go
+// +build integration
+
+package newexchange
+
+import (
+    "context"
+    "os"
+    "testing"
+    "time"
+    "github.com/zif-terminal/lib/exchange"
+    "github.com/zif-terminal/lib/models"
+)
+
+func TestNewExchangeClient_Integration(t *testing.T) {
+    // Skip if no test credentials
+    testAddress := os.Getenv("NEWEXCHANGE_TEST_ADDRESS")
+    if testAddress == "" {
+        t.Skip("Skipping integration test: NEWEXCHANGE_TEST_ADDRESS not set")
+    }
+
+    client := NewClient()
+    account := &models.ExchangeAccount{
+        ID:                uuid.New().String(),
+        AccountIdentifier: testAddress,
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    trades, err := client.FetchTrades(ctx, account, time.Time{})
+    // Assertions...
+}
+
+func TestNewExchangeClient_Integration_Contract(t *testing.T) {
+    testAddress := os.Getenv("NEWEXCHANGE_TEST_ADDRESS")
+    if testAddress == "" {
+        t.Skip("Skipping integration test: NEWEXCHANGE_TEST_ADDRESS not set")
+    }
+
+    contract := exchange.ExchangeClientContract{
+        NewClient: func() exchange.ExchangeClient {
+            return NewClient()
+        },
+        ValidAccount: &models.ExchangeAccount{
+            ID:                uuid.New().String(),
+            AccountIdentifier: testAddress,
+        },
+        InvalidAccount: &models.ExchangeAccount{
+            ID:                uuid.New().String(),
+            AccountIdentifier: "invalid",
+        },
+    }
+
+    exchange.RunExchangeClientContractTests(t, contract)
+}
+```
+
+### 6. Run Tests
+
+```bash
+# Unit tests (mocked HTTP)
+go test ./exchange/newexchange
+
+# Integration tests (real API)
+go test -tags=integration ./exchange/newexchange
+
+# Contract tests (via integration tests)
+go test -tags=integration ./exchange/newexchange -run Contract
+```
+
+### 7. Test Checklist
+
+Before submitting your implementation, ensure:
+
+- [ ] `Name()` returns correct exchange identifier
+- [ ] `FetchTrades()` respects context cancellation
+- [ ] `FetchTrades()` respects context timeout
+- [ ] `FetchTrades()` returns trades sorted by timestamp (oldest first)
+- [ ] `FetchTrades()` filters by `since` timestamp correctly
+- [ ] `FetchTrades()` handles rate limits (returns `RateLimitError`)
+- [ ] `FetchTrades()` handles invalid accounts (returns error)
+- [ ] Side normalization works correctly ("buy"/"sell")
+- [ ] Asset normalization works correctly
+- [ ] Numeric fields converted to strings correctly
+- [ ] Timestamp parsing works correctly
+- [ ] Unit tests pass (mocked HTTP)
+- [ ] Integration tests pass (real API, if credentials available)
+- [ ] Contract tests pass
+
+## Testing Requirements
+
+### Unit Tests (Required)
+
+Unit tests must:
+- Use `httptest.NewServer` to mock HTTP responses
+- Test happy path (successful fetch)
+- Test error cases (rate limit, invalid account, network errors)
+- Test context cancellation/timeout
+- Test filtering by `since` timestamp
+- Test sorting (oldest first)
+- **NOT** make real API calls
+
+### Integration Tests (Optional but Recommended)
+
+Integration tests:
+- Must be tagged with `// +build integration`
+- Must skip if test credentials not available (via environment variable)
+- Should test against real exchange API
+- Should run contract tests against real API
+- Can be run with: `go test -tags=integration ./exchange/newexchange`
+
+### Contract Tests
+
+Contract tests verify your implementation satisfies the interface contract:
+
+```go
+contract := exchange.ExchangeClientContract{
+    NewClient: func() exchange.ExchangeClient {
+        return NewClient()
+    },
+    ValidAccount:   validAccount,
+    InvalidAccount: invalidAccount,
+}
+
+exchange.TestExchangeClientContract(t, contract)
+```
+
+## Error Handling
+
+### Rate Limit Errors
+
+When the exchange API returns HTTP 429, return `RateLimitError`:
+
+```go
+if resp.StatusCode == http.StatusTooManyRequests {
+    retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+    return nil, &exchange.RateLimitError{
+        Exchange:   "newexchange",
+        Message:    "rate limit exceeded",
+        RetryAfter: retryAfter,
+    }
+}
+```
+
+The sync service will handle retries based on `RetryAfter`.
+
+### Context Errors
+
+Context cancellation/timeout errors are automatically handled by `http.NewRequestWithContext()`. Just check `ctx.Err()` at the start:
+
+```go
+if ctx.Err() != nil {
+    return nil, ctx.Err()
+}
+```
+
+### Invalid Account Errors
+
+Return a descriptive error for invalid accounts:
+
+```go
+if account.AccountIdentifier == "" {
+    return nil, fmt.Errorf("account identifier is required")
+}
+```
+
+## Example: Hyperliquid Implementation
+
+See `exchange/hyperliquid/` for a complete reference implementation:
+
+- `client.go`: Full implementation with error handling
+- `types.go`: Exchange-specific response types
+- `client_test.go`: Comprehensive unit tests
+- `integration_test.go`: Integration tests with contract tests
+
+## Common Patterns
+
+### Handling Credentials
+
+**No credentials (address-only):**
+```go
+address := account.AccountIdentifier
+```
+
+**Credentials in metadata:**
+```go
+var metadata map[string]interface{}
+json.Unmarshal(account.AccountTypeMetadata, &metadata)
+apiKey := metadata["api_key"].(string)
+```
+
+### Parsing Timestamps
+
+Exchange APIs return timestamps in various formats:
+
+```go
+// Unix timestamp (milliseconds)
+timestamp := time.Unix(0, ms*int64(time.Millisecond))
+
+// Unix timestamp (seconds)
+timestamp := time.Unix(sec, 0)
+
+// RFC3339 string
+timestamp, err := time.Parse(time.RFC3339, str)
+```
+
+### Normalizing Side
+
+```go
+func normalizeSide(side string) string {
+    side = strings.ToUpper(strings.TrimSpace(side))
+    switch side {
+    case "B", "BUY", "LONG":
+        return "buy"
+    case "S", "SELL", "SHORT":
+        return "sell"
+    default:
+        return "buy" // Default fallback
+    }
+}
+```
+
+## Questions?
+
+- Check `exchange/hyperliquid/` for a complete reference implementation
+- Review `exchange/contract_test.go` for contract requirements
+- See `exchange/errors.go` for error type definitions

--- a/exchange/client.go
+++ b/exchange/client.go
@@ -1,0 +1,23 @@
+package exchange
+
+import (
+	"context"
+	"time"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// ExchangeClient is the interface that all exchange implementations must satisfy
+type ExchangeClient interface {
+	// Name returns the exchange identifier (e.g., "hyperliquid", "lighter")
+	Name() string
+
+	// FetchTrades fetches trades for a given account since a specific timestamp
+	// Returns trades as TradeInput (ready for database insertion), sorted by timestamp (oldest first)
+	// ctx can be cancelled or have a timeout set by the caller (sync service)
+	FetchTrades(
+		ctx context.Context,
+		account *models.ExchangeAccount,
+		since time.Time,
+	) ([]*models.TradeInput, error)
+}

--- a/exchange/contract.go
+++ b/exchange/contract.go
@@ -1,0 +1,178 @@
+package exchange
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// ExchangeClientContract defines the contract tests
+// Each exchange implementation should run these tests
+type ExchangeClientContract struct {
+	NewClient    func() ExchangeClient
+	ValidAccount *models.ExchangeAccount
+	// InvalidAccount is optional - if nil, invalid account tests are skipped
+	InvalidAccount *models.ExchangeAccount
+}
+
+// RunExchangeClientContractTests runs all contract tests
+// This function is exported so integration tests in other packages can use it
+func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContract) {
+	t.Run("Name", func(t *testing.T) {
+		client := contract.NewClient()
+		name := client.Name()
+		if name == "" {
+			t.Error("Name() must return non-empty string")
+		}
+	})
+
+	t.Run("FetchTrades_ValidAccount", func(t *testing.T) {
+		client := contract.NewClient()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		// Should not error with valid account (even if no trades)
+		trades, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		if err != nil {
+			t.Errorf("FetchTrades with valid account should not error: %v", err)
+		}
+
+		// Verify trade structure if trades returned
+		for _, trade := range trades {
+			validateTradeInput(t, trade)
+		}
+	})
+
+	if contract.InvalidAccount != nil {
+		t.Run("FetchTrades_InvalidAccount", func(t *testing.T) {
+			client := contract.NewClient()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			// Should error with invalid account
+			_, err := client.FetchTrades(ctx, contract.InvalidAccount, time.Time{})
+			if err == nil {
+				t.Error("FetchTrades with invalid account should error")
+			}
+		})
+	}
+
+	t.Run("FetchTrades_ContextCancellation", func(t *testing.T) {
+		client := contract.NewClient()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		// Should respect context cancellation
+		_, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		if err == nil {
+			t.Error("FetchTrades should respect context cancellation")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Expected context.Canceled error, got: %v", err)
+		}
+	})
+
+	t.Run("FetchTrades_Timeout", func(t *testing.T) {
+		client := contract.NewClient()
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+		defer cancel()
+
+		// Should timeout (or return error quickly)
+		_, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		if err == nil {
+			t.Error("FetchTrades should respect timeout")
+		}
+		// Note: May not always be DeadlineExceeded if HTTP client handles it differently
+	})
+
+	t.Run("FetchTrades_SortedByTimestamp", func(t *testing.T) {
+		client := contract.NewClient()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		trades, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		if err != nil {
+			t.Skip("Skipping sort test due to error:", err)
+		}
+
+		if len(trades) < 2 {
+			t.Skip("Skipping sort test: need at least 2 trades")
+		}
+
+		// Verify trades are sorted oldest first
+		for i := 1; i < len(trades); i++ {
+			if trades[i].Timestamp.Before(trades[i-1].Timestamp) {
+				t.Error("Trades must be sorted by timestamp (oldest first)")
+			}
+		}
+	})
+
+	t.Run("FetchTrades_FiltersBySince", func(t *testing.T) {
+		client := contract.NewClient()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		// Fetch all trades
+		allTrades, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		if err != nil {
+			t.Skip("Skipping filter test due to error:", err)
+		}
+
+		if len(allTrades) == 0 {
+			t.Skip("Skipping filter test: no trades available")
+		}
+
+		// Use a timestamp in the middle
+		middleIdx := len(allTrades) / 2
+		since := allTrades[middleIdx].Timestamp
+
+		// Fetch trades since that timestamp
+		filteredTrades, err := client.FetchTrades(ctx, contract.ValidAccount, since)
+		if err != nil {
+			t.Fatalf("Failed to fetch filtered trades: %v", err)
+		}
+
+		// All filtered trades should be >= since
+		for _, trade := range filteredTrades {
+			if trade.Timestamp.Before(since) {
+				t.Errorf("Trade timestamp %v is before since %v", trade.Timestamp, since)
+			}
+		}
+
+		// Filtered trades should be <= all trades
+		if len(filteredTrades) > len(allTrades) {
+			t.Errorf("Filtered trades (%d) should not exceed all trades (%d)", len(filteredTrades), len(allTrades))
+		}
+	})
+}
+
+// validateTradeInput validates TradeInput structure
+func validateTradeInput(t *testing.T, trade *models.TradeInput) {
+	if trade.TradeID == "" {
+		t.Error("TradeInput.TradeID must be non-empty")
+	}
+	if trade.Side != "buy" && trade.Side != "sell" {
+		t.Errorf("TradeInput.Side must be 'buy' or 'sell', got: %s", trade.Side)
+	}
+	if trade.BaseAsset == "" {
+		t.Error("TradeInput.BaseAsset must be non-empty")
+	}
+	if trade.QuoteAsset == "" {
+		t.Error("TradeInput.QuoteAsset must be non-empty")
+	}
+	if trade.Price == "" {
+		t.Error("TradeInput.Price must be non-empty")
+	}
+	if trade.Quantity == "" {
+		t.Error("TradeInput.Quantity must be non-empty")
+	}
+	if trade.Fee == "" {
+		t.Error("TradeInput.Fee must be non-empty")
+	}
+	if trade.Timestamp.IsZero() {
+		t.Error("TradeInput.Timestamp must be non-zero")
+	}
+}

--- a/exchange/errors.go
+++ b/exchange/errors.go
@@ -1,0 +1,27 @@
+package exchange
+
+import (
+	"fmt"
+	"time"
+)
+
+// RateLimitError indicates the exchange API rate limit was exceeded
+type RateLimitError struct {
+	Exchange   string
+	Message    string
+	RetryAfter time.Duration // Optional: when to retry (if exchange provides this)
+}
+
+func (e *RateLimitError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("rate limit exceeded for %s: %s (retry after %v)",
+			e.Exchange, e.Message, e.RetryAfter)
+	}
+	return fmt.Sprintf("rate limit exceeded for %s: %s", e.Exchange, e.Message)
+}
+
+// IsRateLimitError checks if an error is a RateLimitError
+func IsRateLimitError(err error) bool {
+	_, ok := err.(*RateLimitError)
+	return ok
+}

--- a/exchange/hyperliquid/client.go
+++ b/exchange/hyperliquid/client.go
@@ -1,0 +1,247 @@
+package hyperliquid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange"
+	"github.com/zif-terminal/lib/models"
+)
+
+// Client implements exchange.ExchangeClient for Hyperliquid
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a new Hyperliquid client
+func NewClient() *Client {
+	return &Client{
+		baseURL:    "https://api.hyperliquid.xyz",
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Name returns the exchange identifier
+func (c *Client) Name() string {
+	return "hyperliquid"
+}
+
+// FetchTrades fetches trades directly from Hyperliquid API
+// Transforms exchange response directly to []*models.TradeInput
+func (c *Client) FetchTrades(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TradeInput, error) {
+	// Check if ctx is cancelled
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Parse account ID to UUID
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	// Extract address from account identifier
+	address := account.AccountIdentifier
+	if address == "" {
+		return nil, fmt.Errorf("account identifier (address) is required")
+	}
+
+	// Build API request body
+	// Based on Hyperliquid API: POST /info with {"type": "userFills", "user": address}
+	requestBody := map[string]interface{}{
+		"type": "userFills",
+		"user": address,
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create HTTP request with context
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/info", strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Make HTTP request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch trades: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for rate limit (HTTP 429)
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, &exchange.RateLimitError{
+			Exchange:   "hyperliquid",
+			Message:    "rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	}
+
+	// Check for other HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	// Parse response - API returns a direct array of fills, not wrapped in an object
+	var apiFills []hyperliquidFill
+	if err := json.NewDecoder(resp.Body).Decode(&apiFills); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Transform to TradeInput
+	trades := make([]*models.TradeInput, 0)
+	for _, apiFill := range apiFills {
+		// Parse timestamp first
+		tradeTimestamp := parseTimestamp(apiFill.Time)
+		
+		// Filter: only trades >= since
+		if !since.IsZero() && tradeTimestamp.Before(since) {
+			continue
+		}
+
+		tradeInput, err := transformFill(apiFill, accountUUID)
+		if err != nil {
+			// Skip fills that fail to transform
+			continue
+		}
+		trades = append(trades, tradeInput)
+	}
+
+	// Sort by timestamp (oldest first) for incremental syncing
+	sort.Slice(trades, func(i, j int) bool {
+		return trades[i].Timestamp.Before(trades[j].Timestamp)
+	})
+
+	return trades, nil
+}
+
+// transformFill converts Hyperliquid fill format to TradeInput
+func transformFill(apiFill hyperliquidFill, accountUUID uuid.UUID) (*models.TradeInput, error) {
+	// Normalize side: Hyperliquid uses "B" for buy, "S" for sell, or "A" for close
+	side := normalizeSide(apiFill.Side)
+
+	// Parse timestamp (Hyperliquid returns Unix timestamp in milliseconds)
+	timestamp := parseTimestamp(apiFill.Time)
+
+	// Convert numeric fields to strings
+	price := convertToString(apiFill.Px)
+	quantity := convertToString(apiFill.Sz)
+	fee := convertToString(apiFill.Fee)
+
+	// Extract base and quote assets from coin (e.g., "BTC" from "BTC-USDC" or just "BTC")
+	baseAsset, quoteAsset := parseAssetPair(apiFill.Coin)
+
+	// Convert order ID to string
+	orderID := convertToString(apiFill.Oid)
+
+	return &models.TradeInput{
+		TradeID:          apiFill.Hash, // Use transaction hash as trade ID
+		OrderID:          orderID,      // Order ID (converted to string)
+		BaseAsset:        baseAsset,
+		QuoteAsset:       quoteAsset,
+		Side:             side,
+		Price:            price,
+		Quantity:         quantity,
+		Fee:              fee,
+		Timestamp:        timestamp,
+		ExchangeAccountID: accountUUID,
+	}, nil
+}
+
+// normalizeSide converts Hyperliquid side format to "buy" or "sell"
+// Hyperliquid uses: "B" (buy), "S" (sell), "A" (close/liquidation)
+func normalizeSide(side string) string {
+	side = strings.ToUpper(strings.TrimSpace(side))
+	switch side {
+	case "B", "BUY", "LONG":
+		return "buy"
+	case "S", "SELL", "SHORT":
+		return "sell"
+	case "A", "CLOSE", "LIQUIDATION":
+		// Close/liquidation is typically a sell
+		return "sell"
+	default:
+		// Default to buy if unknown
+		return "buy"
+	}
+}
+
+// parseTimestamp converts Hyperliquid timestamp to time.Time
+// Hyperliquid returns Unix timestamp in milliseconds
+func parseTimestamp(ts interface{}) time.Time {
+	switch v := ts.(type) {
+	case float64:
+		// Unix timestamp in milliseconds
+		return time.Unix(0, int64(v)*int64(time.Millisecond))
+	case int64:
+		return time.Unix(0, v*int64(time.Millisecond))
+	case string:
+		// Try parsing as Unix timestamp (milliseconds)
+		if ms, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return time.Unix(0, ms*int64(time.Millisecond))
+		}
+		// Try parsing as RFC3339
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// parseAssetPair extracts base and quote assets from coin string
+// Hyperliquid format: "BTC-USDC" or "BTC"
+func parseAssetPair(coin string) (baseAsset, quoteAsset string) {
+	parts := strings.Split(coin, "-")
+	if len(parts) >= 2 {
+		return parts[0], parts[1]
+	}
+	// If no separator, assume USDC as quote (common for Hyperliquid)
+	return parts[0], "USDC"
+}
+
+// convertToString converts numeric values to string for precision
+func convertToString(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		// Format with enough precision
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(val)
+	case int64:
+		return strconv.FormatInt(val, 10)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+// parseRetryAfter parses Retry-After header (seconds)
+func parseRetryAfter(retryAfter string) time.Duration {
+	if retryAfter == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}

--- a/exchange/hyperliquid/client_test.go
+++ b/exchange/hyperliquid/client_test.go
@@ -1,0 +1,283 @@
+package hyperliquid
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange"
+	"github.com/zif-terminal/lib/models"
+)
+
+func TestHyperliquidClient_Name(t *testing.T) {
+	client := NewClient()
+	if client.Name() != "hyperliquid" {
+		t.Errorf("Expected name 'hyperliquid', got '%s'", client.Name())
+	}
+}
+
+func TestHyperliquidClient_FetchTrades_Success(t *testing.T) {
+	// Mock Hyperliquid API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/info" {
+			t.Errorf("Expected path /info, got %s", r.URL.Path)
+		}
+
+		// Verify request body
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+
+		if reqBody["type"] != "userFills" {
+			t.Errorf("Expected type 'userFills', got '%v'", reqBody["type"])
+		}
+
+		// Return mock response - API returns direct array, not wrapped
+		response := []hyperliquidFill{
+			{
+				Hash:    "0x123",
+				Oid:     123456789,
+				Coin:    "BTC-USDC",
+				Side:    "B",
+				Px:      "50000.5",
+				Sz:      "0.1",
+				Fee:     "5.0",
+				Time:    time.Now().UnixMilli() - 10000, // 10 seconds ago
+			},
+			{
+				Hash:    "0x456",
+				Oid:     987654321,
+				Coin:    "ETH-USDC",
+				Side:    "S",
+				Px:      "3000.25",
+				Sz:      "1.5",
+				Fee:     "4.5",
+				Time:    time.Now().UnixMilli() - 5000, // 5 seconds ago
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with test server URL
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0x1234567890123456789012345678901234567890",
+	}
+
+	ctx := context.Background()
+	trades, err := client.FetchTrades(ctx, account, time.Time{})
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	if len(trades) != 2 {
+		t.Fatalf("Expected 2 trades, got %d", len(trades))
+	}
+
+	// Verify first trade (should be oldest due to sorting)
+	if trades[0].TradeID != "0x123" {
+		t.Errorf("Expected trade ID '0x123', got '%s'", trades[0].TradeID)
+	}
+	if trades[0].Side != "buy" {
+		t.Errorf("Expected side 'buy', got '%s'", trades[0].Side)
+	}
+	if trades[0].BaseAsset != "BTC" {
+		t.Errorf("Expected base asset 'BTC', got '%s'", trades[0].BaseAsset)
+	}
+	if trades[0].QuoteAsset != "USDC" {
+		t.Errorf("Expected quote asset 'USDC', got '%s'", trades[0].QuoteAsset)
+	}
+
+	// Verify sorting (oldest first)
+	if trades[0].Timestamp.After(trades[1].Timestamp) {
+		t.Error("Trades should be sorted oldest first")
+	}
+}
+
+func TestHyperliquidClient_FetchTrades_RateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0x1234567890123456789012345678901234567890",
+	}
+
+	ctx := context.Background()
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected rate limit error")
+	}
+
+	if !exchange.IsRateLimitError(err) {
+		t.Errorf("Expected RateLimitError, got: %v", err)
+	}
+
+	rateLimitErr, ok := err.(*exchange.RateLimitError)
+	if !ok {
+		t.Fatalf("Expected *RateLimitError, got %T", err)
+	}
+
+	if rateLimitErr.Exchange != "hyperliquid" {
+		t.Errorf("Expected exchange 'hyperliquid', got '%s'", rateLimitErr.Exchange)
+	}
+
+	if rateLimitErr.RetryAfter != 60*time.Second {
+		t.Errorf("Expected retry after 60s, got %v", rateLimitErr.RetryAfter)
+	}
+}
+
+func TestHyperliquidClient_FetchTrades_ContextCancellation(t *testing.T) {
+	// Server that delays response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]hyperliquidFill{})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0x1234567890123456789012345678901234567890",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected error due to context cancellation")
+	}
+}
+
+func TestHyperliquidClient_FetchTrades_FiltersBySince(t *testing.T) {
+	now := time.Now()
+	oldTradeTime := now.Add(-20 * time.Second)
+	newTradeTime := now.Add(-5 * time.Second)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := []hyperliquidFill{
+			{
+				Hash:    "0xold",
+				Oid:     111111111,
+				Coin:    "BTC-USDC",
+				Side:    "B",
+				Px:      "50000.0",
+				Sz:      "0.1",
+				Fee:     "5.0",
+				Time:    oldTradeTime.UnixMilli(),
+			},
+			{
+				Hash:    "0xnew",
+				Oid:     222222222,
+				Coin:    "ETH-USDC",
+				Side:    "S",
+				Px:      "3000.0",
+				Sz:      "1.0",
+				Fee:     "4.0",
+				Time:    newTradeTime.UnixMilli(),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0x1234567890123456789012345678901234567890",
+	}
+
+	ctx := context.Background()
+	// Filter to only get trades after oldTradeTime
+	since := oldTradeTime.Add(1 * time.Second)
+	trades, err := client.FetchTrades(ctx, account, since)
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	// Should only get the new trade
+	if len(trades) != 1 {
+		t.Fatalf("Expected 1 trade after filtering, got %d", len(trades))
+	}
+
+	if trades[0].TradeID != "0xnew" {
+		t.Errorf("Expected trade ID '0xnew', got '%s'", trades[0].TradeID)
+	}
+}
+
+func TestHyperliquidClient_FetchTrades_InvalidAccountID(t *testing.T) {
+	client := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                "invalid-uuid",
+		AccountIdentifier: "0x1234567890123456789012345678901234567890",
+	}
+
+	ctx := context.Background()
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected error for invalid account ID")
+	}
+}
+
+func TestHyperliquidClient_FetchTrades_EmptyAccountIdentifier(t *testing.T) {
+	client := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "",
+	}
+
+	ctx := context.Background()
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected error for empty account identifier")
+	}
+}
+
+// Test contract compliance (basic tests without real API)
+func TestHyperliquidClient_Contract(t *testing.T) {
+	t.Run("Name", func(t *testing.T) {
+		client := NewClient()
+		name := client.Name()
+		if name == "" {
+			t.Error("Name() must return non-empty string")
+		}
+		if name != "hyperliquid" {
+			t.Errorf("Expected name 'hyperliquid', got '%s'", name)
+		}
+	})
+}

--- a/exchange/hyperliquid/integration_test.go
+++ b/exchange/hyperliquid/integration_test.go
@@ -1,0 +1,155 @@
+// +build integration
+
+package hyperliquid
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange"
+	"github.com/zif-terminal/lib/models"
+)
+
+// TestHyperliquidClient_Integration tests against real Hyperliquid API
+// Set HYPERLIQUID_TEST_ADDRESS environment variable to run
+func TestHyperliquidClient_Integration(t *testing.T) {
+	testAddress := os.Getenv("HYPERLIQUID_TEST_ADDRESS")
+	if testAddress == "" {
+		t.Skip("Skipping integration test: HYPERLIQUID_TEST_ADDRESS not set")
+	}
+
+	client := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: testAddress,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Fetch trades
+	trades, err := client.FetchTrades(ctx, account, time.Time{})
+	if err != nil {
+		t.Fatalf("Failed to fetch trades: %v", err)
+	}
+
+	t.Logf("Fetched %d trades", len(trades))
+
+	// Verify trade structure
+	for i, trade := range trades {
+		if trade.TradeID == "" {
+			t.Errorf("Trade %d: TradeID is empty", i)
+		}
+		if trade.Side != "buy" && trade.Side != "sell" {
+			t.Errorf("Trade %d: Side must be 'buy' or 'sell', got '%s'", i, trade.Side)
+		}
+		if trade.BaseAsset == "" {
+			t.Errorf("Trade %d: BaseAsset is empty", i)
+		}
+		if trade.QuoteAsset == "" {
+			t.Errorf("Trade %d: QuoteAsset is empty", i)
+		}
+		if trade.Price == "" {
+			t.Errorf("Trade %d: Price is empty", i)
+		}
+		if trade.Quantity == "" {
+			t.Errorf("Trade %d: Quantity is empty", i)
+		}
+		if trade.Timestamp.IsZero() {
+			t.Errorf("Trade %d: Timestamp is zero", i)
+		}
+	}
+
+	// Verify sorting (oldest first)
+	for i := 1; i < len(trades); i++ {
+		if trades[i].Timestamp.Before(trades[i-1].Timestamp) {
+			t.Errorf("Trades not sorted: trade %d (%v) is before trade %d (%v)",
+				i, trades[i].Timestamp, i-1, trades[i-1].Timestamp)
+		}
+	}
+}
+
+// TestHyperliquidClient_Integration_FilterBySince tests filtering by timestamp
+func TestHyperliquidClient_Integration_FilterBySince(t *testing.T) {
+	testAddress := os.Getenv("HYPERLIQUID_TEST_ADDRESS")
+	if testAddress == "" {
+		t.Skip("Skipping integration test: HYPERLIQUID_TEST_ADDRESS not set")
+	}
+
+	client := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: testAddress,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Fetch all trades
+	allTrades, err := client.FetchTrades(ctx, account, time.Time{})
+	if err != nil {
+		t.Fatalf("Failed to fetch all trades: %v", err)
+	}
+
+	if len(allTrades) == 0 {
+		t.Skip("Skipping filter test: no trades available")
+	}
+
+	// Use a timestamp in the middle
+	middleIdx := len(allTrades) / 2
+	since := allTrades[middleIdx].Timestamp
+
+	// Fetch trades since that timestamp
+	filteredTrades, err := client.FetchTrades(ctx, account, since)
+	if err != nil {
+		t.Fatalf("Failed to fetch filtered trades: %v", err)
+	}
+
+	// All filtered trades should be >= since
+	for i, trade := range filteredTrades {
+		if trade.Timestamp.Before(since) {
+			t.Errorf("Filtered trade %d timestamp %v is before since %v",
+				i, trade.Timestamp, since)
+		}
+	}
+
+	// Filtered trades should be <= all trades
+	if len(filteredTrades) > len(allTrades) {
+		t.Errorf("Filtered trades (%d) should not exceed all trades (%d)",
+			len(filteredTrades), len(allTrades))
+	}
+
+	t.Logf("All trades: %d, Filtered trades: %d", len(allTrades), len(filteredTrades))
+}
+
+// TestHyperliquidClient_Integration_Contract runs contract tests against real API
+func TestHyperliquidClient_Integration_Contract(t *testing.T) {
+	testAddress := os.Getenv("HYPERLIQUID_TEST_ADDRESS")
+	if testAddress == "" {
+		t.Skip("Skipping integration test: HYPERLIQUID_TEST_ADDRESS not set")
+	}
+
+	validAccount := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: testAddress,
+	}
+
+	invalidAccount := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0xinvalid", // Malformed address that will cause API error
+	}
+
+	contract := exchange.ExchangeClientContract{
+		NewClient: func() exchange.ExchangeClient {
+			return NewClient()
+		},
+		ValidAccount:   validAccount,
+		InvalidAccount: invalidAccount,
+	}
+
+	// Run contract tests
+	exchange.RunExchangeClientContractTests(t, contract)
+}

--- a/exchange/hyperliquid/types.go
+++ b/exchange/hyperliquid/types.go
@@ -1,0 +1,17 @@
+package hyperliquid
+
+// hyperliquidFill represents a single fill from Hyperliquid API
+// The API returns userFills as a direct array, not wrapped in an object
+// Fields match the actual API response structure
+type hyperliquidFill struct {
+	Coin    string      `json:"coin"`     // Asset name (e.g., "BTC", "TNSR")
+	Px      interface{} `json:"px"`      // Price (number or string)
+	Sz      interface{} `json:"sz"`      // Size/Quantity (number or string)
+	Side    string      `json:"side"`     // "B" (buy), "S" (sell), "A" (close)
+	Time    interface{} `json:"time"`    // Unix timestamp in milliseconds
+	Hash    string      `json:"hash"`     // Transaction hash (used as trade_id)
+	Oid     interface{} `json:"oid"`     // Order ID (number or string)
+	Fee     interface{} `json:"fee"`     // Fee (number or string)
+	// Additional fields that may be present but not used:
+	// StartPosition, Dir, ClosedPnl, Crossed, FeeToken, Tid, TwapId
+}


### PR DESCRIPTION
…esponse structure

- Changed API request type from 'userTrades' to 'userFills'
- Updated response parsing to handle direct array instead of wrapped object
- Fixed field names to match actual API: hash (not txHash), px (not price), sz (not size)
- Updated all tests to use correct API format
- Fixed invalid account test to use malformed address

All unit and integration tests now passing.