### PR TITLE
fix: use doRequestWithRetry in DiscoverAccounts

### DIFF
--- a/exchange/drift/discovery.go
+++ b/exchange/drift/discovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/zif-terminal/lib/models"
 )
@@ -23,22 +22,14 @@ func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([
 
 	url := fmt.Sprintf("%s/authority/%s/accounts", c.baseURL, userIdentifier)
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req)
+	// Use doRequestWithRetry which handles 403/429 with exponential backoff
+	resp, err := c.doRequestWithRetry(ctx, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch accounts: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("rate limit exceeded")
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
 	}
 
@@ -73,7 +64,7 @@ func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([
 			AccountType:       accountType,
 			Name:              name,
 			Metadata: map[string]interface{}{
-				"authority":     userIdentifier,
+				"authority":      userIdentifier,
 				"sub_account_id": acc.SubAccountID,
 			},
 		})


### PR DESCRIPTION
## Problem

`DiscoverAccounts` used a raw `http.NewRequestWithContext` call without any retry logic. When Drift's CDN (CloudFront) returns transient 403 responses, the discovery call fails silently and returns 0 accounts.

All other Drift API methods (`FetchTrades`, `FetchFundingPayments`, `FetchDeposits`) already use `doRequestWithRetry` which handles 403/429 with exponential backoff.

## Fix

Switch `DiscoverAccounts` to use `doRequestWithRetry`, consistent with all other API calls. This gives it up to 5 retries with exponential backoff for rate limit/CDN errors.

## Testing

- Verified the fix resolves transient 403s from Drift's CloudFront CDN
- Confirmed 2 Drift subaccounts are correctly discovered after the fix