### PR TITLE
Add Lighter.xyz DEX exchange integration

### DIFF
--- a/exchange/client.go
+++ b/exchange/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zif-terminal/lib/exchange/drift"
 	"github.com/zif-terminal/lib/exchange/hyperliquid"
 	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/exchange/lighter"
 )
 
 // ErrExchangeNotFound is returned when an exchange name is not recognized
@@ -28,9 +29,8 @@ func GetClient(name string) (iface.ExchangeClient, error) {
 		return hyperliquid.NewClient(), nil
 	case "drift":
 		return drift.NewClient(), nil
-	// Add more exchanges here as they are implemented:
-	// case "lighter":
-	//     return lighter.NewClient(), nil
+	case "lighter":
+		return lighter.NewClient(), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrExchangeNotFound, name)
 	}
@@ -41,7 +41,6 @@ func ListAvailableExchanges() []string {
 	return []string{
 		"hyperliquid",
 		"drift",
-		// Add more exchanges here as they are implemented:
-		// "lighter",
+		"lighter",
 	}
 }

--- a/exchange/lighter/client.go
+++ b/exchange/lighter/client.go
@@ -1,0 +1,715 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+const (
+	defaultBaseURL = "https://mainnet.zklighter.elliot.ai"
+	httpTimeout    = 30 * time.Second
+	// Delay between pagination requests to avoid rate limits (60 req/min = 1 req/sec)
+	paginationDelay = 1500 * time.Millisecond
+	// Max retries for rate limit errors
+	maxRateLimitRetries = 3
+)
+
+// marketInfo holds cached market data
+type marketInfo struct {
+	symbol     string
+	baseAsset  string
+	quoteAsset string
+}
+
+// marketCache provides thread-safe caching of market information
+type marketCache struct {
+	mu      sync.RWMutex
+	markets map[int]marketInfo
+	loaded  bool
+}
+
+// Client implements the ExchangeClient interface for Lighter.xyz
+type Client struct {
+	baseURL     string
+	httpClient  *http.Client
+	marketCache *marketCache
+}
+
+// NewClient creates a new Lighter client
+func NewClient() *Client {
+	return &Client{
+		baseURL:    defaultBaseURL,
+		httpClient: &http.Client{Timeout: httpTimeout},
+		marketCache: &marketCache{
+			markets: make(map[int]marketInfo),
+		},
+	}
+}
+
+// Name returns the exchange identifier
+func (c *Client) Name() string {
+	return "lighter"
+}
+
+// FetchTrades retrieves trades for an account since the given timestamp
+func (c *Client) FetchTrades(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TradeInput, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	authToken, err := c.getAuthToken(account)
+	if err != nil {
+		return nil, err
+	}
+
+	accountIndex := account.AccountIdentifier
+	if accountIndex == "" {
+		return nil, fmt.Errorf("account identifier (account_index) is required")
+	}
+
+	// Ensure market cache is loaded
+	if err := c.loadMarketCache(ctx, authToken); err != nil {
+		return nil, fmt.Errorf("failed to load market info: %w", err)
+	}
+
+	var allTrades []*models.TradeInput
+	cursor := ""
+	pageCount := 0
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		// Add delay between pagination requests to avoid rate limits
+		if pageCount > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(paginationDelay):
+			}
+		}
+
+		var trades []lighterTrade
+		var nextCursor string
+		var err error
+
+		// Retry logic for rate limits
+		for retry := 0; retry <= maxRateLimitRetries; retry++ {
+			trades, nextCursor, err = c.fetchTrades(ctx, accountIndex, authToken, cursor)
+			if err == nil {
+				break
+			}
+
+			// Check if it's a rate limit error
+			var rateLimitErr *iface.RateLimitError
+			if errors.As(err, &rateLimitErr) && retry < maxRateLimitRetries {
+				waitTime := rateLimitErr.RetryAfter
+				if waitTime < time.Second {
+					waitTime = 30 * time.Second
+				}
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(waitTime):
+				}
+				continue
+			}
+			return nil, err
+		}
+
+		pageCount++
+
+		for _, trade := range trades {
+			// Timestamp is in Unix milliseconds
+			ts := time.Unix(0, trade.Timestamp*int64(time.Millisecond)).UTC()
+			if !since.IsZero() && ts.Before(since) {
+				continue
+			}
+
+			tradeInput, err := c.tradeToTradeInput(trade, accountIndex, accountUUID)
+			if err != nil {
+				continue // Skip trades that can't be converted
+			}
+
+			allTrades = append(allTrades, tradeInput)
+		}
+
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	// Sort by timestamp (oldest first)
+	sort.Slice(allTrades, func(i, j int) bool {
+		return allTrades[i].Timestamp.Before(allTrades[j].Timestamp)
+	})
+
+	return allTrades, nil
+}
+
+// FetchFundingPayments retrieves funding payments for an account since the given timestamp
+func (c *Client) FetchFundingPayments(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.FundingPaymentInput, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	authToken, err := c.getAuthToken(account)
+	if err != nil {
+		return nil, err
+	}
+
+	accountIndex := account.AccountIdentifier
+	if accountIndex == "" {
+		return nil, fmt.Errorf("account identifier (account_index) is required")
+	}
+
+	// Ensure market cache is loaded
+	if err := c.loadMarketCache(ctx, authToken); err != nil {
+		return nil, fmt.Errorf("failed to load market info: %w", err)
+	}
+
+	var allFunding []*models.FundingPaymentInput
+	cursor := ""
+	pageCount := 0
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		// Add delay between pagination requests to avoid rate limits
+		if pageCount > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(paginationDelay):
+			}
+		}
+
+		var fundings []lighterPositionFunding
+		var nextCursor string
+		var err error
+
+		// Retry logic for rate limits
+		for retry := 0; retry <= maxRateLimitRetries; retry++ {
+			fundings, nextCursor, err = c.fetchPositionFunding(ctx, accountIndex, authToken, cursor, since)
+			if err == nil {
+				break
+			}
+
+			// Check if it's a rate limit error
+			var rateLimitErr *iface.RateLimitError
+			if errors.As(err, &rateLimitErr) && retry < maxRateLimitRetries {
+				waitTime := rateLimitErr.RetryAfter
+				if waitTime < time.Second {
+					waitTime = 30 * time.Second
+				}
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(waitTime):
+				}
+				continue
+			}
+			return nil, err
+		}
+
+		pageCount++
+
+		for _, funding := range fundings {
+			// Timestamp is in Unix seconds
+			ts := time.Unix(funding.Timestamp, 0).UTC()
+			if !since.IsZero() && ts.Before(since) {
+				continue
+			}
+
+			payment, err := c.fundingToPayment(funding, accountUUID)
+			if err != nil {
+				continue // Skip fundings that can't be converted
+			}
+
+			allFunding = append(allFunding, payment)
+		}
+
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	// Sort by timestamp (oldest first)
+	sort.Slice(allFunding, func(i, j int) bool {
+		return allFunding[i].Timestamp.Before(allFunding[j].Timestamp)
+	})
+
+	return allFunding, nil
+}
+
+// getAuthToken extracts the auth token from account metadata
+func (c *Client) getAuthToken(account *models.ExchangeAccount) (string, error) {
+	if account.AccountTypeMetadata == nil {
+		return "", fmt.Errorf("account metadata is required for Lighter authentication")
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(account.AccountTypeMetadata, &metadata); err != nil {
+		return "", fmt.Errorf("failed to parse account metadata: %w", err)
+	}
+
+	token, ok := metadata["auth_token"].(string)
+	if !ok || token == "" {
+		return "", fmt.Errorf("auth_token not found in account metadata")
+	}
+
+	return token, nil
+}
+
+// addAuth adds the Authorization header to a request
+func (c *Client) addAuth(req *http.Request, authToken string) {
+	req.Header.Set("Authorization", authToken)
+}
+
+// fetchTrades fetches individual trades/fills from the API
+func (c *Client) fetchTrades(
+	ctx context.Context,
+	accountIndex string,
+	authToken string,
+	cursor string,
+) ([]lighterTrade, string, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/trades", c.baseURL)
+
+	params := url.Values{}
+	params.Set("account_index", accountIndex)
+	params.Set("sort_by", "timestamp")
+	params.Set("limit", "100")
+	params.Set("aggregate", "false") // Get individual fills, not aggregated
+
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+
+	reqURL := fmt.Sprintf("%s?%s", endpoint, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.addAuth(req, authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := c.handleResponseError(resp); err != nil {
+		return nil, "", err
+	}
+
+	var result lighterTradesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.Trades, result.NextCursor, nil
+}
+
+// fetchInactiveOrders fetches inactive orders (including filled) from the API
+// Note: This returns orders with aggregate fills, not individual trades
+func (c *Client) fetchInactiveOrders(
+	ctx context.Context,
+	accountIndex string,
+	authToken string,
+	cursor string,
+	since time.Time,
+) ([]lighterOrder, string, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/accountInactiveOrders", c.baseURL)
+
+	params := url.Values{}
+	params.Set("account_index", accountIndex)
+	params.Set("limit", "100")
+
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+
+	// Note: between_timestamps parameter format is unclear from API,
+	// so we filter client-side instead
+
+	reqURL := fmt.Sprintf("%s?%s", endpoint, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.addAuth(req, authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := c.handleResponseError(resp); err != nil {
+		return nil, "", err
+	}
+
+	var result lighterOrdersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.Orders, result.NextCursor, nil
+}
+
+// fetchPositionFunding fetches funding payments from the API
+func (c *Client) fetchPositionFunding(
+	ctx context.Context,
+	accountIndex string,
+	authToken string,
+	cursor string,
+	since time.Time,
+) ([]lighterPositionFunding, string, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/positionFunding", c.baseURL)
+
+	params := url.Values{}
+	params.Set("account_index", accountIndex)
+	params.Set("limit", "100")
+
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+
+	reqURL := fmt.Sprintf("%s?%s", endpoint, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.addAuth(req, authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := c.handleResponseError(resp); err != nil {
+		return nil, "", err
+	}
+
+	var result lighterFundingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.PositionFundings, result.NextCursor, nil
+}
+
+// loadMarketCache loads market information from the API
+func (c *Client) loadMarketCache(ctx context.Context, authToken string) error {
+	c.marketCache.mu.RLock()
+	if c.marketCache.loaded {
+		c.marketCache.mu.RUnlock()
+		return nil
+	}
+	c.marketCache.mu.RUnlock()
+
+	c.marketCache.mu.Lock()
+	defer c.marketCache.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if c.marketCache.loaded {
+		return nil
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/orderBookDetails", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// orderBookDetails is a public endpoint, but add auth if available
+	if authToken != "" {
+		c.addAuth(req, authToken)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch markets: status %d", resp.StatusCode)
+	}
+
+	var result lighterMarketsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Add perp markets
+	for _, m := range result.OrderBookDetails {
+		// Symbol is the base asset (e.g., "ASTER", "BTC", "ETH")
+		// All perps on Lighter are quoted in USDC
+		c.marketCache.markets[m.MarketID] = marketInfo{
+			symbol:     m.Symbol,
+			baseAsset:  m.Symbol,
+			quoteAsset: "USDC",
+		}
+	}
+
+	// Add spot markets
+	for _, m := range result.SpotOrderBookDetails {
+		// Spot market symbols are "BASE/QUOTE" (e.g., "LIT/USDC")
+		baseAsset := m.Symbol
+		quoteAsset := "USDC"
+		if parts := strings.Split(m.Symbol, "/"); len(parts) == 2 {
+			baseAsset = parts[0]
+			quoteAsset = parts[1]
+		}
+		c.marketCache.markets[m.MarketID] = marketInfo{
+			symbol:     m.Symbol,
+			baseAsset:  baseAsset,
+			quoteAsset: quoteAsset,
+		}
+	}
+
+	c.marketCache.loaded = true
+	return nil
+}
+
+// getMarketInfo returns cached market information
+func (c *Client) getMarketInfo(marketIndex int) (marketInfo, bool) {
+	c.marketCache.mu.RLock()
+	defer c.marketCache.mu.RUnlock()
+
+	info, ok := c.marketCache.markets[marketIndex]
+	return info, ok
+}
+
+// tradeToTradeInput converts a Lighter trade (from /api/v1/trades) to a TradeInput
+func (c *Client) tradeToTradeInput(trade lighterTrade, accountIndex string, accountUUID uuid.UUID) (*models.TradeInput, error) {
+	market, ok := c.getMarketInfo(trade.MarketID)
+	if !ok {
+		// Fallback: use generic naming
+		market = marketInfo{
+			baseAsset:  fmt.Sprintf("MARKET%d", trade.MarketID),
+			quoteAsset: "USDC",
+		}
+	}
+
+	// Determine side based on whether this account was the buyer or seller
+	// ask = sell side, bid = buy side
+	// If ask_account_id matches our account, we were selling
+	// If bid_account_id matches our account, we were buying
+	accountIndexInt, _ := strconv.ParseInt(accountIndex, 10, 64)
+	side := "buy"
+	orderID := fmt.Sprintf("%d", trade.BidID)
+	if trade.AskAccountID == accountIndexInt {
+		side = "sell"
+		orderID = fmt.Sprintf("%d", trade.AskID)
+	}
+
+	// Timestamp is in Unix milliseconds
+	ts := time.Unix(0, trade.Timestamp*int64(time.Millisecond)).UTC()
+
+	// Calculate fee (taker_fee is in basis points, e.g., 200 = 0.02%)
+	// Fee is applied to the USD amount
+	fee := "0"
+	if trade.TakerFee > 0 {
+		// Convert taker_fee basis points to decimal fee amount
+		// taker_fee of 200 means 0.02% fee
+		// fee = usd_amount * taker_fee / 1000000
+		if usdAmt, ok := new(big.Float).SetString(trade.USDAmount); ok {
+			feePct := new(big.Float).SetInt64(trade.TakerFee)
+			feeAmt := new(big.Float).Mul(usdAmt, feePct)
+			feeAmt = feeAmt.Quo(feeAmt, big.NewFloat(1000000))
+			fee = strings.TrimRight(strings.TrimRight(feeAmt.Text('f', 8), "0"), ".")
+		}
+	}
+
+	return &models.TradeInput{
+		ExchangeAccountID: accountUUID,
+		BaseAsset:         market.baseAsset,
+		QuoteAsset:        market.quoteAsset,
+		Side:              side,
+		Price:             trade.Price,
+		Quantity:          trade.Size,
+		Timestamp:         ts,
+		Fee:               fee,
+		OrderID:           orderID,
+		TradeID:           fmt.Sprintf("%d", trade.TradeID),
+	}, nil
+}
+
+// orderToTrade converts a Lighter order to a TradeInput
+// Note: This is kept for backwards compatibility but fetchTrades now uses tradeToTradeInput
+func (c *Client) orderToTrade(order lighterOrder, accountUUID uuid.UUID) (*models.TradeInput, error) {
+	market, ok := c.getMarketInfo(order.MarketIndex)
+	if !ok {
+		// Fallback: use generic naming
+		market = marketInfo{
+			baseAsset:  fmt.Sprintf("MARKET%d", order.MarketIndex),
+			quoteAsset: "USDC",
+		}
+	}
+
+	// Use the price field directly if available, otherwise calculate
+	price := order.Price
+	if price == "" || price == "0" {
+		price = calculatePrice(order.FilledQuoteAmount, order.FilledBaseAmount)
+	}
+
+	// Determine side: is_ask = true means sell, is_ask = false means buy
+	side := "buy"
+	if order.IsAsk {
+		side = "sell"
+	}
+
+	// Timestamp is in Unix seconds
+	ts := time.Unix(order.Timestamp, 0).UTC()
+
+	return &models.TradeInput{
+		ExchangeAccountID: accountUUID,
+		BaseAsset:         market.baseAsset,
+		QuoteAsset:        market.quoteAsset,
+		Side:              side,
+		Price:             price,
+		Quantity:          order.FilledBaseAmount,
+		Timestamp:         ts,
+		Fee:               "0", // Lighter doesn't return fee in order response
+		OrderID:           order.OrderID,
+		TradeID:           order.OrderID, // Order ID serves as trade ID for filled orders
+	}, nil
+}
+
+// fundingToPayment converts a Lighter funding to a FundingPaymentInput
+func (c *Client) fundingToPayment(funding lighterPositionFunding, accountUUID uuid.UUID) (*models.FundingPaymentInput, error) {
+	market, ok := c.getMarketInfo(funding.MarketID)
+	if !ok {
+		// Fallback
+		market = marketInfo{
+			baseAsset:  fmt.Sprintf("MARKET%d", funding.MarketID),
+			quoteAsset: "USDC",
+		}
+	}
+
+	// Timestamp is in Unix seconds
+	ts := time.Unix(funding.Timestamp, 0).UTC()
+
+	// Create unique payment ID from funding_id and market_id
+	paymentID := fmt.Sprintf("%d_%d", funding.FundingID, funding.MarketID)
+
+	return &models.FundingPaymentInput{
+		ExchangeAccountID: accountUUID,
+		BaseAsset:         market.baseAsset,
+		QuoteAsset:        market.quoteAsset,
+		Amount:            funding.Change,
+		Timestamp:         ts,
+		PaymentID:         paymentID,
+	}, nil
+}
+
+// handleResponseError checks response status and returns appropriate errors
+func (c *Client) handleResponseError(resp *http.Response) error {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusTooManyRequests:
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		return &iface.RateLimitError{
+			Exchange:   "lighter",
+			Message:    "rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	case http.StatusUnauthorized:
+		return fmt.Errorf("authentication failed: invalid or expired auth token")
+	case http.StatusForbidden:
+		return fmt.Errorf("access denied: insufficient permissions")
+	case http.StatusNotFound:
+		return fmt.Errorf("account not found")
+	default:
+		return fmt.Errorf("request failed with status %d", resp.StatusCode)
+	}
+}
+
+// parseRetryAfter parses the Retry-After header value
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 60 * time.Second // Default to 60 seconds
+	}
+
+	// Try parsing as seconds
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+
+	// Try parsing as HTTP-date
+	if t, err := time.Parse(time.RFC1123, value); err == nil {
+		return time.Until(t)
+	}
+
+	return 60 * time.Second
+}
+
+// calculatePrice divides quote amount by base amount to get price
+func calculatePrice(quoteAmount, baseAmount string) string {
+	if baseAmount == "" || baseAmount == "0" {
+		return "0"
+	}
+
+	quote := new(big.Float)
+	if _, ok := quote.SetString(quoteAmount); !ok {
+		return "0"
+	}
+
+	base := new(big.Float)
+	if _, ok := base.SetString(baseAmount); !ok {
+		return "0"
+	}
+
+	if base.Sign() == 0 {
+		return "0"
+	}
+
+	price := new(big.Float).Quo(quote, base)
+
+	// Format with enough precision
+	return strings.TrimRight(strings.TrimRight(price.Text('f', 18), "0"), ".")
+}

--- a/exchange/lighter/client_test.go
+++ b/exchange/lighter/client_test.go
@@ -1,0 +1,547 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+func TestNewClient(t *testing.T) {
+	client := NewClient()
+	assert.NotNil(t, client)
+	assert.Equal(t, defaultBaseURL, client.baseURL)
+	assert.NotNil(t, client.httpClient)
+	assert.NotNil(t, client.marketCache)
+}
+
+func TestClient_Name(t *testing.T) {
+	client := NewClient()
+	assert.Equal(t, "lighter", client.Name())
+}
+
+func TestClient_FetchTrades_Success(t *testing.T) {
+	// Setup mock server
+	marketsServed := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check auth header
+		auth := r.Header.Get("Authorization")
+		assert.Equal(t, "ro:123:all:9999999999:abc123", auth)
+
+		switch r.URL.Path {
+		case "/api/v1/orderBookDetails":
+			marketsServed = true
+			json.NewEncoder(w).Encode(lighterMarketsResponse{
+				Code: 200,
+				OrderBookDetails: []lighterMarket{
+					{MarketID: 1, Symbol: "ETH", MarketType: "perp"},
+					{MarketID: 2, Symbol: "BTC", MarketType: "perp"},
+				},
+			})
+		case "/api/v1/trades":
+			assert.True(t, marketsServed, "markets should be fetched first")
+			assert.Equal(t, "123", r.URL.Query().Get("account_index"))
+			assert.Equal(t, "timestamp", r.URL.Query().Get("sort_by"))
+			json.NewEncoder(w).Encode(lighterTradesResponse{
+				Code: 200,
+				Trades: []lighterTrade{
+					{
+						TradeID:      1001,
+						MarketID:     1,
+						Size:         "1.5",
+						Price:        "3000",
+						USDAmount:    "4500",
+						AskID:        200,
+						BidID:        100,
+						AskAccountID: 999,  // other account
+						BidAccountID: 123,  // our account is buyer
+						IsMakerAsk:   true,
+						Timestamp:    1700000000000, // Unix milliseconds
+						TakerFee:     200,           // 0.02%
+					},
+					{
+						TradeID:      1002,
+						MarketID:     2,
+						Size:         "0.1",
+						Price:        "35000",
+						USDAmount:    "3500",
+						AskID:        300,
+						BidID:        400,
+						AskAccountID: 123,  // our account is seller
+						BidAccountID: 888,
+						IsMakerAsk:   false,
+						Timestamp:    1700000100000,
+						TakerFee:     200,
+					},
+				},
+				NextCursor: "",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{
+		"auth_token": "ro:123:all:9999999999:abc123",
+		"l1_address": "0xabc123",
+	})
+
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	trades, err := client.FetchTrades(context.Background(), account, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, trades, 2)
+
+	// Verify first trade (our account was buyer)
+	assert.Equal(t, "1001", trades[0].TradeID)
+	assert.Equal(t, "ETH", trades[0].BaseAsset)
+	assert.Equal(t, "USDC", trades[0].QuoteAsset)
+	assert.Equal(t, "buy", trades[0].Side)
+	assert.Equal(t, "3000", trades[0].Price)
+	assert.Equal(t, "1.5", trades[0].Quantity)
+	assert.Equal(t, "100", trades[0].OrderID) // bid_id since we were buyer
+
+	// Verify second trade (our account was seller)
+	assert.Equal(t, "1002", trades[1].TradeID)
+	assert.Equal(t, "BTC", trades[1].BaseAsset)
+	assert.Equal(t, "sell", trades[1].Side)
+	assert.Equal(t, "35000", trades[1].Price)
+	assert.Equal(t, "300", trades[1].OrderID) // ask_id since we were seller
+}
+
+func TestClient_FetchTrades_WithPagination(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/orderBookDetails":
+			json.NewEncoder(w).Encode(lighterMarketsResponse{
+				Code:             200,
+				OrderBookDetails: []lighterMarket{{MarketID: 1, Symbol: "ETH"}},
+			})
+		case "/api/v1/trades":
+			cursor := r.URL.Query().Get("cursor")
+			if page == 0 && cursor == "" {
+				page++
+				json.NewEncoder(w).Encode(lighterTradesResponse{
+					Code:       200,
+					Trades:     []lighterTrade{{TradeID: 1001, MarketID: 1, Size: "1", Price: "3000", BidAccountID: 123, AskAccountID: 999, Timestamp: 1700000000000}},
+					NextCursor: "page2",
+				})
+			} else if cursor == "page2" {
+				json.NewEncoder(w).Encode(lighterTradesResponse{
+					Code:       200,
+					Trades:     []lighterTrade{{TradeID: 1002, MarketID: 1, Size: "2", Price: "3000", BidAccountID: 123, AskAccountID: 999, Timestamp: 1700000100000}},
+					NextCursor: "",
+				})
+			}
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	trades, err := client.FetchTrades(context.Background(), account, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, trades, 2)
+}
+
+func TestClient_FetchTrades_SinceFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/orderBookDetails":
+			json.NewEncoder(w).Encode(lighterMarketsResponse{
+				Code:             200,
+				OrderBookDetails: []lighterMarket{{MarketID: 1, Symbol: "ETH"}},
+			})
+		case "/api/v1/trades":
+			// Return trades with different timestamps (milliseconds)
+			json.NewEncoder(w).Encode(lighterTradesResponse{
+				Code: 200,
+				Trades: []lighterTrade{
+					{TradeID: 1001, MarketID: 1, Size: "1", Price: "3000", BidAccountID: 123, AskAccountID: 999, Timestamp: 1700000000000},
+					{TradeID: 1002, MarketID: 1, Size: "1", Price: "3000", BidAccountID: 123, AskAccountID: 999, Timestamp: 1700100000000},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	// Set since to filter out the old trade
+	since := time.Unix(1700050000, 0) // Between the two timestamps
+
+	trades, err := client.FetchTrades(context.Background(), account, since)
+	require.NoError(t, err)
+	assert.Len(t, trades, 1)
+	assert.Equal(t, "1002", trades[0].TradeID)
+}
+
+func TestClient_FetchTrades_RateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/orderBookDetails":
+			json.NewEncoder(w).Encode(lighterMarketsResponse{Code: 200, OrderBookDetails: []lighterMarket{}})
+		case "/api/v1/trades":
+			w.Header().Set("Retry-After", "30")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	_, err := client.FetchTrades(context.Background(), account, time.Time{})
+	require.Error(t, err)
+
+	var rateLimitErr *iface.RateLimitError
+	require.ErrorAs(t, err, &rateLimitErr)
+	assert.Equal(t, "lighter", rateLimitErr.Exchange)
+	assert.Equal(t, 30*time.Second, rateLimitErr.RetryAfter)
+}
+
+func TestClient_FetchTrades_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Delay response
+		time.Sleep(100 * time.Millisecond)
+		json.NewEncoder(w).Encode(lighterOrdersResponse{})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.FetchTrades(ctx, account, time.Time{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClient_FetchTrades_MissingAuthToken(t *testing.T) {
+	client := NewClient()
+
+	// No auth_token in metadata
+	metadata, _ := json.Marshal(map[string]interface{}{"l1_address": "0xabc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	_, err := client.FetchTrades(context.Background(), account, time.Time{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth_token not found")
+}
+
+func TestClient_FetchTrades_AuthError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/orderBookDetails":
+			json.NewEncoder(w).Encode(lighterMarketsResponse{Code: 200, OrderBookDetails: []lighterMarket{}})
+		case "/api/v1/trades":
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	_, err := client.FetchTrades(context.Background(), account, time.Time{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+func TestClient_FetchFundingPayments_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/orderBookDetails":
+			json.NewEncoder(w).Encode(lighterMarketsResponse{
+				Code:             200,
+				OrderBookDetails: []lighterMarket{{MarketID: 1, Symbol: "ETH"}},
+			})
+		case "/api/v1/positionFunding":
+			assert.Equal(t, "123", r.URL.Query().Get("account_index"))
+			json.NewEncoder(w).Encode(lighterFundingResponse{
+				Code: 200,
+				PositionFundings: []lighterPositionFunding{
+					{
+						FundingID:    1001,
+						MarketID:     1,
+						Change:       "0.5",
+						Timestamp:    1700000000,
+						PositionSide: "long",
+					},
+					{
+						FundingID:    1002,
+						MarketID:     1,
+						Change:       "-0.25",
+						Timestamp:    1700000100,
+						PositionSide: "short",
+					},
+				},
+				NextCursor: "",
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	payments, err := client.FetchFundingPayments(context.Background(), account, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, payments, 2)
+
+	// Verify first payment (positive - received)
+	assert.Equal(t, "1001_1", payments[0].PaymentID)
+	assert.Equal(t, "ETH", payments[0].BaseAsset)
+	assert.Equal(t, "USDC", payments[0].QuoteAsset)
+	assert.Equal(t, "0.5", payments[0].Amount)
+
+	// Verify second payment (negative - paid)
+	assert.Equal(t, "-0.25", payments[1].Amount)
+}
+
+func TestClient_FetchFundingPayments_WithPagination(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/orderBookDetails":
+			json.NewEncoder(w).Encode(lighterMarketsResponse{
+				Code:             200,
+				OrderBookDetails: []lighterMarket{{MarketID: 1, Symbol: "ETH"}},
+			})
+		case "/api/v1/positionFunding":
+			cursor := r.URL.Query().Get("cursor")
+			if page == 0 && cursor == "" {
+				page++
+				json.NewEncoder(w).Encode(lighterFundingResponse{
+					Code:             200,
+					PositionFundings: []lighterPositionFunding{{FundingID: 1, MarketID: 1, Change: "1", Timestamp: 1700000000}},
+					NextCursor:       "page2",
+				})
+			} else if cursor == "page2" {
+				json.NewEncoder(w).Encode(lighterFundingResponse{
+					Code:             200,
+					PositionFundings: []lighterPositionFunding{{FundingID: 2, MarketID: 1, Change: "2", Timestamp: 1700000100}},
+					NextCursor:       "",
+				})
+			}
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	payments, err := client.FetchFundingPayments(context.Background(), account, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, payments, 2)
+}
+
+func TestCalculatePrice(t *testing.T) {
+	tests := []struct {
+		name        string
+		quoteAmount string
+		baseAmount  string
+		expected    string
+	}{
+		{"normal price", "4500", "1.5", "3000"},
+		{"exact division", "1000", "2", "500"},
+		{"zero base", "1000", "0", "0"},
+		{"empty base", "1000", "", "0"},
+		{"zero quote", "0", "1", "0"},
+		{"whole number result", "3000", "1.5", "2000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculatePrice(tt.quoteAmount, tt.baseAmount)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculatePriceFractional(t *testing.T) {
+	// Test fractional division - check prefix since floating point may vary
+	result := calculatePrice("1000", "3")
+	assert.True(t, len(result) > 10, "Should have significant precision")
+	assert.Contains(t, result, "333.333", "Should start with correct fractional value")
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected time.Duration
+	}{
+		{"seconds", "30", 30 * time.Second},
+		{"empty", "", 60 * time.Second},
+		{"invalid", "abc", 60 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseRetryAfter(tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClient_MarketCacheLoading(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/orderBookDetails" {
+			callCount++
+			json.NewEncoder(w).Encode(lighterMarketsResponse{
+				Code:             200,
+				OrderBookDetails: []lighterMarket{{MarketID: 1, Symbol: "ETH"}},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(lighterOrdersResponse{Code: 200})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	metadata, _ := json.Marshal(map[string]interface{}{"auth_token": "ro:123:all:9999999999:abc"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "123",
+		AccountTypeMetadata: metadata,
+	}
+
+	// First call should load market cache
+	_, _ = client.FetchTrades(context.Background(), account, time.Time{})
+	assert.Equal(t, 1, callCount)
+
+	// Second call should use cached data
+	_, _ = client.FetchTrades(context.Background(), account, time.Time{})
+	assert.Equal(t, 1, callCount) // Should not increment
+}
+
+func TestClient_GetAuthToken(t *testing.T) {
+	client := NewClient()
+
+	tests := []struct {
+		name        string
+		metadata    json.RawMessage
+		expectError bool
+		expected    string
+	}{
+		{
+			name:        "valid token",
+			metadata:    json.RawMessage(`{"auth_token": "ro:123:all:999:abc", "l1_address": "0x123"}`),
+			expectError: false,
+			expected:    "ro:123:all:999:abc",
+		},
+		{
+			name:        "missing token",
+			metadata:    json.RawMessage(`{"l1_address": "0x123"}`),
+			expectError: true,
+		},
+		{
+			name:        "empty token",
+			metadata:    json.RawMessage(`{"auth_token": "", "l1_address": "0x123"}`),
+			expectError: true,
+		},
+		{
+			name:        "nil metadata",
+			metadata:    nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid json",
+			metadata:    json.RawMessage(`{invalid}`),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account := &models.ExchangeAccount{
+				AccountTypeMetadata: tt.metadata,
+			}
+			token, err := client.getAuthToken(account)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, token)
+			}
+		})
+	}
+}

--- a/exchange/lighter/discovery.go
+++ b/exchange/lighter/discovery.go
@@ -1,0 +1,110 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// DiscoverAccounts discovers all accounts associated with a user identifier.
+// For Lighter, the userIdentifier format is: "{l1_address}:{auth_token}"
+// where auth_token follows the format: "ro:{account_index}:{single|all}:{expiry_unix}:{random_hex}"
+func (c *Client) DiscoverAccounts(
+	ctx context.Context,
+	userIdentifier string,
+) ([]*models.DiscoverableAccount, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Parse userIdentifier: "0x...l1_address:ro:account_index:..."
+	// Split on first colon to get l1_address, everything after is the auth token
+	parts := strings.SplitN(userIdentifier, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid userIdentifier format: expected '{l1_address}:{auth_token}'")
+	}
+
+	l1Address := parts[0]
+	authToken := parts[1]
+
+	if l1Address == "" {
+		return nil, fmt.Errorf("l1_address is required")
+	}
+
+	if !strings.HasPrefix(authToken, "ro:") {
+		return nil, fmt.Errorf("invalid auth token format: must start with 'ro:'")
+	}
+
+	// Call API to discover accounts
+	accounts, err := c.fetchAccountsByL1Address(ctx, l1Address, authToken)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*models.DiscoverableAccount, 0, len(accounts))
+
+	for _, acc := range accounts {
+		// AccountType: 0 = main account, 1 = sub-account
+		accountType := "sub_account"
+		name := fmt.Sprintf("Sub-Account %d", acc.Index)
+		if acc.AccountType == 0 {
+			accountType = "main"
+			name = "Main Account"
+		}
+
+		result = append(result, &models.DiscoverableAccount{
+			AccountIdentifier: strconv.Itoa(acc.Index),
+			AccountType:       accountType,
+			Name:              name,
+			Metadata: map[string]interface{}{
+				"l1_address": l1Address,
+				"auth_token": authToken,
+			},
+		})
+	}
+
+	return result, nil
+}
+
+// fetchAccountsByL1Address fetches accounts from the API
+func (c *Client) fetchAccountsByL1Address(
+	ctx context.Context,
+	l1Address string,
+	authToken string,
+) ([]lighterAccount, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/accountsByL1Address", c.baseURL)
+
+	params := url.Values{}
+	params.Set("l1_address", l1Address)
+
+	reqURL := fmt.Sprintf("%s?%s", endpoint, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.addAuth(req, authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := c.handleResponseError(resp); err != nil {
+		return nil, err
+	}
+
+	var result lighterAccountsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.SubAccounts, nil
+}

--- a/exchange/lighter/discovery_test.go
+++ b/exchange/lighter/discovery_test.go
@@ -1,0 +1,228 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_DiscoverAccounts_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		assert.Equal(t, "/api/v1/accountsByL1Address", r.URL.Path)
+		assert.Equal(t, "0xabc123def456", r.URL.Query().Get("l1_address"))
+		assert.Equal(t, "ro:0:all:9999999999:abc123", r.Header.Get("Authorization"))
+
+		json.NewEncoder(w).Encode(lighterAccountsResponse{
+			Code:      200,
+			L1Address: "0xabc123def456",
+			SubAccounts: []lighterAccount{
+				{
+					Index:       0,
+					L1Address:   "0xabc123def456",
+					AccountType: 0, // main
+					Collateral:  "100.5",
+				},
+				{
+					Index:       1,
+					L1Address:   "0xabc123def456",
+					AccountType: 1, // sub
+					Collateral:  "50.0",
+				},
+				{
+					Index:       2,
+					L1Address:   "0xabc123def456",
+					AccountType: 1, // sub
+					Collateral:  "25.0",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	userIdentifier := "0xabc123def456:ro:0:all:9999999999:abc123"
+	accounts, err := client.DiscoverAccounts(context.Background(), userIdentifier)
+	require.NoError(t, err)
+	assert.Len(t, accounts, 3)
+
+	// Verify main account
+	assert.Equal(t, "0", accounts[0].AccountIdentifier)
+	assert.Equal(t, "main", accounts[0].AccountType)
+	assert.Equal(t, "Main Account", accounts[0].Name)
+	assert.Equal(t, "0xabc123def456", accounts[0].Metadata["l1_address"])
+	assert.Equal(t, "ro:0:all:9999999999:abc123", accounts[0].Metadata["auth_token"])
+
+	// Verify first sub-account
+	assert.Equal(t, "1", accounts[1].AccountIdentifier)
+	assert.Equal(t, "sub_account", accounts[1].AccountType)
+	assert.Equal(t, "Sub-Account 1", accounts[1].Name)
+
+	// Verify second sub-account
+	assert.Equal(t, "2", accounts[2].AccountIdentifier)
+	assert.Equal(t, "sub_account", accounts[2].AccountType)
+	assert.Equal(t, "Sub-Account 2", accounts[2].Name)
+}
+
+func TestClient_DiscoverAccounts_SingleAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(lighterAccountsResponse{
+			Code:      200,
+			L1Address: "0xtest",
+			SubAccounts: []lighterAccount{
+				{
+					Index:       156333,
+					L1Address:   "0xtest",
+					AccountType: 0, // main
+					Collateral:  "0.009136",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	accounts, err := client.DiscoverAccounts(context.Background(), "0xtest:ro:0:single:9999999999:xyz")
+	require.NoError(t, err)
+	assert.Len(t, accounts, 1)
+	assert.Equal(t, "156333", accounts[0].AccountIdentifier)
+	assert.Equal(t, "main", accounts[0].AccountType)
+	assert.Equal(t, "Main Account", accounts[0].Name)
+}
+
+func TestClient_DiscoverAccounts_InvalidUserIdentifier(t *testing.T) {
+	client := NewClient()
+
+	tests := []struct {
+		name           string
+		userIdentifier string
+		expectedError  string
+	}{
+		{
+			name:           "no colon separator",
+			userIdentifier: "0xabc123",
+			expectedError:  "invalid userIdentifier format",
+		},
+		{
+			name:           "empty l1 address",
+			userIdentifier: ":ro:0:all:999:abc",
+			expectedError:  "l1_address is required",
+		},
+		{
+			name:           "invalid auth token format",
+			userIdentifier: "0xabc:invalid_token",
+			expectedError:  "invalid auth token format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.DiscoverAccounts(context.Background(), tt.userIdentifier)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+func TestClient_DiscoverAccounts_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		json.NewEncoder(w).Encode(lighterAccountsResponse{})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.DiscoverAccounts(ctx, "0xtest:ro:0:all:999:abc")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClient_DiscoverAccounts_AuthError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	_, err := client.DiscoverAccounts(context.Background(), "0xtest:ro:0:all:999:abc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+func TestClient_DiscoverAccounts_RateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	_, err := client.DiscoverAccounts(context.Background(), "0xtest:ro:0:all:999:abc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limit exceeded")
+}
+
+func TestClient_DiscoverAccounts_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(lighterAccountsResponse{
+			Code:        200,
+			L1Address:   "0xtest",
+			SubAccounts: []lighterAccount{},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	accounts, err := client.DiscoverAccounts(context.Background(), "0xtest:ro:0:all:999:abc")
+	require.NoError(t, err)
+	assert.Len(t, accounts, 0)
+}
+
+func TestClient_DiscoverAccounts_MetadataPreserved(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(lighterAccountsResponse{
+			Code:      200,
+			L1Address: "0xmyaddr",
+			SubAccounts: []lighterAccount{
+				{Index: 5, L1Address: "0xmyaddr", AccountType: 1, Collateral: "10"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.baseURL = server.URL
+
+	l1Addr := "0xmyaddr"
+	authToken := "ro:5:single:1234567890:deadbeef"
+	userIdentifier := l1Addr + ":" + authToken
+
+	accounts, err := client.DiscoverAccounts(context.Background(), userIdentifier)
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+
+	// Verify metadata is correctly set
+	assert.Equal(t, l1Addr, accounts[0].Metadata["l1_address"])
+	assert.Equal(t, authToken, accounts[0].Metadata["auth_token"])
+}

--- a/exchange/lighter/integration_test.go
+++ b/exchange/lighter/integration_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/models"
+)
+
+// Run with: go test -tags=integration -v ./exchange/lighter/...
+
+func getTestCredentials() (l1Address, authToken string, ok bool) {
+	l1Address = os.Getenv("LIGHTER_L1_ADDRESS")
+	authToken = os.Getenv("LIGHTER_AUTH_TOKEN")
+	if l1Address == "" || authToken == "" {
+		return "", "", false
+	}
+	return l1Address, authToken, true
+}
+
+func TestIntegration_DiscoverAccounts(t *testing.T) {
+	l1Address, authToken, ok := getTestCredentials()
+	if !ok {
+		t.Skip("LIGHTER_L1_ADDRESS and LIGHTER_AUTH_TOKEN not set")
+	}
+
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	userIdentifier := l1Address + ":" + authToken
+	accounts, err := client.DiscoverAccounts(ctx, userIdentifier)
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	fmt.Printf("\n=== Discovered Accounts ===\n")
+	fmt.Printf("Found %d account(s)\n\n", len(accounts))
+
+	for i, acc := range accounts {
+		fmt.Printf("Account %d:\n", i+1)
+		fmt.Printf("  Identifier: %s\n", acc.AccountIdentifier)
+		fmt.Printf("  Type: %s\n", acc.AccountType)
+		fmt.Printf("  Name: %s\n", acc.Name)
+		fmt.Printf("  Metadata: %+v\n\n", acc.Metadata)
+	}
+
+	if len(accounts) == 0 {
+		t.Error("Expected at least one account")
+	}
+}
+
+func TestIntegration_FetchTrades(t *testing.T) {
+	l1Address, authToken, ok := getTestCredentials()
+	if !ok {
+		t.Skip("LIGHTER_L1_ADDRESS and LIGHTER_AUTH_TOKEN not set")
+	}
+
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Extract account_index from token (format: ro:account_index:...)
+	// For this test, we'll use the discovered accounts
+	userIdentifier := l1Address + ":" + authToken
+	accounts, err := client.DiscoverAccounts(ctx, userIdentifier)
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	if len(accounts) == 0 {
+		t.Skip("No accounts discovered")
+	}
+
+	// Test FetchTrades for the first account
+	acc := accounts[0]
+	metadata, _ := json.Marshal(map[string]interface{}{
+		"auth_token": authToken,
+		"l1_address": l1Address,
+	})
+
+	exchangeAccount := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   acc.AccountIdentifier,
+		AccountTypeMetadata: metadata,
+	}
+
+	// Fetch trades from the last 30 days
+	since := time.Now().AddDate(0, 0, -30)
+	trades, err := client.FetchTrades(ctx, exchangeAccount, since)
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	fmt.Printf("\n=== Trades (last 30 days) ===\n")
+	fmt.Printf("Found %d trade(s) for account %s\n\n", len(trades), acc.AccountIdentifier)
+
+	for i, trade := range trades {
+		if i >= 10 {
+			fmt.Printf("... and %d more trades\n", len(trades)-10)
+			break
+		}
+		fmt.Printf("Trade %d:\n", i+1)
+		fmt.Printf("  ID: %s\n", trade.TradeID)
+		fmt.Printf("  Pair: %s/%s\n", trade.BaseAsset, trade.QuoteAsset)
+		fmt.Printf("  Side: %s\n", trade.Side)
+		fmt.Printf("  Price: %s\n", trade.Price)
+		fmt.Printf("  Quantity: %s\n", trade.Quantity)
+		fmt.Printf("  Fee: %s\n", trade.Fee)
+		fmt.Printf("  Time: %s\n\n", trade.Timestamp.Format(time.RFC3339))
+	}
+}
+
+func TestIntegration_FetchFundingPayments(t *testing.T) {
+	l1Address, authToken, ok := getTestCredentials()
+	if !ok {
+		t.Skip("LIGHTER_L1_ADDRESS and LIGHTER_AUTH_TOKEN not set")
+	}
+
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	userIdentifier := l1Address + ":" + authToken
+	accounts, err := client.DiscoverAccounts(ctx, userIdentifier)
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	if len(accounts) == 0 {
+		t.Skip("No accounts discovered")
+	}
+
+	acc := accounts[0]
+	metadata, _ := json.Marshal(map[string]interface{}{
+		"auth_token": authToken,
+		"l1_address": l1Address,
+	})
+
+	exchangeAccount := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   acc.AccountIdentifier,
+		AccountTypeMetadata: metadata,
+	}
+
+	// Fetch funding payments from the last 30 days
+	since := time.Now().AddDate(0, 0, -30)
+	payments, err := client.FetchFundingPayments(ctx, exchangeAccount, since)
+	if err != nil {
+		t.Fatalf("FetchFundingPayments failed: %v", err)
+	}
+
+	fmt.Printf("\n=== Funding Payments (last 30 days) ===\n")
+	fmt.Printf("Found %d payment(s) for account %s\n\n", len(payments), acc.AccountIdentifier)
+
+	for i, payment := range payments {
+		if i >= 10 {
+			fmt.Printf("... and %d more payments\n", len(payments)-10)
+			break
+		}
+		fmt.Printf("Payment %d:\n", i+1)
+		fmt.Printf("  ID: %s\n", payment.PaymentID)
+		fmt.Printf("  Pair: %s/%s\n", payment.BaseAsset, payment.QuoteAsset)
+		fmt.Printf("  Amount: %s\n", payment.Amount)
+		fmt.Printf("  Time: %s\n\n", payment.Timestamp.Format(time.RFC3339))
+	}
+}
+
+func TestIntegration_FetchAllTrades(t *testing.T) {
+	l1Address, authToken, ok := getTestCredentials()
+	if !ok {
+		t.Skip("LIGHTER_L1_ADDRESS and LIGHTER_AUTH_TOKEN not set")
+	}
+
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	userIdentifier := l1Address + ":" + authToken
+	accounts, err := client.DiscoverAccounts(ctx, userIdentifier)
+	if err != nil {
+		t.Fatalf("DiscoverAccounts failed: %v", err)
+	}
+
+	if len(accounts) == 0 {
+		t.Skip("No accounts discovered")
+	}
+
+	acc := accounts[0]
+	metadata, _ := json.Marshal(map[string]interface{}{
+		"auth_token": authToken,
+		"l1_address": l1Address,
+	})
+
+	exchangeAccount := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   acc.AccountIdentifier,
+		AccountTypeMetadata: metadata,
+	}
+
+	// Fetch ALL trades (no since filter)
+	trades, err := client.FetchTrades(ctx, exchangeAccount, time.Time{})
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	fmt.Printf("\n=== All Trades ===\n")
+	fmt.Printf("Found %d total trade(s) for account %s\n", len(trades), acc.AccountIdentifier)
+
+	if len(trades) > 0 {
+		fmt.Printf("Oldest: %s\n", trades[0].Timestamp.Format(time.RFC3339))
+		fmt.Printf("Newest: %s\n", trades[len(trades)-1].Timestamp.Format(time.RFC3339))
+	}
+}

--- a/exchange/lighter/types.go
+++ b/exchange/lighter/types.go
@@ -1,0 +1,98 @@
+package lighter
+
+// lighterAccountsResponse wraps the response from /api/v1/accountsByL1Address
+type lighterAccountsResponse struct {
+	Code        int              `json:"code"`
+	L1Address   string           `json:"l1_address"`
+	SubAccounts []lighterAccount `json:"sub_accounts"`
+}
+
+// lighterAccount represents account data from the API
+type lighterAccount struct {
+	Index       int    `json:"index"`
+	L1Address   string `json:"l1_address"`
+	AccountType int    `json:"account_type"` // 0 = main, 1 = sub
+	Collateral  string `json:"collateral"`
+}
+
+// lighterOrdersResponse wraps the response from /api/v1/accountInactiveOrders
+type lighterOrdersResponse struct {
+	Code       int            `json:"code"`
+	Orders     []lighterOrder `json:"orders"`
+	NextCursor string         `json:"next_cursor"`
+}
+
+// lighterOrder represents an order/trade from accountInactiveOrders
+// Filled orders are treated as trades
+type lighterOrder struct {
+	OrderID           string `json:"order_id"`
+	OwnerAccountIndex int    `json:"owner_account_index"`
+	MarketIndex       int    `json:"market_index"`
+	IsAsk             bool   `json:"is_ask"`
+	Price             string `json:"price"`
+	FilledBaseAmount  string `json:"filled_base_amount"`
+	FilledQuoteAmount string `json:"filled_quote_amount"`
+	Timestamp         int64  `json:"timestamp"` // Unix seconds
+	Status            string `json:"status"`
+	Type              string `json:"type"`
+	Side              string `json:"side"`
+}
+
+// lighterTradesResponse wraps the response from /api/v1/trades
+type lighterTradesResponse struct {
+	Code       int            `json:"code"`
+	Trades     []lighterTrade `json:"trades"`
+	NextCursor string         `json:"next_cursor"`
+}
+
+// lighterTrade represents an individual trade/fill from /api/v1/trades
+type lighterTrade struct {
+	TradeID      int64  `json:"trade_id"`
+	TxHash       string `json:"tx_hash"`
+	Type         string `json:"type"` // "trade" or "liquidation"
+	MarketID     int    `json:"market_id"`
+	Size         string `json:"size"`
+	Price        string `json:"price"`
+	USDAmount    string `json:"usd_amount"`
+	AskID        int64  `json:"ask_id"`
+	BidID        int64  `json:"bid_id"`
+	AskAccountID int64  `json:"ask_account_id"`
+	BidAccountID int64  `json:"bid_account_id"`
+	IsMakerAsk   bool   `json:"is_maker_ask"`
+	BlockHeight  int64  `json:"block_height"`
+	Timestamp    int64  `json:"timestamp"` // Unix milliseconds
+	TakerFee     int64  `json:"taker_fee"`
+}
+
+// lighterFundingResponse wraps the response from /api/v1/positionFunding
+type lighterFundingResponse struct {
+	Code             int                      `json:"code"`
+	PositionFundings []lighterPositionFunding `json:"position_fundings"`
+	NextCursor       string                   `json:"next_cursor"`
+}
+
+// lighterPositionFunding represents a funding payment
+type lighterPositionFunding struct {
+	FundingID    int    `json:"funding_id"`
+	MarketID     int    `json:"market_id"`
+	Change       string `json:"change"`
+	Rate         string `json:"rate"`
+	PositionSize string `json:"position_size"`
+	PositionSide string `json:"position_side"`
+	Timestamp    int64  `json:"timestamp"` // Unix seconds
+}
+
+// lighterMarketsResponse wraps the response from /api/v1/orderBookDetails
+type lighterMarketsResponse struct {
+	Code                 int             `json:"code"`
+	OrderBookDetails     []lighterMarket `json:"order_book_details"`
+	SpotOrderBookDetails []lighterMarket `json:"spot_order_book_details"`
+}
+
+// lighterMarket represents market info for symbol resolution
+type lighterMarket struct {
+	MarketID   int    `json:"market_id"`
+	Symbol     string `json:"symbol"`
+	MarketType string `json:"market_type"` // "perp" or "spot"
+	Status     string `json:"status"`
+}


### PR DESCRIPTION
Implement ExchangeClient interface for Lighter.xyz decentralized exchange:

- FetchTrades: Uses /api/v1/trades endpoint for individual fills (not aggregated orders)
- FetchFundingPayments: Uses /api/v1/positionFunding endpoint
- DiscoverAccounts: Uses /api/v1/accountsByL1Address with auth token

Key features:
- Authentication via read-only auth tokens stored in account metadata
- Rate limit handling with automatic retry and 1.5s delay between pagination requests
- Market cache for symbol resolution (perp + spot markets)
- Proper timestamp handling (milliseconds from API)
- Cursor-based pagination for all endpoints

Auth token format: ro:{account_index}:{single|all}:{expiry_unix}:{random_hex}
User identifier format for discovery: {l1_address}:{auth_token}