### PR TITLE
feat: update trades to use BIGINT timestamp and tid as trade_id

### DIFF
--- a/db/trade.go
+++ b/db/trade.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/zif-terminal/lib/models"
@@ -34,7 +33,6 @@ func (c *Client) GetTrade(ctx context.Context, id string) (*Trade, error) {
 				order_id
 				trade_id
 				exchange_account_id
-				created_at
 			}
 		}
 	`
@@ -87,7 +85,6 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					order_id
 					trade_id
 					exchange_account_id
-					created_at
 				}
 			}
 		`
@@ -117,7 +114,6 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					order_id
 					trade_id
 					exchange_account_id
-					created_at
 				}
 			}
 		`
@@ -146,7 +142,7 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 			$side: String!
 			$price: numeric!
 			$quantity: numeric!
-			$timestamp: timestamp!
+			$timestamp: bigint!
 			$fee: numeric!
 			$order_id: String!
 			$trade_id: String!
@@ -175,7 +171,6 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 				order_id
 				trade_id
 				exchange_account_id
-				created_at
 			}
 		}
 	`
@@ -186,7 +181,7 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 		"side":               input.Side,
 		"price":              input.Price,
 		"quantity":           input.Quantity,
-		"timestamp":          input.Timestamp.Format(time.RFC3339),
+		"timestamp":          input.Timestamp.UnixMilli(),
 		"fee":                input.Fee,
 		"order_id":           input.OrderID,
 		"trade_id":           input.TradeID,
@@ -220,7 +215,7 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 			$side: String!
 			$price: numeric!
 			$quantity: numeric!
-			$timestamp: timestamp!
+			$timestamp: bigint!
 			$fee: numeric!
 			$order_id: String!
 			$trade_id: String!
@@ -252,7 +247,6 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 				order_id
 				trade_id
 				exchange_account_id
-				created_at
 			}
 		}
 	`
@@ -264,7 +258,7 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 		"side":               input.Side,
 		"price":              input.Price,
 		"quantity":           input.Quantity,
-		"timestamp":          input.Timestamp.Format(time.RFC3339),
+		"timestamp":          input.Timestamp.UnixMilli(),
 		"fee":                input.Fee,
 		"order_id":           input.OrderID,
 		"trade_id":           input.TradeID,
@@ -347,7 +341,6 @@ func (c *Client) LatestTrade(ctx context.Context, exchangeAccountIDs []uuid.UUID
 				order_id
 				trade_id
 				exchange_account_id
-				created_at
 			}
 		}
 	`

--- a/db/trades_test.go
+++ b/db/trades_test.go
@@ -26,7 +26,6 @@ func TestClient_GetTrade(t *testing.T) {
 		OrderID:           "order-123",
 		TradeID:           "trade-456",
 		ExchangeAccountID: accountID,
-		CreatedAt:         time.Now(),
 	}
 
 	mockClient := &mockGraphQLClient{
@@ -108,7 +107,6 @@ func TestClient_ListTrades_NoFilter(t *testing.T) {
 			OrderID:           "order-123",
 			TradeID:           "trade-456",
 			ExchangeAccountID: accountID1,
-			CreatedAt:         time.Now(),
 		},
 		{
 			ID:                uuid.New(),
@@ -122,7 +120,6 @@ func TestClient_ListTrades_NoFilter(t *testing.T) {
 			OrderID:           "order-789",
 			TradeID:           "trade-101",
 			ExchangeAccountID: accountID2,
-			CreatedAt:         time.Now(),
 		},
 	}
 
@@ -169,7 +166,6 @@ func TestClient_ListTrades_WithFilter(t *testing.T) {
 			OrderID:           "order-123",
 			TradeID:           "trade-456",
 			ExchangeAccountID: accountID1,
-			CreatedAt:         time.Now(),
 		},
 	}
 
