### PR TITLE
fix: GetLatestBalanceSnapshots fails to unmarshal Hasura NUMERIC

### DIFF
--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -44,12 +44,7 @@ func (c *Client) GetLatestBalanceSnapshots(ctx context.Context, accountID uuid.U
 	})
 
 	var resp struct {
-		Snapshots []struct {
-			Asset       string `json:"asset"`
-			Balance     string `json:"balance"`
-			OraclePrice string `json:"oracle_price"`
-			UsdValue    string `json:"usd_value"`
-		} `json:"spot_balance_snapshots"`
+		Snapshots []*SpotBalanceSnapshot `json:"spot_balance_snapshots"`
 	}
 
 	if err := c.execute(ctx, req, &resp); err != nil {
@@ -62,7 +57,7 @@ func (c *Client) GetLatestBalanceSnapshots(ctx context.Context, accountID uuid.U
 			Asset:       s.Asset,
 			Balance:     parseFloat64(s.Balance),
 			OraclePrice: parseFloat64(s.OraclePrice),
-			UsdValue:    parseFloat64(s.UsdValue),
+			UsdValue:    parseFloat64(s.USDValue),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- `GetLatestBalanceSnapshots()` used an anonymous struct with `string` fields
- Hasura returns `NUMERIC` columns as JSON numbers, not strings
- This caused `json: cannot unmarshal number into Go struct field` on every activity_processor reconciliation run
- Fix: use `SpotBalanceSnapshot` model type which has a custom `UnmarshalJSON` handler

## Closes
- Fixes #32

## Test plan
- [ ] `go test ./...` passes
- [ ] Activity processor no longer logs "cannot unmarshal number" errors
- [ ] Interest reconciliation against snapshots runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)