### PR TITLE
Add spot market support with market_type field

### DIFF
--- a/db/trade.go
+++ b/db/trade.go
@@ -33,6 +33,7 @@ func (c *Client) GetTrade(ctx context.Context, id string) (*Trade, error) {
 				order_id
 				trade_id
 				exchange_account_id
+				market_type
 			}
 		}
 	`
@@ -61,16 +62,18 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 	var query string
 	var vars map[string]interface{}
 
-	// Build query based on whether we're filtering by account IDs
-	if len(filter.ExchangeAccountIDs) > 0 {
-		// Filter by specific account IDs
+	// Build query based on filter options
+	hasAccountFilter := len(filter.ExchangeAccountIDs) > 0
+	hasMarketTypeFilter := len(filter.MarketTypes) > 0
+
+	if hasAccountFilter && hasMarketTypeFilter {
+		// Filter by both account IDs and market types
 		query = `
-			query ListTrades($exchange_account_ids: [uuid!]!) {
+			query ListTrades($exchange_account_ids: [uuid!]!, $market_types: [String!]!) {
 				trades(
 					where: {
-						exchange_account_id: {
-							_in: $exchange_account_ids
-						}
+						exchange_account_id: { _in: $exchange_account_ids }
+						market_type: { _in: $market_types }
 					}
 					order_by: { timestamp: desc }
 				) {
@@ -85,16 +88,77 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					order_id
 					trade_id
 					exchange_account_id
+					market_type
 				}
 			}
 		`
-		// Convert UUIDs to strings for GraphQL
 		accountIDs := make([]string, len(filter.ExchangeAccountIDs))
 		for i, id := range filter.ExchangeAccountIDs {
 			accountIDs[i] = id.String()
 		}
 		vars = map[string]interface{}{
 			"exchange_account_ids": accountIDs,
+			"market_types":         filter.MarketTypes,
+		}
+	} else if hasAccountFilter {
+		// Filter by account IDs only
+		query = `
+			query ListTrades($exchange_account_ids: [uuid!]!) {
+				trades(
+					where: {
+						exchange_account_id: { _in: $exchange_account_ids }
+					}
+					order_by: { timestamp: desc }
+				) {
+					id
+					base_asset
+					quote_asset
+					side
+					price
+					quantity
+					timestamp
+					fee
+					order_id
+					trade_id
+					exchange_account_id
+					market_type
+				}
+			}
+		`
+		accountIDs := make([]string, len(filter.ExchangeAccountIDs))
+		for i, id := range filter.ExchangeAccountIDs {
+			accountIDs[i] = id.String()
+		}
+		vars = map[string]interface{}{
+			"exchange_account_ids": accountIDs,
+		}
+	} else if hasMarketTypeFilter {
+		// Filter by market types only
+		query = `
+			query ListTrades($market_types: [String!]!) {
+				trades(
+					where: {
+						market_type: { _in: $market_types }
+					}
+					order_by: { timestamp: desc }
+				) {
+					id
+					base_asset
+					quote_asset
+					side
+					price
+					quantity
+					timestamp
+					fee
+					order_id
+					trade_id
+					exchange_account_id
+					market_type
+				}
+			}
+		`
+		vars = map[string]interface{}{
+			"market_types": filter.MarketTypes,
 		}
 	} else {
 		// No filter - get all trades
@@ -114,6 +178,7 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					order_id
 					trade_id
 					exchange_account_id
+					market_type
 				}
 			}
 		`
@@ -147,6 +212,7 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 			$order_id: String!
 			$trade_id: String!
 			$exchange_account_id: uuid!
+			$market_type: String!
 		) {
 			insert_trades_one(object: {
 				base_asset: $base_asset
@@ -159,6 +225,7 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 				order_id: $order_id
 				trade_id: $trade_id
 				exchange_account_id: $exchange_account_id
+				market_type: $market_type
 			}) {
 				id
 				base_asset
@@ -171,21 +238,29 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 				order_id
 				trade_id
 				exchange_account_id
+				market_type
 			}
 		}
 	`
 
+	// Default to "perp" if market_type is not specified
+	marketType := input.MarketType
+	if marketType == "" {
+		marketType = "perp"
+	}
+
 	vars := map[string]interface{}{
-		"base_asset":         input.BaseAsset,
-		"quote_asset":        input.QuoteAsset,
-		"side":               input.Side,
-		"price":              input.Price,
-		"quantity":           input.Quantity,
-		"timestamp":          input.Timestamp.UnixMilli(),
-		"fee":                input.Fee,
-		"order_id":           input.OrderID,
-		"trade_id":           input.TradeID,
+		"base_asset":          input.BaseAsset,
+		"quote_asset":         input.QuoteAsset,
+		"side":                input.Side,
+		"price":               input.Price,
+		"quantity":            input.Quantity,
+		"timestamp":           input.Timestamp.UnixMilli(),
+		"fee":                 input.Fee,
+		"order_id":            input.OrderID,
+		"trade_id":            input.TradeID,
 		"exchange_account_id": input.ExchangeAccountID.String(),
+		"market_type":         marketType,
 	}
 
 	req := c.graphqlRequestWithVars(query, vars)
@@ -220,6 +295,7 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 			$order_id: String!
 			$trade_id: String!
 			$exchange_account_id: uuid!
+			$market_type: String!
 		) {
 			update_trades_by_pk(
 				pk_columns: { id: $id }
@@ -234,6 +310,7 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 					order_id: $order_id
 					trade_id: $trade_id
 					exchange_account_id: $exchange_account_id
+					market_type: $market_type
 				}
 			) {
 				id
@@ -247,22 +324,30 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 				order_id
 				trade_id
 				exchange_account_id
+				market_type
 			}
 		}
 	`
 
