### PR TITLE
feat: Replace ExchangeID with nested Exchange object in ExchangeAccount

### DIFF
--- a/db/accounts.go
+++ b/db/accounts.go
@@ -20,10 +20,14 @@ func (c *Client) GetAccount(ctx context.Context, id string) (*ExchangeAccount, e
 		query GetAccount($id: uuid!) {
 			exchange_accounts_by_pk(id: $id) {
 				id
-				exchange_id
 				account_identifier
 				account_type
 				account_type_metadata
+				exchange {
+					id
+					name
+					display_name
+				}
 			}
 		}
 	`
@@ -53,10 +57,14 @@ func (c *Client) ListAccounts(ctx context.Context) ([]*ExchangeAccount, error) {
 		query ListAccounts {
 			exchange_accounts {
 				id
-				exchange_id
 				account_identifier
 				account_type
 				account_type_metadata
+				exchange {
+					id
+					name
+					display_name
+				}
 			}
 		}
 	`
@@ -85,10 +93,14 @@ func (c *Client) CreateAccount(ctx context.Context, input *ExchangeAccountInput)
 				account_type_metadata: $account_type_metadata
 			}) {
 				id
-				exchange_id
 				account_identifier
 				account_type
 				account_type_metadata
+				exchange {
+					id
+					name
+					display_name
+				}
 			}
 		}
 	`
@@ -135,10 +147,14 @@ func (c *Client) UpdateAccount(ctx context.Context, id string, input *ExchangeAc
 				account_type_metadata: $account_type_metadata
 			}) {
 				id
-				exchange_id
 				account_identifier
 				account_type
 				account_type_metadata
+				exchange {
+					id
+					name
+					display_name
+				}
 			}
 		}
 	`

--- a/models/account.go
+++ b/models/account.go
@@ -11,11 +11,11 @@ type AccountType struct {
 }
 
 // ExchangeAccount represents a user's account on an exchange in the database
-// Matches the 'exchange_accounts' table schema
+// Uses Hasura relationship to fetch nested Exchange object
 type ExchangeAccount struct {
 	ID                  string          `json:"id" db:"id"`
 	UserID              string          `json:"user_id" db:"user_id"`
-	ExchangeID          string          `json:"exchange_id" db:"exchange_id"`
+	Exchange            *Exchange       `json:"exchange"` // Nested via Hasura relationship
 	AccountIdentifier   string          `json:"account_identifier" db:"account_identifier"`
 	AccountType         string          `json:"account_type" db:"account_type"` // "main", "sub_account", "vault" - FK to exchange_account_types.code
 	AccountTypeMetadata json.RawMessage `json:"account_type_metadata" db:"account_type_metadata"` // JSONB


### PR DESCRIPTION
- Update ExchangeAccount model to use Exchange *Exchange instead of ExchangeID string
- Update GraphQL queries to fetch exchange relationship (id, name, display_name)
- Update mutations to query back exchange relationship in response
- Update all unit tests to use nested Exchange object structure