@@ -217,7 +213,6 @@ func TestClient_CreateTrade(t *testing.T) {
 		OrderID:           "order-123",
 		TradeID:           "trade-456",
 		ExchangeAccountID: accountID,
-		CreatedAt:         time.Now(),
 	}
 
 	mockClient := &mockGraphQLClient{
@@ -277,7 +272,6 @@ func TestClient_UpdateTrade(t *testing.T) {
 		OrderID:           "order-789",
 		TradeID:           "trade-101",
 		ExchangeAccountID: accountID,
-		CreatedAt:         time.Now(),
 	}
 
 	mockClient := &mockGraphQLClient{
@@ -367,7 +361,6 @@ func TestClient_LatestTrade(t *testing.T) {
 			OrderID:           "order-123",
 			TradeID:           "trade-456",
 			ExchangeAccountID: accountID1,
-			CreatedAt:         time.Now(),
 		},
 		{
 			ID:                uuid.New(),
@@ -381,7 +374,6 @@ func TestClient_LatestTrade(t *testing.T) {
 			OrderID:           "order-789",
 			TradeID:           "trade-101",
 			ExchangeAccountID: accountID2,
-			CreatedAt:         time.Now(),
 		},
 		{
 			ID:                uuid.New(),
@@ -395,7 +387,6 @@ func TestClient_LatestTrade(t *testing.T) {
 			OrderID:           "order-111",
 			TradeID:           "trade-222",
 			ExchangeAccountID: accountID1,
-			CreatedAt:         time.Now(),
 		},
 	}
 

--- a/exchange/hyperliquid/client_test.go
+++ b/exchange/hyperliquid/client_test.go
@@ -44,6 +44,7 @@ func TestHyperliquidClient_FetchTrades_Success(t *testing.T) {
 		response := []hyperliquidFill{
 			{
 				Hash:    "0x123",
+				Tid:     111111111111111, // Unique fill ID
 				Oid:     123456789,
 				Coin:    "BTC-USDC",
 				Side:    "B",
@@ -54,6 +55,7 @@ func TestHyperliquidClient_FetchTrades_Success(t *testing.T) {
 			},
 			{
 				Hash:    "0x456",
+				Tid:     222222222222222, // Unique fill ID
 				Oid:     987654321,
 				Coin:    "ETH-USDC",
 				Side:    "S",
@@ -91,8 +93,9 @@ func TestHyperliquidClient_FetchTrades_Success(t *testing.T) {
 	}
 
 	// Verify first trade (should be oldest due to sorting)
-	if trades[0].TradeID != "0x123" {
-		t.Errorf("Expected trade ID '0x123', got '%s'", trades[0].TradeID)
+	// TradeID should now be the tid (fill ID), not the hash
+	if trades[0].TradeID != "111111111111111" {
+		t.Errorf("Expected trade ID '111111111111111' (tid), got '%s'", trades[0].TradeID)
 	}
 	if trades[0].Side != "buy" {
 		t.Errorf("Expected side 'buy', got '%s'", trades[0].Side)
@@ -188,6 +191,7 @@ func TestHyperliquidClient_FetchTrades_FiltersBySince(t *testing.T) {
 		response := []hyperliquidFill{
 			{
 				Hash:    "0xold",
+				Tid:     333333333333333, // Unique fill ID
 				Oid:     111111111,
 				Coin:    "BTC-USDC",
 				Side:    "B",
@@ -198,6 +202,7 @@ func TestHyperliquidClient_FetchTrades_FiltersBySince(t *testing.T) {
 			},
 			{
 				Hash:    "0xnew",
+				Tid:     444444444444444, // Unique fill ID
 				Oid:     222222222,
 				Coin:    "ETH-USDC",
 				Side:    "S",
@@ -235,8 +240,9 @@ func TestHyperliquidClient_FetchTrades_FiltersBySince(t *testing.T) {
 		t.Fatalf("Expected 1 trade after filtering, got %d", len(trades))
 	}
 
-	if trades[0].TradeID != "0xnew" {
-		t.Errorf("Expected trade ID '0xnew', got '%s'", trades[0].TradeID)
+	// TradeID should now be the tid (fill ID), not the hash
+	if trades[0].TradeID != "444444444444444" {
+		t.Errorf("Expected trade ID '444444444444444' (tid), got '%s'", trades[0].TradeID)
 	}
 }
 

--- a/exchange/hyperliquid/types.go
+++ b/exchange/hyperliquid/types.go
@@ -9,9 +9,10 @@ type hyperliquidFill struct {
 	Sz      interface{} `json:"sz"`      // Size/Quantity (number or string)
 	Side    string      `json:"side"`     // "B" (buy), "S" (sell), "A" (close)
 	Time    interface{} `json:"time"`    // Unix timestamp in milliseconds
-	Hash    string      `json:"hash"`     // Transaction hash (used as trade_id)
+	Hash    string      `json:"hash"`     // Transaction hash
+	Tid     interface{} `json:"tid"`      // Fill ID (unique per fill, used as trade_id)
 	Oid     interface{} `json:"oid"`     // Order ID (number or string)
 	Fee     interface{} `json:"fee"`     // Fee (number or string)
 	// Additional fields that may be present but not used:
-	// StartPosition, Dir, ClosedPnl, Crossed, FeeToken, Tid, TwapId
+	// StartPosition, Dir, ClosedPnl, Crossed, FeeToken, TwapId
 }

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/zif-terminal/lib
 
 go 1.21
 
-require github.com/machinebox/graphql v0.2.2
+require (
+	github.com/google/uuid v1.6.0
+	github.com/machinebox/graphql v0.2.2
+)
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/matryer/is v1.4.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 )


### PR DESCRIPTION
- Remove created_at field from Trade model and GraphQL queries
- Change timestamp from TIMESTAMP to BIGINT (Unix milliseconds)
- Use tid (fill ID) instead of hash as trade_id for uniqueness
- Update timestamp parsing to handle BIGINT Unix milliseconds
- Ensure timestamps are converted to UTC for consistency
- Update tests to remove CreatedAt references
- Move google/uuid from indirect to direct dependency