### PR TITLE
Add tags field to Wallet and ExchangeAccount models

### DIFF
--- a/db/accounts.go
+++ b/db/accounts.go
@@ -259,6 +259,37 @@ func (c *Client) ListAccountTypes(ctx context.Context) ([]*models.AccountType, e
 	return resp.AccountTypes, nil
 }
 
+// UpdateAccountTags updates the tags for an account
+func (c *Client) UpdateAccountTags(ctx context.Context, accountID string, tags []string) error {
+	query := `
+		mutation UpdateAccountTags($id: uuid!, $tags: jsonb!) {
+			update_exchange_accounts_by_pk(pk_columns: {id: $id}, _set: {tags: $tags}) {
+				id
+				tags
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id":   accountID,
+		"tags": tags,
+	})
+
+	var resp struct {
+		UpdateExchangeAccountsByPk *ExchangeAccount `json:"update_exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to update account tags: %w", err)
+	}
+
+	if resp.UpdateExchangeAccountsByPk == nil {
+		return fmt.Errorf("account not found: %s", accountID)
+	}
+
+	return nil
+}
+
 // UpdateAccountLastSynced updates the last_synced_at timestamp for an account
 func (c *Client) UpdateAccountLastSynced(ctx context.Context, accountID string) error {
 	query := `

--- a/db/wallet.go
+++ b/db/wallet.go
@@ -198,6 +198,37 @@ func (c *Client) DeleteWallet(ctx context.Context, id string) error {
 	return nil
 }
 
+// UpdateWalletTags updates the tags for a wallet
+func (c *Client) UpdateWalletTags(ctx context.Context, walletID string, tags []string) error {
+	query := `
+		mutation UpdateWalletTags($id: uuid!, $tags: jsonb!) {
+			update_wallets_by_pk(pk_columns: {id: $id}, _set: {tags: $tags}) {
+				id
+				tags
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id":   walletID,
+		"tags": tags,
+	})
+
+	var resp struct {
+		UpdateWalletsByPk *Wallet `json:"update_wallets_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to update wallet tags: %w", err)
+	}
+
+	if resp.UpdateWalletsByPk == nil {
+		return fmt.Errorf("wallet not found: %s", walletID)
+	}
+
+	return nil
+}
+
 // UpdateWalletLastDetected updates the last_detected_at timestamp for a wallet
 func (c *Client) UpdateWalletLastDetected(ctx context.Context, walletID string) error {
 	query := `

--- a/models/account.go
+++ b/models/account.go
@@ -23,6 +23,7 @@ type ExchangeAccount struct {
 	Status              string          `json:"status" db:"status"`                               // "active", "needs_token", "disabled"
 	DetectedAt          *string         `json:"detected_at,omitempty" db:"detected_at"`           // When account was detected
 	LastSyncedAt        *string         `json:"last_synced_at,omitempty" db:"last_synced_at"`     // When account was last synced
+	Tags                []string        `json:"tags" db:"tags"`
 }
 
 // ExchangeAccountInput is used for GraphQL mutations

--- a/models/wallet.go
+++ b/models/wallet.go
@@ -11,6 +11,7 @@ type Wallet struct {
 	Chain          string     `json:"chain" db:"chain"` // "solana", "ethereum"
 	CreatedAt      time.Time  `json:"created_at" db:"created_at"`
 	LastDetectedAt *time.Time `json:"last_detected_at,omitempty" db:"last_detected_at"`
+	Tags           []string   `json:"tags" db:"tags"`
 }
 
 // WalletInput is used for creating wallets via GraphQL mutations


### PR DESCRIPTION
Add Tags []string field to both models for user-defined categorization. Add UpdateWalletTags and UpdateAccountTags methods for updating tags via GraphQL mutations.