+	// Default to "perp" if market_type is not specified
+	marketType := input.MarketType
+	if marketType == "" {
+		marketType = "perp"
+	}
+
 	vars := map[string]interface{}{
-		"id":                 id,
-		"base_asset":         input.BaseAsset,
-		"quote_asset":        input.QuoteAsset,
-		"side":               input.Side,
-		"price":              input.Price,
-		"quantity":           input.Quantity,
-		"timestamp":          input.Timestamp.UnixMilli(),
-		"fee":                input.Fee,
-		"order_id":           input.OrderID,
-		"trade_id":           input.TradeID,
+		"id":                  id,
+		"base_asset":          input.BaseAsset,
+		"quote_asset":         input.QuoteAsset,
+		"side":                input.Side,
+		"price":               input.Price,
+		"quantity":            input.Quantity,
+		"timestamp":           input.Timestamp.UnixMilli(),
+		"fee":                 input.Fee,
+		"order_id":            input.OrderID,
+		"trade_id":            input.TradeID,
 		"exchange_account_id": input.ExchangeAccountID.String(),
+		"market_type":         marketType,
 	}
 
 	req := c.graphqlRequestWithVars(query, vars)
@@ -341,6 +426,7 @@ func (c *Client) LatestTrade(ctx context.Context, exchangeAccountIDs []uuid.UUID
 				order_id
 				trade_id
 				exchange_account_id
+				market_type
 			}
 		}
 	`

--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -314,6 +314,12 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 	// Convert timestamp (Drift uses seconds, not milliseconds)
 	timestamp := time.Unix(record.Ts, 0).UTC()
 
+	// Extract market type from API response, default to "perp" if empty
+	marketType := strings.ToLower(record.MarketType)
+	if marketType == "" {
+		marketType = "perp"
+	}
+
 	return &models.TradeInput{
 		TradeID:           record.FillRecordID,
 		OrderID:           orderID,
@@ -325,6 +331,7 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 		Fee:               fee,
 		Timestamp:         timestamp,
 		ExchangeAccountID: accountUUID,
+		MarketType:        marketType,
 	}, nil
 }
 

--- a/exchange/hyperliquid/client.go
+++ b/exchange/hyperliquid/client.go
@@ -235,16 +235,17 @@ func transformFill(apiFill hyperliquidFill, accountUUID uuid.UUID) (*models.Trad
 	}
 
 	return &models.TradeInput{
-		TradeID:          tradeID,      // Use fill ID (tid) as trade ID - unique per fill
-		OrderID:          orderID,      // Order ID (converted to string)
-		BaseAsset:        baseAsset,
-		QuoteAsset:       quoteAsset,
-		Side:             side,
-		Price:            price,
-		Quantity:         quantity,
-		Fee:              fee,
-		Timestamp:        timestamp,
+		TradeID:           tradeID,   // Use fill ID (tid) as trade ID - unique per fill
+		OrderID:           orderID,   // Order ID (converted to string)
+		BaseAsset:         baseAsset,
+		QuoteAsset:        quoteAsset,
+		Side:              side,
+		Price:             price,
+		Quantity:          quantity,
+		Fee:               fee,
+		Timestamp:         timestamp,
 		ExchangeAccountID: accountUUID,
+		MarketType:        detectMarketType(apiFill.Coin),
 	}, nil
 }
 
@@ -303,6 +304,22 @@ func parseAssetPair(coin string) (baseAsset, quoteAsset string) {
 	}
 	// If no separator, assume USDC as quote (common for Hyperliquid)
 	return parts[0], "USDC"
+}
+
+// detectMarketType detects whether a Hyperliquid trade is spot or perp based on coin format
+// Spot trades use "@{index}" format (e.g., "@107") or "TOKEN/USDC" format (e.g., "PURR/USDC")
+// Perp trades use simple names (e.g., "BTC", "ETH") or HIP-3 prefix format (e.g., "xyz:XYZ100")
+func detectMarketType(coin string) string {
+	// Spot: "@{index}" format
+	if strings.HasPrefix(coin, "@") {
+		return "spot"
+	}
+	// Spot: "TOKEN/USDC" pair format
+	if strings.Contains(coin, "/") {
+		return "spot"
+	}
+	// Everything else is perp (including HIP-3 "xyz:" prefix)
+	return "perp"
 }
 
 // convertToString converts numeric values to string for precision

--- a/exchange/lighter/client.go
+++ b/exchange/lighter/client.go
@@ -33,6 +33,7 @@ type marketInfo struct {
 	symbol     string
 	baseAsset  string
 	quoteAsset string
+	marketType string // "perp" or "spot"
 }
 
 // marketCache provides thread-safe caching of market information
@@ -491,6 +492,7 @@ func (c *Client) loadMarketCache(ctx context.Context, authToken string) error {
 			symbol:     m.Symbol,
 			baseAsset:  m.Symbol,
 			quoteAsset: "USDC",
+			marketType: "perp",
 		}
 	}
 
@@ -507,6 +509,7 @@ func (c *Client) loadMarketCache(ctx context.Context, authToken string) error {
 			symbol:     m.Symbol,
 			baseAsset:  baseAsset,
 			quoteAsset: quoteAsset,
+			marketType: "spot",
 		}
 	}
 
@@ -527,10 +530,11 @@ func (c *Client) getMarketInfo(marketIndex int) (marketInfo, bool) {
 func (c *Client) tradeToTradeInput(trade lighterTrade, accountIndex string, accountUUID uuid.UUID) (*models.TradeInput, error) {
 	market, ok := c.getMarketInfo(trade.MarketID)
 	if !ok {
-		// Fallback: use generic naming
+		// Fallback: use generic naming and default to perp
 		market = marketInfo{
 			baseAsset:  fmt.Sprintf("MARKET%d", trade.MarketID),
 			quoteAsset: "USDC",
+			marketType: "perp",
 		}
 	}
 
@@ -575,6 +579,7 @@ func (c *Client) tradeToTradeInput(trade lighterTrade, accountIndex string, acco
 		Fee:               fee,
 		OrderID:           orderID,
 		TradeID:           fmt.Sprintf("%d", trade.TradeID),
+		MarketType:        market.marketType,
 	}, nil
 }
 
@@ -583,10 +588,11 @@ func (c *Client) tradeToTradeInput(trade lighterTrade, accountIndex string, acco
 func (c *Client) orderToTrade(order lighterOrder, accountUUID uuid.UUID) (*models.TradeInput, error) {
 	market, ok := c.getMarketInfo(order.MarketIndex)
 	if !ok {
-		// Fallback: use generic naming
+		// Fallback: use generic naming and default to perp
 		market = marketInfo{
 			baseAsset:  fmt.Sprintf("MARKET%d", order.MarketIndex),
 			quoteAsset: "USDC",
+			marketType: "perp",
 		}
 	}
 
@@ -616,6 +622,7 @@ func (c *Client) orderToTrade(order lighterOrder, accountUUID uuid.UUID) (*model
 		Fee:               "0", // Lighter doesn't return fee in order response
 		OrderID:           order.OrderID,
 		TradeID:           order.OrderID, // Order ID serves as trade ID for filled orders
+		MarketType:        market.marketType,
 	}, nil
 }
 

--- a/models/trade.go
+++ b/models/trade.go
@@ -23,6 +23,7 @@ type Trade struct {
 	OrderID           string    `json:"order_id"`
 	TradeID           string    `json:"trade_id"`
 	ExchangeAccountID uuid.UUID `json:"exchange_account_id"`
+	MarketType        string    `json:"market_type"` // "perp" or "spot"
 }
 
 // UnmarshalJSON custom unmarshaler to handle BIGINT timestamp (Unix milliseconds) and NUMERIC as numbers
@@ -118,9 +119,11 @@ type TradeInput struct {
 	OrderID           string    `json:"order_id"`
 	TradeID           string    `json:"trade_id"`
 	ExchangeAccountID uuid.UUID `json:"exchange_account_id"`
+	MarketType        string    `json:"market_type"` // "perp" or "spot"
 }
 
 // TradeFilter represents filtering options for listing trades
 type TradeFilter struct {
 	ExchangeAccountIDs []uuid.UUID // Empty slice = all accounts, non-empty = filter by these IDs
+	MarketTypes        []string    // Optional: ["perp"], ["spot"], or both. Empty = all market types
 }


### PR DESCRIPTION
- Add MarketType field to Trade and TradeInput models
- Add MarketTypes filter to TradeFilter for filtering by market type
- Update all GraphQL queries to include market_type field
- Add market type detection for each exchange:
  - Hyperliquid: Detect spot by "@index" or "TOKEN/USDC" format
  - Drift: Extract marketType from API response
  - Lighter: Use marketType from market cache (perp vs spot orderbooks)