### PR TITLE
feat: add GetLatestBalanceSnapshots to DBClient

### DIFF
--- a/db/client.go
+++ b/db/client.go
@@ -129,6 +129,9 @@ type DBClient interface {
 	ListSettlements(ctx context.Context, filter SettlementFilter) ([]*Settlement, error)
 	GetLatestSettlement(ctx context.Context, exchangeAccountID uuid.UUID) (*Settlement, error)
 
+	// Snapshot methods
+	GetLatestBalanceSnapshots(ctx context.Context, accountID uuid.UUID) ([]*BalanceSnapshot, error)
+
 	// Processor checkpoint methods
 	SaveCheckpoint(ctx context.Context, accountID uuid.UUID, state json.RawMessage, lastEventTimestamp int64, eventCounts json.RawMessage) error
 	LoadCheckpoint(ctx context.Context, accountID uuid.UUID) (*ProcessorCheckpoint, error)

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/models"
+)
+
+// BalanceSnapshot aliased from models
+type BalanceSnapshot = models.BalanceSnapshot
+
+// GetLatestBalanceSnapshots returns the most recent balance snapshot per asset
+// for the given account. It queries the spot_balance_snapshots table using
+// distinct_on to get only the latest entry per asset.
+func (c *Client) GetLatestBalanceSnapshots(ctx context.Context, accountID uuid.UUID) ([]*BalanceSnapshot, error) {
+	query := `
+		query GetLatestBalanceSnapshots($account_id: uuid!) {
+			spot_balance_snapshots(
+				where: { exchange_account_id: { _eq: $account_id } }
+				distinct_on: asset
+				order_by: [{ asset: asc }, { timestamp: desc }]
+			) {
+				asset
+				balance
+				oracle_price
+				usd_value
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"account_id": accountID.String(),
+	})
+
+	var resp struct {
+		Snapshots []struct {
+			Asset       string `json:"asset"`
+			Balance     string `json:"balance"`
+			OraclePrice string `json:"oracle_price"`
+			UsdValue    string `json:"usd_value"`
+		} `json:"spot_balance_snapshots"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get latest balance snapshots: %w", err)
+	}
+
+	balances := make([]*BalanceSnapshot, 0, len(resp.Snapshots))
+	for _, s := range resp.Snapshots {
+		balances = append(balances, &BalanceSnapshot{
+			Asset:       s.Asset,
+			Balance:     parseFloat64(s.Balance),
+			OraclePrice: parseFloat64(s.OraclePrice),
+			UsdValue:    parseFloat64(s.UsdValue),
+		})
+	}
+
+	return balances, nil
+}
+
+// parseFloat64 parses a numeric string to float64, returning 0 on error.
+func parseFloat64(s string) float64 {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/machinebox/graphql"
+)
+
+func TestClient_GetLatestBalanceSnapshots(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"spot_balance_snapshots": []map[string]interface{}{
+					{
+						"asset":        "USDC",
+						"balance":      "1500.123456",
+						"oracle_price": "1.0",
+						"usd_value":    "1500.123456",
+					},
+					{
+						"asset":        "SOL",
+						"balance":      "25.5",
+						"oracle_price": "150.75",
+						"usd_value":    "3844.125",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	balances, err := client.GetLatestBalanceSnapshots(ctx, accountID)
+	if err != nil {
+		t.Fatalf("GetLatestBalanceSnapshots failed: %v", err)
+	}
+
+	if len(balances) != 2 {
+		t.Fatalf("Expected 2 balances, got %d", len(balances))
+	}
+
+	// Check USDC
+	if balances[0].Asset != "USDC" {
+		t.Errorf("Expected first asset USDC, got %s", balances[0].Asset)
+	}
+	if balances[0].Balance != 1500.123456 {
+		t.Errorf("Expected USDC balance 1500.123456, got %f", balances[0].Balance)
+	}
+	if balances[0].OraclePrice != 1.0 {
+		t.Errorf("Expected USDC oracle price 1.0, got %f", balances[0].OraclePrice)
+	}
+
+	// Check SOL
+	if balances[1].Asset != "SOL" {
+		t.Errorf("Expected second asset SOL, got %s", balances[1].Asset)
+	}
+	if balances[1].Balance != 25.5 {
+		t.Errorf("Expected SOL balance 25.5, got %f", balances[1].Balance)
+	}
+}
+
+func TestClient_GetLatestBalanceSnapshots_Empty(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"spot_balance_snapshots": []map[string]interface{}{},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	balances, err := client.GetLatestBalanceSnapshots(ctx, accountID)
+	if err != nil {
+		t.Fatalf("GetLatestBalanceSnapshots failed: %v", err)
+	}
+
+	if len(balances) != 0 {
+		t.Errorf("Expected 0 balances, got %d", len(balances))
+	}
+}
+
+func TestParseFloat64(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"100.5", 100.5},
+		{"-50.25", -50.25},
+		{"0", 0},
+		{"invalid", 0},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseFloat64(tt.input)
+			if got != tt.want {
+				t.Errorf("parseFloat64(%q) = %f, want %f", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `GetLatestBalanceSnapshots(ctx, accountID)` to the `DBClient` interface
- Queries `spot_balance_snapshots` table using Hasura `distinct_on` to get the latest snapshot per asset
- Returns `[]*models.BalanceSnapshot` (reuses existing type) with numeric strings parsed to float64
- Enables activity_processor to reconcile against DB snapshots instead of calling exchange APIs

## Test plan
- [x] Unit tests for `GetLatestBalanceSnapshots` (success + empty cases)
- [x] Unit tests for `parseFloat64` helper
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)