### PR TITLE
fix: use txSig+txSigIndex for Drift funding payment IDs

### DIFF
--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -507,7 +507,7 @@ func (c *Client) transformFundingPayment(ctx context.Context, record driftFundin
 	}
 
 	amount := cleanDecimalString(record.FundingPayment)
-	paymentID := fmt.Sprintf("%d_%d", record.Ts, record.MarketIndex)
+	paymentID := fmt.Sprintf("%s_%d", record.TxSig, record.TxSigIndex)
 	timestamp := time.Unix(record.Ts, 0).UTC()
 
 	return &models.FundingPaymentInput{


### PR DESCRIPTION
## Summary

- **Fix funding payment ID collisions**: Changed the payment ID format from `{timestamp}_{marketIndex}` to `{txSig}_{txSigIndex}`, which is guaranteed unique per Drift record
- This matches the pattern already used for swap trade IDs in the same file (`client.go:486`)
- The old format could produce duplicate IDs when multiple funding payments for the same market occur within the same Unix second, causing batch insert failures

## Context

Discovered during investigation of a $0.68 funding discrepancy between Drift's dashboard and ZIF. The discrepancy turned out to be between Drift's own API and dashboard (not a ZIF bug), but this collision risk in payment IDs was identified as a real improvement.

## Test plan

- [ ] Verify `go test ./exchange/drift/...` passes
- [ ] Verify funding payment sync works correctly with existing data (re-sync should handle new ID format gracefully via upsert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)