### PR TITLE
Add Drift DEX support and unified account discovery

### DIFF
--- a/exchange/client.go
+++ b/exchange/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/zif-terminal/lib/exchange/drift"
 	"github.com/zif-terminal/lib/exchange/hyperliquid"
 	"github.com/zif-terminal/lib/exchange/iface"
 )
@@ -25,11 +26,11 @@ func GetClient(name string) (iface.ExchangeClient, error) {
 	switch name {
 	case "hyperliquid":
 		return hyperliquid.NewClient(), nil
+	case "drift":
+		return drift.NewClient(), nil
 	// Add more exchanges here as they are implemented:
 	// case "lighter":
 	//     return lighter.NewClient(), nil
-	// case "drift":
-	//     return drift.NewClient(), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrExchangeNotFound, name)
 	}
@@ -39,8 +40,8 @@ func GetClient(name string) (iface.ExchangeClient, error) {
 func ListAvailableExchanges() []string {
 	return []string{
 		"hyperliquid",
+		"drift",
 		// Add more exchanges here as they are implemented:
 		// "lighter",
-		// "drift",
 	}
 }

--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -1,0 +1,749 @@
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+// Client implements iface.ExchangeClient for Drift
+type Client struct {
+	baseURL     string
+	httpClient  *http.Client
+	marketCache *marketCache
+}
+
+// NewClient creates a new Drift client
+func NewClient() *Client {
+	return &Client{
+		baseURL:     "https://data.api.drift.trade",
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour), // Cache markets for 1 hour
+	}
+}
+
+// Name returns the exchange identifier
+func (c *Client) Name() string {
+	return "drift"
+}
+
+// FetchTrades fetches trades from Drift API
+// Transforms exchange response directly to []*models.TradeInput
+// Implements pagination to fetch all historical trades
+// Drift API returns trades newest→oldest, so we reverse at the end
+func (c *Client) FetchTrades(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TradeInput, error) {
+	// Check if ctx is cancelled
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Parse account ID to UUID
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	// Extract account identifier (Drift subaccount public key)
+	accountID := account.AccountIdentifier
+	if accountID == "" {
+		return nil, fmt.Errorf("account identifier (subaccount public key) is required")
+	}
+
+	// Determine if we need to fetch historical data (older than 31 days)
+	thirtyOneDaysAgo := time.Now().AddDate(0, 0, -31)
+
+	// Determine the effective "since" date for historical fetching
+	// If since is zero, we want ALL historical data - use Drift launch date (Nov 2021)
+	var effectiveSince time.Time
+	if since.IsZero() {
+		effectiveSince = time.Date(2021, 11, 1, 0, 0, 0, 0, time.UTC)
+	} else {
+		effectiveSince = since
+	}
+
+	needsHistorical := effectiveSince.Before(thirtyOneDaysAgo)
+
+	var allTrades []*models.TradeInput
+
+	// Fetch historical months if needed
+	if needsHistorical {
+		historicalTrades, err := c.fetchHistoricalTrades(ctx, accountID, accountUUID, effectiveSince, thirtyOneDaysAgo)
+		if err != nil {
+			return nil, err
+		}
+		allTrades = append(allTrades, historicalTrades...)
+	}
+
+	// Fetch recent trades (last 31 days)
+	recentTrades, err := c.fetchRecentTrades(ctx, accountID, accountUUID)
+	if err != nil {
+		return nil, err
+	}
+	allTrades = append(allTrades, recentTrades...)
+
+	// Filter by since timestamp
+	if !since.IsZero() {
+		filtered := make([]*models.TradeInput, 0)
+		for _, trade := range allTrades {
+			if !trade.Timestamp.Before(since) {
+				filtered = append(filtered, trade)
+			}
+		}
+		allTrades = filtered
+	}
+
+	// Deduplicate by TradeID
+	allTrades = deduplicateTrades(allTrades)
+
+	// Sort by timestamp (oldest first)
+	sort.Slice(allTrades, func(i, j int) bool {
+		return allTrades[i].Timestamp.Before(allTrades[j].Timestamp)
+	})
+
+	return allTrades, nil
+}
+
+// fetchRecentTrades fetches trades from the last 31 days
+func (c *Client) fetchRecentTrades(ctx context.Context, accountID string, accountUUID uuid.UUID) ([]*models.TradeInput, error) {
+	var allTrades []*models.TradeInput
+	var page string // Empty for first request, API returns nextPage token for pagination
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		var url string
+		if page == "" {
+			url = fmt.Sprintf("%s/user/%s/trades", c.baseURL, accountID)
+		} else {
+			url = fmt.Sprintf("%s/user/%s/trades?page=%s", c.baseURL, accountID, page)
+		}
+		trades, nextPage, err := c.fetchTradesPage(ctx, url, accountUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		allTrades = append(allTrades, trades...)
+
+		if nextPage == "" {
+			break
+		}
+		page = nextPage
+	}
+
+	return allTrades, nil
+}
+
+// fetchHistoricalTrades fetches trades from historical months
+func (c *Client) fetchHistoricalTrades(ctx context.Context, accountID string, accountUUID uuid.UUID, since, until time.Time) ([]*models.TradeInput, error) {
+	var allTrades []*models.TradeInput
+
+	// Iterate through months from since to until
+	current := time.Date(since.Year(), since.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(until.Year(), until.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	for !current.After(end) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		monthTrades, err := c.fetchTradesForMonth(ctx, accountID, accountUUID, current.Year(), int(current.Month()))
+		if err != nil {
+			// Log but continue - some months may not have data
+			current = current.AddDate(0, 1, 0)
+			continue
+		}
+
+		allTrades = append(allTrades, monthTrades...)
+		current = current.AddDate(0, 1, 0)
+	}
+
+	return allTrades, nil
+}
+
+// fetchTradesForMonth fetches trades for a specific year/month
+func (c *Client) fetchTradesForMonth(ctx context.Context, accountID string, accountUUID uuid.UUID, year, month int) ([]*models.TradeInput, error) {
+	var allTrades []*models.TradeInput
+	var page string // Empty for first request
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		var url string
+		if page == "" {
+			url = fmt.Sprintf("%s/user/%s/trades/%d/%d", c.baseURL, accountID, year, month)
+		} else {
+			url = fmt.Sprintf("%s/user/%s/trades/%d/%d?page=%s", c.baseURL, accountID, year, month, page)
+		}
+		trades, nextPage, err := c.fetchTradesPage(ctx, url, accountUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		allTrades = append(allTrades, trades...)
+
+		if nextPage == "" {
+			break
+		}
+		page = nextPage
+	}
+
+	return allTrades, nil
+}
+
+// fetchTradesPage fetches a single page of trades
+func (c *Client) fetchTradesPage(ctx context.Context, url string, accountUUID uuid.UUID) ([]*models.TradeInput, string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to fetch trades: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for rate limit (HTTP 429)
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, "", &iface.RateLimitError{
+			Exchange:   "drift",
+			Message:    "rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	var response driftTradesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !response.Success {
+		return nil, "", fmt.Errorf("API returned success=false")
+	}
+
+	// Transform records to TradeInput
+	trades := make([]*models.TradeInput, 0, len(response.Records))
+	for _, record := range response.Records {
+		trade, err := c.transformTrade(ctx, record, accountUUID)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to transform trade: %w", err)
+		}
+		trades = append(trades, trade)
+	}
+
+	// Get next page
+	nextPage := ""
+	if response.Meta.NextPage != nil {
+		switch v := response.Meta.NextPage.(type) {
+		case string:
+			nextPage = v
+		case float64:
+			nextPage = strconv.Itoa(int(v))
+		}
+	}
+
+	return trades, nextPage, nil
+}
+
+// transformTrade converts a Drift trade record to TradeInput
+func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, accountUUID uuid.UUID) (*models.TradeInput, error) {
+	// Determine if user is taker or maker
+	isTaker := record.User == record.Taker
+
+	// Get side based on whether user is taker or maker
+	var direction string
+	if isTaker {
+		direction = record.TakerOrderDirection
+	} else {
+		direction = record.MakerOrderDirection
+	}
+	side := normalizeSide(direction)
+
+	// Get order ID based on role
+	var orderID string
+	if isTaker {
+		orderID = record.TakerOrderID
+	} else {
+		orderID = record.MakerOrderID
+	}
+
+	// Get fee based on role (API returns already-formatted decimals)
+	var fee string
+	if isTaker {
+		fee = record.TakerFee
+	} else {
+		fee = record.MakerFee
+	}
+	// Clean up the fee value (remove trailing zeros)
+	fee = cleanDecimalString(fee)
+
+	// Parse symbol to get base/quote assets
+	// Drift format: "SOL-PERP" or "BTC-PERP"
+	baseAsset, quoteAsset := parseSymbol(record.Symbol)
+
+	// API returns already-formatted decimal values
+	baseAmount := cleanDecimalString(record.BaseAssetAmountFilled)
+	quoteAmount := cleanDecimalString(record.QuoteAssetAmountFilled)
+
+	// Calculate price = quoteAssetAmountFilled / baseAssetAmountFilled
+	price := calculatePrice(quoteAmount, baseAmount)
+
+	// Convert timestamp (Drift uses seconds, not milliseconds)
+	timestamp := time.Unix(record.Ts, 0).UTC()
+
+	return &models.TradeInput{
+		TradeID:           record.FillRecordID,
+		OrderID:           orderID,
+		BaseAsset:         baseAsset,
+		QuoteAsset:        quoteAsset,
+		Side:              side,
+		Price:             price,
+		Quantity:          baseAmount,
+		Fee:               fee,
+		Timestamp:         timestamp,
+		ExchangeAccountID: accountUUID,
+	}, nil
+}
+
+// FetchFundingPayments fetches funding payments from Drift API
+func (c *Client) FetchFundingPayments(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.FundingPaymentInput, error) {
+	// Check if ctx is cancelled
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Parse account ID to UUID
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	// Extract account identifier
+	accountID := account.AccountIdentifier
+	if accountID == "" {
+		return nil, fmt.Errorf("account identifier (subaccount public key) is required")
+	}
+
+	// Determine if we need to fetch historical data
+	thirtyOneDaysAgo := time.Now().AddDate(0, 0, -31)
+
+	// Determine the effective "since" date for historical fetching
+	// If since is zero, we want ALL historical data - use Drift launch date (Nov 2021)
+	var effectiveSince time.Time
+	if since.IsZero() {
+		effectiveSince = time.Date(2021, 11, 1, 0, 0, 0, 0, time.UTC)
+	} else {
+		effectiveSince = since
+	}
+
+	needsHistorical := effectiveSince.Before(thirtyOneDaysAgo)
+
+	var allPayments []*models.FundingPaymentInput
+
+	// Fetch historical months if needed
+	if needsHistorical {
+		historicalPayments, err := c.fetchHistoricalFunding(ctx, accountID, accountUUID, effectiveSince, thirtyOneDaysAgo)
+		if err != nil {
+			return nil, err
+		}
+		allPayments = append(allPayments, historicalPayments...)
+	}
+
+	// Fetch recent funding payments (last 31 days)
+	recentPayments, err := c.fetchRecentFunding(ctx, accountID, accountUUID)
+	if err != nil {
+		return nil, err
+	}
+	allPayments = append(allPayments, recentPayments...)
+
+	// Filter by since timestamp
+	if !since.IsZero() {
+		filtered := make([]*models.FundingPaymentInput, 0)
+		for _, payment := range allPayments {
+			if !payment.Timestamp.Before(since) {
+				filtered = append(filtered, payment)
+			}
+		}
+		allPayments = filtered
+	}
+
+	// Deduplicate by PaymentID
+	allPayments = deduplicateFunding(allPayments)
+
+	// Sort by timestamp (oldest first)
+	sort.Slice(allPayments, func(i, j int) bool {
+		return allPayments[i].Timestamp.Before(allPayments[j].Timestamp)
+	})
+
+	return allPayments, nil
+}
+
+// fetchRecentFunding fetches funding payments from the last 31 days
+func (c *Client) fetchRecentFunding(ctx context.Context, accountID string, accountUUID uuid.UUID) ([]*models.FundingPaymentInput, error) {
+	var allPayments []*models.FundingPaymentInput
+	var page string // Empty for first request
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		var url string
+		if page == "" {
+			url = fmt.Sprintf("%s/user/%s/fundingPayments", c.baseURL, accountID)
+		} else {
+			url = fmt.Sprintf("%s/user/%s/fundingPayments?page=%s", c.baseURL, accountID, page)
+		}
+		payments, nextPage, err := c.fetchFundingPage(ctx, url, accountUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		allPayments = append(allPayments, payments...)
+
+		if nextPage == "" {
+			break
+		}
+		page = nextPage
+	}
+
+	return allPayments, nil
+}
+
+// fetchHistoricalFunding fetches funding payments from historical months
+func (c *Client) fetchHistoricalFunding(ctx context.Context, accountID string, accountUUID uuid.UUID, since, until time.Time) ([]*models.FundingPaymentInput, error) {
+	var allPayments []*models.FundingPaymentInput
+
+	current := time.Date(since.Year(), since.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(until.Year(), until.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	for !current.After(end) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		monthPayments, err := c.fetchFundingForMonth(ctx, accountID, accountUUID, current.Year(), int(current.Month()))
+		if err != nil {
+			current = current.AddDate(0, 1, 0)
+			continue
+		}
+
+		allPayments = append(allPayments, monthPayments...)
+		current = current.AddDate(0, 1, 0)
+	}
+
+	return allPayments, nil
+}
+
+// fetchFundingForMonth fetches funding payments for a specific year/month
+func (c *Client) fetchFundingForMonth(ctx context.Context, accountID string, accountUUID uuid.UUID, year, month int) ([]*models.FundingPaymentInput, error) {
+	var allPayments []*models.FundingPaymentInput
+	var page string // Empty for first request
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		var url string
+		if page == "" {
+			url = fmt.Sprintf("%s/user/%s/fundingPayments/%d/%d", c.baseURL, accountID, year, month)
+		} else {
+			url = fmt.Sprintf("%s/user/%s/fundingPayments/%d/%d?page=%s", c.baseURL, accountID, year, month, page)
+		}
+		payments, nextPage, err := c.fetchFundingPage(ctx, url, accountUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		allPayments = append(allPayments, payments...)
+
+		if nextPage == "" {
+			break
+		}
+		page = nextPage
+	}
+
+	return allPayments, nil
+}
+
+// fetchFundingPage fetches a single page of funding payments
+func (c *Client) fetchFundingPage(ctx context.Context, url string, accountUUID uuid.UUID) ([]*models.FundingPaymentInput, string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to fetch funding payments: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, "", &iface.RateLimitError{
+			Exchange:   "drift",
+			Message:    "rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	var response driftFundingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !response.Success {
+		return nil, "", fmt.Errorf("API returned success=false")
+	}
+
+	// Transform records to FundingPaymentInput
+	payments := make([]*models.FundingPaymentInput, 0, len(response.Records))
+	for _, record := range response.Records {
+		payment, err := c.transformFundingPayment(ctx, record, accountUUID)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to transform funding payment: %w", err)
+		}
+		payments = append(payments, payment)
+	}
+
+	// Get next page
+	nextPage := ""
+	if response.Meta.NextPage != nil {
+		switch v := response.Meta.NextPage.(type) {
+		case string:
+			nextPage = v
+		case float64:
+			nextPage = strconv.Itoa(int(v))
+		}
+	}
+
+	return payments, nextPage, nil
+}
+
+// transformFundingPayment converts a Drift funding payment record to FundingPaymentInput
+func (c *Client) transformFundingPayment(ctx context.Context, record driftFundingPayment, accountUUID uuid.UUID) (*models.FundingPaymentInput, error) {
+	// Get market info to determine base asset
+	marketInfo, err := c.getMarketInfo(ctx, record.MarketIndex, "perp")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get market info for index %d: %w", record.MarketIndex, err)
+	}
+
+	// API returns already-formatted decimal values
+	amount := cleanDecimalString(record.FundingPayment)
+
+	// Generate unique payment ID: {ts}_{marketIndex}
+	paymentID := fmt.Sprintf("%d_%d", record.Ts, record.MarketIndex)
+
+	// Convert timestamp
+	timestamp := time.Unix(record.Ts, 0).UTC()
+
+	return &models.FundingPaymentInput{
+		ExchangeAccountID: accountUUID,
+		BaseAsset:         marketInfo.BaseAsset,
+		QuoteAsset:        marketInfo.QuoteAsset,
+		Amount:            amount,
+		Timestamp:         timestamp,
+		PaymentID:         paymentID,
+	}, nil
+}
+
+// Helper functions
+
+// normalizeSide converts Drift direction to "buy" or "sell"
+func normalizeSide(direction string) string {
+	direction = strings.ToLower(strings.TrimSpace(direction))
+	switch direction {
+	case "long":
+		return "buy"
+	case "short":
+		return "sell"
+	default:
+		return "buy" // Default to buy if unknown
+	}
+}
+
+// parseSymbol extracts base and quote assets from Drift symbol
+// Drift format: "SOL-PERP" -> base="SOL", quote="USDC"
+func parseSymbol(symbol string) (baseAsset, quoteAsset string) {
+	parts := strings.Split(symbol, "-")
+	if len(parts) >= 1 {
+		baseAsset = parts[0]
+	}
+	quoteAsset = "USDC" // Drift uses USDC for all perp markets
+	return
+}
+
+// cleanDecimalString removes trailing zeros from a decimal string
+func cleanDecimalString(s string) string {
+	if s == "" {
+		return "0"
+	}
+	// Trim trailing zeros after decimal point
+	if strings.Contains(s, ".") {
+		s = strings.TrimRight(s, "0")
+		s = strings.TrimRight(s, ".")
+	}
+	if s == "" || s == "-" {
+		return "0"
+	}
+	return s
+}
+
+// convertFromBasePrecision converts raw base amount to decimal string
+func convertFromBasePrecision(raw string) string {
+	if raw == "" {
+		return "0"
+	}
+	return divideByPrecision(raw, BasePrecision)
+}
+
+// convertFromQuotePrecision converts raw quote amount to decimal string
+func convertFromQuotePrecision(raw string) string {
+	if raw == "" {
+		return "0"
+	}
+	return divideByPrecision(raw, QuotePrecision)
+}
+
+// divideByPrecision divides a raw integer string by precision
+func divideByPrecision(raw string, precision int64) string {
+	// Parse the raw value as big.Int to handle large numbers
+	rawInt := new(big.Int)
+	rawInt, ok := rawInt.SetString(raw, 10)
+	if !ok {
+		return "0"
+	}
+
+	// Handle negative values
+	negative := rawInt.Sign() < 0
+	if negative {
+		rawInt = rawInt.Abs(rawInt)
+	}
+
+	// Divide by precision using big.Float for decimal handling
+	rawFloat := new(big.Float).SetInt(rawInt)
+	precFloat := new(big.Float).SetInt64(precision)
+	result := new(big.Float).Quo(rawFloat, precFloat)
+
+	// Format with appropriate precision
+	str := result.Text('f', 18) // Use 18 decimal places max
+
+	// Trim trailing zeros
+	if strings.Contains(str, ".") {
+		str = strings.TrimRight(str, "0")
+		str = strings.TrimRight(str, ".")
+	}
+
+	if negative {
+		str = "-" + str
+	}
+
+	return str
+}
+
+// calculatePrice calculates price from quote and base amounts
+func calculatePrice(quoteAmount, baseAmount string) string {
+	if baseAmount == "" || baseAmount == "0" {
+		return "0"
+	}
+
+	quoteFloat, _, err := big.ParseFloat(quoteAmount, 10, 256, big.ToNearestEven)
+	if err != nil {
+		return "0"
+	}
+
+	baseFloat, _, err := big.ParseFloat(baseAmount, 10, 256, big.ToNearestEven)
+	if err != nil {
+		return "0"
+	}
+
+	if baseFloat.Sign() == 0 {
+		return "0"
+	}
+
+	result := new(big.Float).Quo(quoteFloat, baseFloat)
+	str := result.Text('f', 18)
+
+	// Trim trailing zeros
+	if strings.Contains(str, ".") {
+		str = strings.TrimRight(str, "0")
+		str = strings.TrimRight(str, ".")
+	}
+
+	return str
+}
+
+// parseRetryAfter parses Retry-After header (seconds)
+func parseRetryAfter(retryAfter string) time.Duration {
+	if retryAfter == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// deduplicateTrades removes duplicate trades by TradeID
+func deduplicateTrades(trades []*models.TradeInput) []*models.TradeInput {
+	seen := make(map[string]bool)
+	result := make([]*models.TradeInput, 0, len(trades))
+
+	for _, trade := range trades {
+		if !seen[trade.TradeID] {
+			seen[trade.TradeID] = true
+			result = append(result, trade)
+		}
+	}
+
+	return result
+}
+
+// deduplicateFunding removes duplicate funding payments by PaymentID
+func deduplicateFunding(payments []*models.FundingPaymentInput) []*models.FundingPaymentInput {
+	seen := make(map[string]bool)
+	result := make([]*models.FundingPaymentInput, 0, len(payments))
+
+	for _, payment := range payments {
+		if !seen[payment.PaymentID] {
+			seen[payment.PaymentID] = true
+			result = append(result, payment)
+		}
+	}
+
+	return result
+}

--- a/exchange/drift/client_test.go
+++ b/exchange/drift/client_test.go
@@ -1,0 +1,642 @@
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+func TestDriftClient_Name(t *testing.T) {
+	client := NewClient()
+	if client.Name() != "drift" {
+		t.Errorf("Expected name 'drift', got '%s'", client.Name())
+	}
+}
+
+func TestDriftClient_FetchTrades_Success(t *testing.T) {
+	// Mock Drift API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+
+		// Return mock response - API returns already-formatted decimal strings
+		response := driftTradesResponse{
+			Success: true,
+			Records: []driftTradeRecord{
+				{
+					Ts:                     time.Now().Unix() - 10,
+					TxSig:                  "tx123",
+					FillRecordID:           "fill-001",
+					BaseAssetAmountFilled:  "1.000000000",  // Already decimal
+					QuoteAssetAmountFilled: "50.000000",    // Already decimal
+					TakerFee:               "0.050000",     // Already decimal
+					MakerFee:               "0",
+					TakerOrderDirection:    "long",
+					MakerOrderDirection:    "short",
+					TakerOrderID:           "order-001",
+					MakerOrderID:           "order-002",
+					Taker:                  "test-account",
+					Maker:                  "maker-account",
+					User:                   "test-account",
+					Symbol:                 "SOL-PERP",
+					MarketIndex:            0,
+					MarketType:             "perp",
+				},
+				{
+					Ts:                     time.Now().Unix() - 5,
+					TxSig:                  "tx456",
+					FillRecordID:           "fill-002",
+					BaseAssetAmountFilled:  "2.000000000",  // Already decimal
+					QuoteAssetAmountFilled: "6.000000",     // Already decimal
+					TakerFee:               "0",
+					MakerFee:               "0.030000",     // Already decimal
+					TakerOrderDirection:    "short",
+					MakerOrderDirection:    "long",
+					TakerOrderID:           "order-003",
+					MakerOrderID:           "order-004",
+					Taker:                  "taker-account",
+					Maker:                  "test-account",
+					User:                   "test-account",
+					Symbol:                 "BTC-PERP",
+					MarketIndex:            1,
+					MarketType:             "perp",
+				},
+			},
+			Meta: driftMeta{NextPage: nil},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create client with test server URL
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx := context.Background()
+	trades, err := client.FetchTrades(ctx, account, time.Time{})
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	if len(trades) != 2 {
+		t.Fatalf("Expected 2 trades, got %d", len(trades))
+	}
+
+	// Verify first trade (should be oldest due to sorting)
+	if trades[0].TradeID != "fill-001" {
+		t.Errorf("Expected trade ID 'fill-001', got '%s'", trades[0].TradeID)
+	}
+	if trades[0].Side != "buy" { // long -> buy
+		t.Errorf("Expected side 'buy', got '%s'", trades[0].Side)
+	}
+	if trades[0].BaseAsset != "SOL" {
+		t.Errorf("Expected base asset 'SOL', got '%s'", trades[0].BaseAsset)
+	}
+	if trades[0].QuoteAsset != "USDC" {
+		t.Errorf("Expected quote asset 'USDC', got '%s'", trades[0].QuoteAsset)
+	}
+	if trades[0].Quantity != "1" {
+		t.Errorf("Expected quantity '1', got '%s'", trades[0].Quantity)
+	}
+
+	// Verify second trade (maker)
+	if trades[1].TradeID != "fill-002" {
+		t.Errorf("Expected trade ID 'fill-002', got '%s'", trades[1].TradeID)
+	}
+	if trades[1].Side != "buy" { // maker is long
+		t.Errorf("Expected side 'buy', got '%s'", trades[1].Side)
+	}
+
+	// Verify sorting (oldest first)
+	if trades[0].Timestamp.After(trades[1].Timestamp) {
+		t.Error("Trades should be sorted oldest first")
+	}
+}
+
+func TestDriftClient_FetchTrades_Pagination(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var response driftTradesResponse
+		if callCount == 1 {
+			// First page
+			response = driftTradesResponse{
+				Success: true,
+				Records: []driftTradeRecord{
+					{
+						Ts:                     time.Now().Unix() - 20,
+						FillRecordID:           "fill-page1",
+						BaseAssetAmountFilled:  "1.000000000",
+						QuoteAssetAmountFilled: "50.000000",
+						TakerFee:               "0.050000",
+						TakerOrderDirection:    "long",
+						Taker:                  "test-account",
+						User:                   "test-account",
+						Symbol:                 "SOL-PERP",
+						MarketType:             "perp",
+					},
+				},
+				Meta: driftMeta{NextPage: "2"},
+			}
+		} else {
+			// Second page (last)
+			response = driftTradesResponse{
+				Success: true,
+				Records: []driftTradeRecord{
+					{
+						Ts:                     time.Now().Unix() - 10,
+						FillRecordID:           "fill-page2",
+						BaseAssetAmountFilled:  "2.000000000",
+						QuoteAssetAmountFilled: "100.000000",
+						TakerFee:               "0.100000",
+						TakerOrderDirection:    "short",
+						Taker:                  "test-account",
+						User:                   "test-account",
+						Symbol:                 "BTC-PERP",
+						MarketType:             "perp",
+					},
+				},
+				Meta: driftMeta{NextPage: nil},
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx := context.Background()
+	// Use a recent since time (within last 31 days) to avoid historical backfilling
+	recentSince := time.Now().Add(-7 * 24 * time.Hour)
+	trades, err := client.FetchTrades(ctx, account, recentSince)
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("Expected 2 API calls for pagination, got %d", callCount)
+	}
+
+	if len(trades) != 2 {
+		t.Fatalf("Expected 2 trades from pagination, got %d", len(trades))
+	}
+}
+
+func TestDriftClient_FetchTrades_RateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx := context.Background()
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected rate limit error")
+	}
+
+	if !iface.IsRateLimitError(err) {
+		t.Errorf("Expected RateLimitError, got: %v", err)
+	}
+
+	rateLimitErr, ok := err.(*iface.RateLimitError)
+	if !ok {
+		t.Fatalf("Expected *RateLimitError, got %T", err)
+	}
+
+	if rateLimitErr.Exchange != "drift" {
+		t.Errorf("Expected exchange 'drift', got '%s'", rateLimitErr.Exchange)
+	}
+
+	if rateLimitErr.RetryAfter != 60*time.Second {
+		t.Errorf("Expected retry after 60s, got %v", rateLimitErr.RetryAfter)
+	}
+}
+
+func TestDriftClient_FetchTrades_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(driftTradesResponse{Success: true})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected error due to context cancellation")
+	}
+}
+
+func TestDriftClient_FetchTrades_FiltersBySince(t *testing.T) {
+	now := time.Now()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := driftTradesResponse{
+			Success: true,
+			Records: []driftTradeRecord{
+				{
+					Ts:                     now.Add(-20 * time.Second).Unix(),
+					FillRecordID:           "old-trade",
+					BaseAssetAmountFilled:  "1.000000000",
+					QuoteAssetAmountFilled: "50.000000",
+					TakerFee:               "0.050000",
+					TakerOrderDirection:    "long",
+					Taker:                  "test-account",
+					User:                   "test-account",
+					Symbol:                 "SOL-PERP",
+					MarketType:             "perp",
+				},
+				{
+					Ts:                     now.Add(-5 * time.Second).Unix(),
+					FillRecordID:           "new-trade",
+					BaseAssetAmountFilled:  "2.000000000",
+					QuoteAssetAmountFilled: "100.000000",
+					TakerFee:               "0.100000",
+					TakerOrderDirection:    "short",
+					Taker:                  "test-account",
+					User:                   "test-account",
+					Symbol:                 "BTC-PERP",
+					MarketType:             "perp",
+				},
+			},
+			Meta: driftMeta{NextPage: nil},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx := context.Background()
+	since := now.Add(-10 * time.Second)
+	trades, err := client.FetchTrades(ctx, account, since)
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	// Should only get the new trade
+	if len(trades) != 1 {
+		t.Fatalf("Expected 1 trade after filtering, got %d", len(trades))
+	}
+
+	if trades[0].TradeID != "new-trade" {
+		t.Errorf("Expected trade ID 'new-trade', got '%s'", trades[0].TradeID)
+	}
+}
+
+func TestDriftClient_FetchTrades_InvalidAccountID(t *testing.T) {
+	client := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                "invalid-uuid",
+		AccountIdentifier: "test-account",
+	}
+
+	ctx := context.Background()
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected error for invalid account ID")
+	}
+}
+
+func TestDriftClient_FetchTrades_EmptyAccountIdentifier(t *testing.T) {
+	client := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "",
+	}
+
+	ctx := context.Background()
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected error for empty account identifier")
+	}
+}
+
+func TestDriftClient_FetchFundingPayments_Success(t *testing.T) {
+	// First call will be for markets, second for funding
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		if r.URL.Path == "/stats/markets" {
+			// Return mock markets
+			response := driftMarketsResponse{
+				Success: true,
+				Markets: []driftMarket{
+					{MarketIndex: 0, Symbol: "SOL-PERP", BaseAsset: "SOL", MarketType: "perp"},
+					{MarketIndex: 1, Symbol: "BTC-PERP", BaseAsset: "BTC", MarketType: "perp"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+
+		// Return mock funding payments (API returns decimal strings)
+		response := driftFundingResponse{
+			Success: true,
+			Records: []driftFundingPayment{
+				{
+					Ts:              time.Now().Unix() - 10,
+					TxSig:           "tx123",
+					MarketIndex:     0, // SOL-PERP
+					FundingPayment:  "0.1",
+					User:            "test-account",
+					BaseAssetAmount: "1.000000000",
+				},
+				{
+					Ts:              time.Now().Unix() - 5,
+					TxSig:           "tx456",
+					MarketIndex:     1, // BTC-PERP
+					FundingPayment:  "-0.05",
+					User:            "test-account",
+					BaseAssetAmount: "0.500000000",
+				},
+			},
+			Meta: driftMeta{NextPage: nil},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx := context.Background()
+	payments, err := client.FetchFundingPayments(ctx, account, time.Time{})
+	if err != nil {
+		t.Fatalf("FetchFundingPayments failed: %v", err)
+	}
+
+	if len(payments) != 2 {
+		t.Fatalf("Expected 2 payments, got %d", len(payments))
+	}
+
+	// Verify first payment (oldest)
+	if payments[0].BaseAsset != "SOL" {
+		t.Errorf("Expected base asset 'SOL', got '%s'", payments[0].BaseAsset)
+	}
+	if payments[0].Amount != "0.1" {
+		t.Errorf("Expected amount '0.1', got '%s'", payments[0].Amount)
+	}
+
+	// Verify second payment (negative)
+	if payments[1].BaseAsset != "BTC" {
+		t.Errorf("Expected base asset 'BTC', got '%s'", payments[1].BaseAsset)
+	}
+	if payments[1].Amount != "-0.05" {
+		t.Errorf("Expected amount '-0.05', got '%s'", payments[1].Amount)
+	}
+
+	// Verify sorting
+	if payments[0].Timestamp.After(payments[1].Timestamp) {
+		t.Error("Payments should be sorted oldest first")
+	}
+}
+
+func TestDriftClient_FetchFundingPayments_ContextCancellation(t *testing.T) {
+	client := NewClient()
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.FetchFundingPayments(ctx, account, time.Time{})
+	if err == nil {
+		t.Fatal("Expected error due to context cancellation")
+	}
+}
+
+// Test helper functions
+
+func TestNormalizeSide(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"long", "buy"},
+		{"LONG", "buy"},
+		{"Long", "buy"},
+		{"short", "sell"},
+		{"SHORT", "sell"},
+		{"Short", "sell"},
+		{"unknown", "buy"}, // Default
+		{"", "buy"},        // Default
+	}
+
+	for _, tc := range tests {
+		result := normalizeSide(tc.input)
+		if result != tc.expected {
+			t.Errorf("normalizeSide(%q) = %q, expected %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestParseSymbol(t *testing.T) {
+	tests := []struct {
+		symbol     string
+		baseAsset  string
+		quoteAsset string
+	}{
+		{"SOL-PERP", "SOL", "USDC"},
+		{"BTC-PERP", "BTC", "USDC"},
+		{"ETH-PERP", "ETH", "USDC"},
+		{"SOL", "SOL", "USDC"}, // No suffix
+	}
+
+	for _, tc := range tests {
+		base, quote := parseSymbol(tc.symbol)
+		if base != tc.baseAsset {
+			t.Errorf("parseSymbol(%q) base = %q, expected %q", tc.symbol, base, tc.baseAsset)
+		}
+		if quote != tc.quoteAsset {
+			t.Errorf("parseSymbol(%q) quote = %q, expected %q", tc.symbol, quote, tc.quoteAsset)
+		}
+	}
+}
+
+func TestCleanDecimalString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"1.000000000", "1"},
+		{"50.000000", "50"},
+		{"0.050000", "0.05"},
+		{"1.500000000", "1.5"},
+		{"0.123456789", "0.123456789"},
+		{"-0.05", "-0.05"},
+		{"-1.000000", "-1"},
+		{"0", "0"},
+		{"0.0", "0"},
+		{"", "0"},
+		{"100", "100"},
+	}
+
+	for _, tc := range tests {
+		result := cleanDecimalString(tc.input)
+		if result != tc.expected {
+			t.Errorf("cleanDecimalString(%q) = %q, expected %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestConvertFromBasePrecision(t *testing.T) {
+	tests := []struct {
+		raw      string
+		expected string
+	}{
+		{"1000000000", "1"},           // 1.0
+		{"1500000000", "1.5"},         // 1.5
+		{"500000000", "0.5"},          // 0.5
+		{"123456789", "0.123456789"},  // Fractional
+		{"0", "0"},
+		{"", "0"},
+	}
+
+	for _, tc := range tests {
+		result := convertFromBasePrecision(tc.raw)
+		if result != tc.expected {
+			t.Errorf("convertFromBasePrecision(%q) = %q, expected %q", tc.raw, result, tc.expected)
+		}
+	}
+}
+
+func TestConvertFromQuotePrecision(t *testing.T) {
+	tests := []struct {
+		raw      string
+		expected string
+	}{
+		{"1000000", "1"},       // 1.0
+		{"1500000", "1.5"},     // 1.5
+		{"500000", "0.5"},      // 0.5
+		{"100000", "0.1"},      // 0.1
+		{"50000", "0.05"},      // 0.05
+		{"-100000", "-0.1"},    // Negative
+		{"0", "0"},
+		{"", "0"},
+	}
+
+	for _, tc := range tests {
+		result := convertFromQuotePrecision(tc.raw)
+		if result != tc.expected {
+			t.Errorf("convertFromQuotePrecision(%q) = %q, expected %q", tc.raw, result, tc.expected)
+		}
+	}
+}
+
+func TestCalculatePrice(t *testing.T) {
+	tests := []struct {
+		quote    string
+		base     string
+		expected string
+	}{
+		{"50", "1", "50"},
+		{"100", "2", "50"},
+		{"33", "3", "11"},
+		{"0", "1", "0"},
+		{"50", "0", "0"}, // Division by zero
+		{"50", "", "0"},  // Empty base
+	}
+
+	for _, tc := range tests {
+		result := calculatePrice(tc.quote, tc.base)
+		if result != tc.expected {
+			t.Errorf("calculatePrice(%q, %q) = %q, expected %q", tc.quote, tc.base, result, tc.expected)
+		}
+	}
+}
+
+// Test contract compliance
+func TestDriftClient_Contract(t *testing.T) {
+	t.Run("Name", func(t *testing.T) {
+		client := NewClient()
+		name := client.Name()
+		if name == "" {
+			t.Error("Name() must return non-empty string")
+		}
+		if name != "drift" {
+			t.Errorf("Expected name 'drift', got '%s'", name)
+		}
+	})
+}

--- a/exchange/drift/discovery.go
+++ b/exchange/drift/discovery.go
@@ -1,0 +1,83 @@
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// DiscoverAccounts discovers all syncable accounts for a given Solana wallet address
+// Drift uses subaccounts tied to a wallet authority
+// GET /authority/{walletAddress}/accounts
+func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([]*models.DiscoverableAccount, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	if userIdentifier == "" {
+		return nil, fmt.Errorf("user identifier (Solana wallet address) is required")
+	}
+
+	url := fmt.Sprintf("%s/authority/%s/accounts", c.baseURL, userIdentifier)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch accounts: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("rate limit exceeded")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	var response driftAuthorityAccountsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	// Transform to DiscoverableAccount
+	accounts := make([]*models.DiscoverableAccount, 0, len(response.Accounts))
+	for _, acc := range response.Accounts {
+		accountType := "main"
+		if acc.SubAccountID > 0 {
+			accountType = "sub_account"
+		}
+
+		name := acc.Name
+		if name == "" {
+			if acc.SubAccountID == 0 {
+				name = "Main Account"
+			} else {
+				name = fmt.Sprintf("Subaccount %d", acc.SubAccountID)
+			}
+		}
+
+		accounts = append(accounts, &models.DiscoverableAccount{
+			AccountIdentifier: acc.AccountID,
+			AccountType:       accountType,
+			Name:              name,
+			Metadata: map[string]interface{}{
+				"authority":     userIdentifier,
+				"sub_account_id": acc.SubAccountID,
+			},
+		})
+	}
+
+	return accounts, nil
+}

--- a/exchange/drift/discovery_test.go
+++ b/exchange/drift/discovery_test.go
@@ -1,0 +1,173 @@
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDriftClient_DiscoverAccounts_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+
+		// Should be calling /authority/{wallet}/accounts
+		expectedPath := "/authority/ELoqJYcFTc8qjGhJShUupEkRomed8rykb3CUhrzAT4Q1/accounts"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		response := driftAuthorityAccountsResponse{
+			Success: true,
+			Accounts: []driftAuthorityAccount{
+				{
+					AccountID:    "C13FZykQ123abc",
+					SubAccountID: 0,
+					Name:         "Main Trading",
+					Authority:    "ELoqJYcFTc8qjGhJShUupEkRomed8rykb3CUhrzAT4Q1",
+				},
+				{
+					AccountID:    "H7s1cVn4456def",
+					SubAccountID: 1,
+					Name:         "Bot Account",
+					Authority:    "ELoqJYcFTc8qjGhJShUupEkRomed8rykb3CUhrzAT4Q1",
+				},
+				{
+					AccountID:    "BYhwfY1b789ghi",
+					SubAccountID: 2,
+					Name:         "", // Empty name
+					Authority:    "ELoqJYcFTc8qjGhJShUupEkRomed8rykb3CUhrzAT4Q1",
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	ctx := context.Background()
+	accounts, err := client.DiscoverAccounts(ctx, "ELoqJYcFTc8qjGhJShUupEkRomed8rykb3CUhrzAT4Q1")
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	if len(accounts) != 3 {
+		t.Fatalf("Expected 3 accounts, got %d", len(accounts))
+	}
+
+	// Verify first account (main)
+	if accounts[0].AccountIdentifier != "C13FZykQ123abc" {
+		t.Errorf("Expected account identifier 'C13FZykQ123abc', got '%s'", accounts[0].AccountIdentifier)
+	}
+	if accounts[0].AccountType != "main" {
+		t.Errorf("Expected account type 'main', got '%s'", accounts[0].AccountType)
+	}
+	if accounts[0].Name != "Main Trading" {
+		t.Errorf("Expected name 'Main Trading', got '%s'", accounts[0].Name)
+	}
+
+	// Verify second account (subaccount)
+	if accounts[1].AccountType != "sub_account" {
+		t.Errorf("Expected account type 'sub_account', got '%s'", accounts[1].AccountType)
+	}
+	if accounts[1].Name != "Bot Account" {
+		t.Errorf("Expected name 'Bot Account', got '%s'", accounts[1].Name)
+	}
+
+	// Verify third account (subaccount with empty name)
+	if accounts[2].AccountType != "sub_account" {
+		t.Errorf("Expected account type 'sub_account', got '%s'", accounts[2].AccountType)
+	}
+	if accounts[2].Name != "Subaccount 2" {
+		t.Errorf("Expected default name 'Subaccount 2', got '%s'", accounts[2].Name)
+	}
+
+	// Verify metadata
+	if accounts[0].Metadata["authority"] != "ELoqJYcFTc8qjGhJShUupEkRomed8rykb3CUhrzAT4Q1" {
+		t.Errorf("Expected authority in metadata")
+	}
+	if accounts[0].Metadata["sub_account_id"] != 0 {
+		t.Errorf("Expected sub_account_id 0 in metadata")
+	}
+}
+
+func TestDriftClient_DiscoverAccounts_EmptyUserIdentifier(t *testing.T) {
+	client := NewClient()
+
+	ctx := context.Background()
+	_, err := client.DiscoverAccounts(ctx, "")
+	if err == nil {
+		t.Fatal("Expected error for empty user identifier")
+	}
+}
+
+func TestDriftClient_DiscoverAccounts_ContextCancellation(t *testing.T) {
+	client := NewClient()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.DiscoverAccounts(ctx, "ELoqJYcFTc8qjGhJShUupEkRomed8rykb3CUhrzAT4Q1")
+	if err == nil {
+		t.Fatal("Expected error due to context cancellation")
+	}
+}
+
+func TestDriftClient_DiscoverAccounts_NoAccounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := driftAuthorityAccountsResponse{
+			Success:  true,
+			Accounts: []driftAuthorityAccount{},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	ctx := context.Background()
+	accounts, err := client.DiscoverAccounts(ctx, "some-wallet")
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	if len(accounts) != 0 {
+		t.Errorf("Expected 0 accounts, got %d", len(accounts))
+	}
+}
+
+func TestDriftClient_DiscoverAccounts_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	ctx := context.Background()
+	_, err := client.DiscoverAccounts(ctx, "some-wallet")
+	if err == nil {
+		t.Fatal("Expected error for API error")
+	}
+}

--- a/exchange/drift/markets.go
+++ b/exchange/drift/markets.go
@@ -1,0 +1,161 @@
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// MarketInfo contains parsed market information
+type MarketInfo struct {
+	MarketIndex int
+	Symbol      string
+	BaseAsset   string
+	QuoteAsset  string
+	MarketType  string
+}
+
+// marketCache caches market information with TTL
+type marketCache struct {
+	perpMarkets map[int]MarketInfo
+	spotMarkets map[int]MarketInfo
+	mu          sync.RWMutex
+	lastFetch   time.Time
+	ttl         time.Duration
+}
+
+// newMarketCache creates a new market cache with the given TTL
+func newMarketCache(ttl time.Duration) *marketCache {
+	return &marketCache{
+		perpMarkets: make(map[int]MarketInfo),
+		spotMarkets: make(map[int]MarketInfo),
+		ttl:         ttl,
+	}
+}
+
+// isExpired checks if the cache has expired
+func (mc *marketCache) isExpired() bool {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	return time.Since(mc.lastFetch) > mc.ttl
+}
+
+// getMarket returns market info for the given index and type
+func (mc *marketCache) getMarket(marketIndex int, marketType string) (MarketInfo, bool) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	var markets map[int]MarketInfo
+	if marketType == "perp" {
+		markets = mc.perpMarkets
+	} else {
+		markets = mc.spotMarkets
+	}
+
+	info, ok := markets[marketIndex]
+	return info, ok
+}
+
+// setMarkets updates the cache with new market data
+func (mc *marketCache) setMarkets(perpMarkets, spotMarkets map[int]MarketInfo) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	mc.perpMarkets = perpMarkets
+	mc.spotMarkets = spotMarkets
+	mc.lastFetch = time.Now()
+}
+
+// fetchMarkets fetches market information from the Drift API
+func (c *Client) fetchMarkets(ctx context.Context) error {
+	// Check if cache is still valid
+	if !c.marketCache.isExpired() {
+		return nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/stats/markets", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to fetch markets: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("markets API returned status %d", resp.StatusCode)
+	}
+
+	var response driftMarketsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return fmt.Errorf("failed to decode markets response: %w", err)
+	}
+
+	if !response.Success {
+		return fmt.Errorf("markets API returned success=false")
+	}
+
+	// Build market maps
+	perpMarkets := make(map[int]MarketInfo)
+	spotMarkets := make(map[int]MarketInfo)
+
+	for _, m := range response.Markets {
+		info := MarketInfo{
+			MarketIndex: m.MarketIndex,
+			Symbol:      m.Symbol,
+			BaseAsset:   m.BaseAsset,
+			QuoteAsset:  "USDC", // Drift uses USDC as quote for all markets
+			MarketType:  m.MarketType,
+		}
+
+		if m.MarketType == "perp" {
+			perpMarkets[m.MarketIndex] = info
+		} else {
+			spotMarkets[m.MarketIndex] = info
+		}
+	}
+
+	c.marketCache.setMarkets(perpMarkets, spotMarkets)
+	return nil
+}
+
+// getMarketInfo returns market information for the given market index and type
+// It will fetch from API if cache is expired or missing
+func (c *Client) getMarketInfo(ctx context.Context, marketIndex int, marketType string) (MarketInfo, error) {
+	// Try cache first
+	if info, ok := c.marketCache.getMarket(marketIndex, marketType); ok {
+		return info, nil
+	}
+
+	// Fetch markets if cache miss or expired
+	if err := c.fetchMarkets(ctx); err != nil {
+		// Return a fallback if we can't fetch markets
+		// This allows the system to continue working even if markets API is down
+		return MarketInfo{
+			MarketIndex: marketIndex,
+			Symbol:      fmt.Sprintf("UNKNOWN-%d", marketIndex),
+			BaseAsset:   fmt.Sprintf("UNKNOWN-%d", marketIndex),
+			QuoteAsset:  "USDC",
+			MarketType:  marketType,
+		}, nil
+	}
+
+	// Try cache again after fetch
+	if info, ok := c.marketCache.getMarket(marketIndex, marketType); ok {
+		return info, nil
+	}
+
+	// Market not found even after fetch - return fallback
+	return MarketInfo{
+		MarketIndex: marketIndex,
+		Symbol:      fmt.Sprintf("UNKNOWN-%d", marketIndex),
+		BaseAsset:   fmt.Sprintf("UNKNOWN-%d", marketIndex),
+		QuoteAsset:  "USDC",
+		MarketType:  marketType,
+	}, nil
+}

--- a/exchange/drift/types.go
+++ b/exchange/drift/types.go
@@ -1,0 +1,96 @@
+package drift
+
+// Drift API response types
+// Base URL: https://data.api.drift.trade
+
+// Precision constants for Drift API
+// Drift returns raw integer values that need precision adjustment
+const (
+	// BASE_PRECISION for position sizes (divide by 10^9)
+	BasePrecision = 1_000_000_000
+	// QUOTE_PRECISION for USD values, fees, funding (divide by 10^6)
+	QuotePrecision = 1_000_000
+)
+
+// driftTradeRecord represents a single trade/fill from Drift API
+// GET /user/{accountId}/trades
+type driftTradeRecord struct {
+	Ts                     int64  `json:"ts"`                     // Unix timestamp (seconds)
+	TxSig                  string `json:"txSig"`                  // Transaction signature
+	TxSigIndex             int    `json:"txSigIndex"`             // Index within tx
+	FillRecordID           string `json:"fillRecordId"`           // Unique fill ID
+	BaseAssetAmountFilled  string `json:"baseAssetAmountFilled"`  // Quantity (raw, divide by BasePrecision)
+	QuoteAssetAmountFilled string `json:"quoteAssetAmountFilled"` // Value (raw, divide by QuotePrecision)
+	TakerFee               string `json:"takerFee"`               // Fee if taker (raw, divide by QuotePrecision)
+	MakerFee               string `json:"makerFee"`               // Fee if maker (raw, divide by QuotePrecision)
+	TakerOrderDirection    string `json:"takerOrderDirection"`    // "long"/"short"
+	MakerOrderDirection    string `json:"makerOrderDirection"`    // "long"/"short"
+	TakerOrderID           string `json:"takerOrderId"`
+	MakerOrderID           string `json:"makerOrderId"`
+	Taker                  string `json:"taker"`       // Taker account
+	Maker                  string `json:"maker"`       // Maker account
+	User                   string `json:"user"`        // Account for this record
+	Symbol                 string `json:"symbol"`      // e.g., "SOL-PERP"
+	MarketIndex            int    `json:"marketIndex"` // Market index
+	MarketType             string `json:"marketType"`  // "perp"/"spot"
+	OraclePrice            string `json:"oraclePrice"` // Oracle price at fill time
+}
+
+// driftFundingPayment represents a single funding payment from Drift API
+// GET /user/{accountId}/fundingPayments
+type driftFundingPayment struct {
+	Ts              int64  `json:"ts"`              // Unix timestamp (seconds)
+	TxSig           string `json:"txSig"`           // Transaction signature
+	TxSigIndex      int    `json:"txSigIndex"`      // Index within tx
+	MarketIndex     int    `json:"marketIndex"`     // Market index
+	FundingPayment  string `json:"fundingPayment"`  // Amount (signed, raw, divide by QuotePrecision)
+	User            string `json:"user"`            // Account public key
+	BaseAssetAmount string `json:"baseAssetAmount"` // Position size at payment time
+}
+
+// driftTradesResponse wraps the trades API response
+type driftTradesResponse struct {
+	Success bool               `json:"success"`
+	Records []driftTradeRecord `json:"records"`
+	Meta    driftMeta          `json:"meta"`
+}
+
+// driftFundingResponse wraps the funding payments API response
+type driftFundingResponse struct {
+	Success bool                  `json:"success"`
+	Records []driftFundingPayment `json:"records"`
+	Meta    driftMeta             `json:"meta"`
+}
+
+// driftMeta contains pagination metadata
+type driftMeta struct {
+	NextPage interface{} `json:"nextPage"` // string page number or nil when no more pages
+}
+
+// driftMarket represents market info from /stats/markets
+type driftMarket struct {
+	MarketIndex int    `json:"marketIndex"`
+	Symbol      string `json:"symbol"`     // e.g., "SOL-PERP"
+	BaseAsset   string `json:"baseAsset"`  // e.g., "SOL"
+	MarketType  string `json:"marketType"` // "perp" or "spot"
+}
+
+// driftMarketsResponse wraps the markets API response
+type driftMarketsResponse struct {
+	Success bool          `json:"success"`
+	Markets []driftMarket `json:"markets"`
+}
+
+// driftAuthorityAccount represents a subaccount from /authority/{wallet}/accounts
+type driftAuthorityAccount struct {
+	AccountID    string `json:"accountId"`    // Subaccount public key (used for API calls)
+	SubAccountID int    `json:"subAccountId"` // 0 for main, 1+ for subaccounts
+	Name         string `json:"name"`         // Account name
+	Authority    string `json:"authority"`    // Wallet address that owns this account
+}
+
+// driftAuthorityAccountsResponse wraps the authority accounts API response
+type driftAuthorityAccountsResponse struct {
+	Success  bool                    `json:"success"`
+	Accounts []driftAuthorityAccount `json:"accounts"`
+}

--- a/exchange/hyperliquid/discovery.go
+++ b/exchange/hyperliquid/discovery.go
@@ -1,0 +1,184 @@
+package hyperliquid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// subAccountResponse represents the response from subAccounts API
+type subAccountResponse struct {
+	SubAccountUser string `json:"subAccountUser"` // The subaccount address
+	Name           string `json:"name"`           // The subaccount name
+	Master         string `json:"master"`         // The master account address
+}
+
+// vaultEquityResponse represents the response from userVaultEquities API
+type vaultEquityResponse struct {
+	Vault       string `json:"vault"`       // The vault address
+	VaultName   string `json:"vaultName"`   // The vault name
+	Equity      string `json:"equity"`      // User's equity in the vault
+	VaultEquity string `json:"vaultEquity"` // Total vault equity
+}
+
+// DiscoverAccounts discovers all syncable accounts for a given wallet address
+// This includes: main account, subaccounts, and vaults the user has deposited in
+func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([]*models.DiscoverableAccount, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	if userIdentifier == "" {
+		return nil, fmt.Errorf("user identifier (wallet address) is required")
+	}
+
+	accounts := make([]*models.DiscoverableAccount, 0)
+
+	// 1. Add main account
+	accounts = append(accounts, &models.DiscoverableAccount{
+		AccountIdentifier: userIdentifier,
+		AccountType:       "main",
+		Name:              "Main Account",
+		Metadata:          map[string]interface{}{},
+	})
+
+	// 2. Fetch subaccounts
+	subAccounts, err := c.fetchSubAccounts(ctx, userIdentifier)
+	if err != nil {
+		// Log but don't fail - we still have the main account
+		// In production, consider proper logging
+	} else {
+		for _, sub := range subAccounts {
+			name := sub.Name
+			if name == "" {
+				name = fmt.Sprintf("Subaccount %s", truncateAddress(sub.SubAccountUser))
+			}
+			accounts = append(accounts, &models.DiscoverableAccount{
+				AccountIdentifier: sub.SubAccountUser,
+				AccountType:       "sub_account",
+				Name:              name,
+				Metadata: map[string]interface{}{
+					"master": userIdentifier,
+				},
+			})
+		}
+	}
+
+	// 3. Fetch vaults user has deposited in
+	vaults, err := c.fetchUserVaultEquities(ctx, userIdentifier)
+	if err != nil {
+		// Log but don't fail
+	} else {
+		for _, vault := range vaults {
+			name := vault.VaultName
+			if name == "" {
+				name = fmt.Sprintf("Vault %s", truncateAddress(vault.Vault))
+			}
+			accounts = append(accounts, &models.DiscoverableAccount{
+				AccountIdentifier: vault.Vault,
+				AccountType:       "vault",
+				Name:              name,
+				Metadata: map[string]interface{}{
+					"equity":       vault.Equity,
+					"vault_equity": vault.VaultEquity,
+				},
+			})
+		}
+	}
+
+	return accounts, nil
+}
+
+// fetchSubAccounts fetches subaccounts for a user
+// POST /info {"type": "subAccounts", "user": "<address>"}
+func (c *Client) fetchSubAccounts(ctx context.Context, userAddress string) ([]subAccountResponse, error) {
+	requestBody := map[string]interface{}{
+		"type": "subAccounts",
+		"user": userAddress,
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := c.createRequest(ctx, bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch subaccounts: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var subAccounts []subAccountResponse
+	if err := json.NewDecoder(resp.Body).Decode(&subAccounts); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return subAccounts, nil
+}
+
+// fetchUserVaultEquities fetches vaults the user has deposited in
+// POST /info {"type": "userVaultEquities", "user": "<address>"}
+func (c *Client) fetchUserVaultEquities(ctx context.Context, userAddress string) ([]vaultEquityResponse, error) {
+	requestBody := map[string]interface{}{
+		"type": "userVaultEquities",
+		"user": userAddress,
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := c.createRequest(ctx, bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch vault equities: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var vaults []vaultEquityResponse
+	if err := json.NewDecoder(resp.Body).Decode(&vaults); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return vaults, nil
+}
+
+// createRequest creates an HTTP request for the Hyperliquid API
+func (c *Client) createRequest(ctx context.Context, body []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/info", strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// truncateAddress returns a short version of an address for display
+func truncateAddress(addr string) string {
+	if len(addr) <= 10 {
+		return addr
+	}
+	return addr[:6] + "..." + addr[len(addr)-4:]
+}

--- a/exchange/hyperliquid/discovery_test.go
+++ b/exchange/hyperliquid/discovery_test.go
@@ -1,0 +1,245 @@
+package hyperliquid
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHyperliquidClient_DiscoverAccounts_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/info" {
+			t.Errorf("Expected path /info, got %s", r.URL.Path)
+		}
+
+		// Parse request to determine which endpoint is being called
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+
+		reqType := reqBody["type"].(string)
+
+		switch reqType {
+		case "subAccounts":
+			// Return mock subaccounts
+			response := []subAccountResponse{
+				{
+					SubAccountUser: "0x1111111111111111111111111111111111111111",
+					Name:           "Trading Bot",
+					Master:         "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8",
+				},
+				{
+					SubAccountUser: "0x2222222222222222222222222222222222222222",
+					Name:           "", // Empty name
+					Master:         "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8",
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+
+		case "userVaultEquities":
+			// Return mock vaults
+			response := []vaultEquityResponse{
+				{
+					Vault:       "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					VaultName:   "Alpha Vault",
+					Equity:      "1000.50",
+					VaultEquity: "50000.00",
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+
+		default:
+			t.Errorf("Unexpected request type: %s", reqType)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx := context.Background()
+	accounts, err := client.DiscoverAccounts(ctx, "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8")
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	// Should have: 1 main + 2 subaccounts + 1 vault = 4 accounts
+	if len(accounts) != 4 {
+		t.Fatalf("Expected 4 accounts, got %d", len(accounts))
+	}
+
+	// Verify main account
+	if accounts[0].AccountIdentifier != "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8" {
+		t.Errorf("Expected main account identifier, got '%s'", accounts[0].AccountIdentifier)
+	}
+	if accounts[0].AccountType != "main" {
+		t.Errorf("Expected account type 'main', got '%s'", accounts[0].AccountType)
+	}
+	if accounts[0].Name != "Main Account" {
+		t.Errorf("Expected name 'Main Account', got '%s'", accounts[0].Name)
+	}
+
+	// Verify first subaccount
+	if accounts[1].AccountType != "sub_account" {
+		t.Errorf("Expected account type 'sub_account', got '%s'", accounts[1].AccountType)
+	}
+	if accounts[1].Name != "Trading Bot" {
+		t.Errorf("Expected name 'Trading Bot', got '%s'", accounts[1].Name)
+	}
+	if accounts[1].Metadata["master"] != "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8" {
+		t.Errorf("Expected master in metadata")
+	}
+
+	// Verify second subaccount (with empty name - should have generated name)
+	if accounts[2].AccountType != "sub_account" {
+		t.Errorf("Expected account type 'sub_account', got '%s'", accounts[2].AccountType)
+	}
+	if accounts[2].Name == "" {
+		t.Error("Expected generated name for subaccount with empty name")
+	}
+
+	// Verify vault
+	if accounts[3].AccountType != "vault" {
+		t.Errorf("Expected account type 'vault', got '%s'", accounts[3].AccountType)
+	}
+	if accounts[3].Name != "Alpha Vault" {
+		t.Errorf("Expected name 'Alpha Vault', got '%s'", accounts[3].Name)
+	}
+	if accounts[3].Metadata["equity"] != "1000.50" {
+		t.Errorf("Expected equity in metadata")
+	}
+}
+
+func TestHyperliquidClient_DiscoverAccounts_EmptyUserIdentifier(t *testing.T) {
+	client := NewClient()
+
+	ctx := context.Background()
+	_, err := client.DiscoverAccounts(ctx, "")
+	if err == nil {
+		t.Fatal("Expected error for empty user identifier")
+	}
+}
+
+func TestHyperliquidClient_DiscoverAccounts_ContextCancellation(t *testing.T) {
+	client := NewClient()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.DiscoverAccounts(ctx, "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8")
+	if err == nil {
+		t.Fatal("Expected error due to context cancellation")
+	}
+}
+
+func TestHyperliquidClient_DiscoverAccounts_NoSubaccountsOrVaults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return empty arrays for both subaccounts and vaults
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]interface{}{})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx := context.Background()
+	accounts, err := client.DiscoverAccounts(ctx, "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8")
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	// Should have just the main account
+	if len(accounts) != 1 {
+		t.Fatalf("Expected 1 account (main only), got %d", len(accounts))
+	}
+
+	if accounts[0].AccountType != "main" {
+		t.Errorf("Expected account type 'main', got '%s'", accounts[0].AccountType)
+	}
+}
+
+func TestHyperliquidClient_DiscoverAccounts_SubaccountAPIError(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+
+		reqType := reqBody["type"].(string)
+
+		switch reqType {
+		case "subAccounts":
+			// Return error for subaccounts
+			w.WriteHeader(http.StatusInternalServerError)
+		case "userVaultEquities":
+			// Return success for vaults
+			response := []vaultEquityResponse{
+				{
+					Vault:     "0xaaaa",
+					VaultName: "Test Vault",
+					Equity:    "100",
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx := context.Background()
+	accounts, err := client.DiscoverAccounts(ctx, "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8")
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	// Should still return main account + vault even if subaccounts fail
+	// This tests graceful degradation
+	if len(accounts) < 1 {
+		t.Fatal("Expected at least main account")
+	}
+
+	// Main account should always be present
+	if accounts[0].AccountType != "main" {
+		t.Error("Expected main account to be first")
+	}
+}
+
+func TestTruncateAddress(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"0x1234567890abcdef1234567890abcdef12345678", "0x1234...5678"},
+		{"0x1234", "0x1234"},           // Short address - no truncation
+		{"short", "short"},             // Very short - no truncation
+		{"", ""},                       // Empty
+	}
+
+	for _, tc := range tests {
+		result := truncateAddress(tc.input)
+		if result != tc.expected {
+			t.Errorf("truncateAddress(%q) = %q, expected %q", tc.input, result, tc.expected)
+		}
+	}
+}

--- a/exchange/iface/client.go
+++ b/exchange/iface/client.go
@@ -9,7 +9,7 @@ import (
 
 // ExchangeClient is the interface that all exchange implementations must satisfy
 type ExchangeClient interface {
-	// Name returns the exchange identifier (e.g., "hyperliquid", "lighter")
+	// Name returns the exchange identifier (e.g., "hyperliquid", "drift")
 	Name() string
 
 	// FetchTrades fetches trades for a given account since a specific timestamp
@@ -30,4 +30,13 @@ type ExchangeClient interface {
 		account *models.ExchangeAccount,
 		since time.Time,
 	) ([]*models.FundingPaymentInput, error)
+
+	// DiscoverAccounts discovers all syncable accounts (main, subaccounts, vaults) for a given user identifier
+	// For Hyperliquid: userIdentifier is the wallet address (0x...)
+	// For Drift: userIdentifier is the Solana wallet address (authority)
+	// Returns a list of discoverable accounts that can be added for syncing
+	DiscoverAccounts(
+		ctx context.Context,
+		userIdentifier string,
+	) ([]*models.DiscoverableAccount, error)
 }

--- a/models/account.go
+++ b/models/account.go
@@ -29,3 +29,12 @@ type ExchangeAccountInput struct {
 	AccountType         string          `json:"account_type"` // Uses code string ('main', 'sub_account', 'vault')
 	AccountTypeMetadata json.RawMessage `json:"account_type_metadata,omitempty"`
 }
+
+// DiscoverableAccount represents an account discovered from an exchange
+// Used by the DiscoverAccounts interface method
+type DiscoverableAccount struct {
+	AccountIdentifier string                 `json:"account_identifier"` // The ID to use for syncing (subaccount address/pubkey)
+	AccountType       string                 `json:"account_type"`       // "main", "sub_account", "vault"
+	Name              string                 `json:"name"`               // Display name (e.g., "Main Account", "Trading Sub")
+	Metadata          map[string]interface{} `json:"metadata,omitempty"` // Exchange-specific extra data
+}


### PR DESCRIPTION
- Add Drift exchange client with trades and funding payment sync
- Implement historical backfilling for data older than 31 days
- Add DiscoverAccounts interface method for both Drift and Hyperliquid
- Support subaccount discovery via /authority/{wallet}/accounts endpoint
- Handle Drift API pagination with nextPage tokens
- Dynamic market mapping via /stats/markets endpoint