### PR TITLE
feat: add DeletePositionsByIDs for atomic position rewrites

### DIFF
--- a/db/client.go
+++ b/db/client.go
@@ -107,6 +107,7 @@ type DBClient interface {
 	// Position methods
 	DeletePositionsForAccount(ctx context.Context, accountID uuid.UUID) (int, error)
 	DeleteOpenPositionsForAccount(ctx context.Context, accountID uuid.UUID) (int, error)
+	DeletePositionsByIDs(ctx context.Context, ids []uuid.UUID) (int, error)
 	CountClosedPositions(ctx context.Context, accountID uuid.UUID) (int, error)
 	AddPositions(ctx context.Context, inputs []*PositionInput) ([]*Position, error)
 	AddPositionEvents(ctx context.Context, inputs []*PositionEventInput) (int, error)

--- a/db/position.go
+++ b/db/position.go
@@ -74,6 +74,43 @@ func (c *Client) DeleteOpenPositionsForAccount(ctx context.Context, accountID uu
 	return resp.DeletePositions.AffectedRows, nil
 }
 
+// DeletePositionsByIDs deletes positions by their specific IDs (and cascades to position_events).
+// Used by the write-first-then-delete pattern to remove old positions after new ones are inserted.
+func (c *Client) DeletePositionsByIDs(ctx context.Context, ids []uuid.UUID) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	query := `
+		mutation DeletePositionsByIDs($ids: [uuid!]!) {
+			delete_positions(where: { id: { _in: $ids } }) {
+				affected_rows
+			}
+		}
+	`
+
+	idStrs := make([]string, len(ids))
+	for i, id := range ids {
+		idStrs[i] = id.String()
+	}
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"ids": idStrs,
+	})
+
+	var resp struct {
+		DeletePositions struct {
+			AffectedRows int `json:"affected_rows"`
+		} `json:"delete_positions"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return 0, fmt.Errorf("failed to delete positions by IDs: %w", err)
+	}
+
+	return resp.DeletePositions.AffectedRows, nil
+}
+
 // CountClosedPositions returns the number of closed positions for an account.
 func (c *Client) CountClosedPositions(ctx context.Context, accountID uuid.UUID) (int, error) {
 	query := `


### PR DESCRIPTION
## Summary
- Adds `DeletePositionsByIDs(ctx, ids []uuid.UUID) (int, error)` to `db.Client` and `DBClient` interface
- Enables the write-first-then-delete pattern: insert new positions, then delete old ones by ID
- Eliminates the window where positions table is empty during activity_processor rewrites

## Refs
- Refs zif-terminal/activity_processor#7

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./db/...` passes
- [ ] Downstream: activity_processor uses this to implement atomic writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)