### PR TITLE
feat: add PnL fields to Position model + price cache methods

### DIFF
--- a/db/client.go
+++ b/db/client.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/machinebox/graphql"
@@ -112,6 +113,9 @@ type DBClient interface {
 	AddPositions(ctx context.Context, inputs []*PositionInput) ([]*Position, error)
 	AddPositionEvents(ctx context.Context, inputs []*PositionEventInput) (int, error)
 	GetPositions(ctx context.Context, filter PositionFilter) ([]*Position, error)
+	GetPositionEventsByPositionID(ctx context.Context, positionID uuid.UUID) ([]*PositionEvent, error)
+	UpdatePositionPnL(ctx context.Context, positionID uuid.UUID, realizedPnl float64, denomination string) error
+	GetPositionsWithNullPnL(ctx context.Context, since time.Time, limit int) ([]*Position, error)
 
 	// Wallet methods
 	GetWallet(ctx context.Context, id string) (*Wallet, error)
@@ -131,6 +135,10 @@ type DBClient interface {
 	AddSettlements(ctx context.Context, inputs []*SettlementInput) (int, error)
 	ListSettlements(ctx context.Context, filter SettlementFilter) ([]*Settlement, error)
 	GetLatestSettlement(ctx context.Context, exchangeAccountID uuid.UUID) (*Settlement, error)
+
+	// Price cache methods
+	GetCachedPrice(ctx context.Context, asset, denomination string, timestamp time.Time, tolerance time.Duration) (*PriceCache, error)
+	AddPriceCache(ctx context.Context, input *PriceCacheInput) error
 
 	// Snapshot methods
 	GetLatestBalanceSnapshots(ctx context.Context, accountID uuid.UUID) ([]*BalanceSnapshot, error)

--- a/db/position.go
+++ b/db/position.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/zif-terminal/lib/models"
@@ -329,6 +330,143 @@ func (c *Client) GetPositions(ctx context.Context, filter PositionFilter) ([]*Po
 
 	if err := c.execute(ctx, req, &resp); err != nil {
 		return nil, fmt.Errorf("failed to get positions: %w", err)
+	}
+
+	return resp.Positions, nil
+}
+
+// GetPositionEventsByPositionID returns all position events for a given position,
+// ordered by timestamp ascending (chronological trade order).
+func (c *Client) GetPositionEventsByPositionID(ctx context.Context, positionID uuid.UUID) ([]*PositionEvent, error) {
+	query := `
+		query GetPositionEventsByPositionID($position_id: uuid!) {
+			position_events(
+				where: { position_id: { _eq: $position_id } }
+				order_by: { timestamp: asc }
+			) {
+				id
+				position_id
+				event_type
+				event_id
+				direction
+				quantity
+				price
+				timestamp
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"position_id": positionID.String(),
+	})
+
+	var resp struct {
+		PositionEvents []*PositionEvent `json:"position_events"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get position events: %w", err)
+	}
+
+	return resp.PositionEvents, nil
+}
+
+// UpdatePositionPnL sets realized_pnl and pnl_denomination on a single position.
+func (c *Client) UpdatePositionPnL(ctx context.Context, positionID uuid.UUID, realizedPnl float64, denomination string) error {
+	query := `
+		mutation UpdatePositionPnL($id: uuid!, $realized_pnl: numeric!, $pnl_denomination: String!) {
+			update_positions_by_pk(
+				pk_columns: { id: $id }
+				_set: {
+					realized_pnl: $realized_pnl
+					pnl_denomination: $pnl_denomination
+					updated_at: "now()"
+				}
+			) {
+				id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id":               positionID.String(),
+		"realized_pnl":     realizedPnl,
+		"pnl_denomination": denomination,
+	})
+
+	var resp struct {
+		UpdatePositionsByPk *struct {
+			ID string `json:"id"`
+		} `json:"update_positions_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to update position PnL: %w", err)
+	}
+
+	if resp.UpdatePositionsByPk == nil {
+		return fmt.Errorf("position %s not found", positionID)
+	}
+
+	return nil
+}
+
+// GetPositionsWithNullPnL returns closed positions that don't yet have realized_pnl computed.
+func (c *Client) GetPositionsWithNullPnL(ctx context.Context, since time.Time, limit int) ([]*Position, error) {
+	query := `
+		query GetPositionsWithNullPnL($since: timestamptz!, $limit: Int!) {
+			positions(
+				where: {
+					status: { _eq: "closed" }
+					realized_pnl: { _is_null: true }
+					end_time: { _gte: $since }
+				}
+				order_by: { end_time: asc }
+				limit: $limit
+			) {
+				id
+				exchange_account_id
+				market
+				market_type
+				side
+				status
+				quantity
+				entry_price
+				exit_price
+				total_fees
+				cumulative_funding
+				start_time
+				end_time
+				order_id
+				updated_at
+				exchange_account {
+					id
+					exchange_id
+					account_identifier
+					label
+					account_type
+					tags
+					exchange {
+						id
+						name
+						display_name
+					}
+				}
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"since": since.Format(time.RFC3339),
+		"limit": limit,
+	})
+
+	var resp struct {
+		Positions []*Position `json:"positions"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get positions with null PnL: %w", err)
 	}
 
 	return resp.Positions, nil

--- a/db/position_test.go
+++ b/db/position_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/machinebox/graphql"
@@ -439,5 +440,181 @@ func TestClient_GetPositions_NoFilter(t *testing.T) {
 
 	if len(positions) != 0 {
 		t.Errorf("Expected 0 positions, got %d", len(positions))
+	}
+}
+
+func TestClient_GetPositionEventsByPositionID(t *testing.T) {
+	ctx := context.Background()
+	positionID := uuid.New()
+	eventID1 := uuid.New()
+	eventID2 := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"position_events": []map[string]interface{}{
+					{
+						"id":          uuid.New().String(),
+						"position_id": positionID.String(),
+						"event_type":  "trade",
+						"event_id":    eventID1.String(),
+						"direction":   "entry",
+						"quantity":    "100",
+						"price":       "150.25",
+						"timestamp":   "2024-01-15T12:00:00Z",
+					},
+					{
+						"id":          uuid.New().String(),
+						"position_id": positionID.String(),
+						"event_type":  "trade",
+						"event_id":    eventID2.String(),
+						"direction":   "exit",
+						"quantity":    "100",
+						"price":       "160.00",
+						"timestamp":   "2024-01-16T12:00:00Z",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	events, err := client.GetPositionEventsByPositionID(ctx, positionID)
+	if err != nil {
+		t.Fatalf("GetPositionEventsByPositionID failed: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("Expected 2 events, got %d", len(events))
+	}
+
+	if events[0].Direction != "entry" {
+		t.Errorf("Expected first event direction 'entry', got %s", events[0].Direction)
+	}
+	if events[1].Direction != "exit" {
+		t.Errorf("Expected second event direction 'exit', got %s", events[1].Direction)
+	}
+}
+
+func TestClient_GetPositionEventsByPositionID_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.GetPositionEventsByPositionID(ctx, uuid.New())
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestClient_UpdatePositionPnL(t *testing.T) {
+	ctx := context.Background()
+	positionID := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"update_positions_by_pk": map[string]interface{}{
+					"id": positionID.String(),
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	err := client.UpdatePositionPnL(ctx, positionID, 1234.56, "USDC")
+	if err != nil {
+		t.Fatalf("UpdatePositionPnL failed: %v", err)
+	}
+}
+
+func TestClient_UpdatePositionPnL_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"update_positions_by_pk": nil,
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	err := client.UpdatePositionPnL(ctx, uuid.New(), 1234.56, "USDC")
+	if err == nil {
+		t.Fatal("Expected error for non-existent position")
+	}
+}
+
+func TestClient_GetPositionsWithNullPnL(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"positions": []*models.Position{
+					{
+						ID:                uuid.New(),
+						ExchangeAccountID: accountID,
+						Market:            "SOL-PERP",
+						MarketType:        "perp",
+						Side:              "long",
+						Status:            "closed",
+						Quantity:          "100",
+						EntryPrice:        "150",
+						TotalFees:         "1.5",
+						CumulativeFunding: "0.5",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	since := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	positions, err := client.GetPositionsWithNullPnL(ctx, since, 100)
+	if err != nil {
+		t.Fatalf("GetPositionsWithNullPnL failed: %v", err)
+	}
+
+	if len(positions) != 1 {
+		t.Fatalf("Expected 1 position, got %d", len(positions))
+	}
+	if positions[0].RealizedPnl != nil {
+		t.Errorf("Expected nil RealizedPnl, got %v", positions[0].RealizedPnl)
 	}
 }

--- a/db/price_cache.go
+++ b/db/price_cache.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// PriceCache type aliases
+type PriceCache = models.PriceCache
+type PriceCacheInput = models.PriceCacheInput
+
+// GetCachedPrice looks up a cached price within a time tolerance window.
+// Returns the closest price entry within [timestamp-tolerance, timestamp+tolerance],
+// or nil if no match is found.
+func (c *Client) GetCachedPrice(ctx context.Context, asset, denomination string, timestamp time.Time, tolerance time.Duration) (*PriceCache, error) {
+	lower := timestamp.Add(-tolerance)
+	upper := timestamp.Add(tolerance)
+
+	query := `
+		query GetCachedPrice($asset: String!, $denomination: String!, $lower: timestamptz!, $upper: timestamptz!) {
+			price_cache(
+				where: {
+					asset: { _eq: $asset }
+					denomination: { _eq: $denomination }
+					timestamp: { _gte: $lower, _lte: $upper }
+				}
+				order_by: { timestamp: asc }
+				limit: 1
+			) {
+				id
+				asset
+				denomination
+				timestamp
+				price
+				source
+				created_at
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"asset":        asset,
+		"denomination": denomination,
+		"lower":        lower.Format(time.RFC3339Nano),
+		"upper":        upper.Format(time.RFC3339Nano),
+	})
+
+	var resp struct {
+		PriceCache []*PriceCache `json:"price_cache"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get cached price: %w", err)
+	}
+
+	if len(resp.PriceCache) == 0 {
+		return nil, nil
+	}
+
+	return resp.PriceCache[0], nil
+}
+
+// AddPriceCache stores a resolved price in the cache.
+// Uses on_conflict to avoid duplicates on (asset, denomination, timestamp, source).
+func (c *Client) AddPriceCache(ctx context.Context, input *PriceCacheInput) error {
+	query := `
+		mutation AddPriceCache($object: price_cache_insert_input!) {
+			insert_price_cache_one(
+				object: $object
+				on_conflict: {
+					constraint: price_cache_asset_denomination_timestamp_source_key
+					update_columns: [price]
+				}
+			) {
+				id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"object": map[string]interface{}{
+			"asset":        input.Asset,
+			"denomination": input.Denomination,
+			"timestamp":    input.Timestamp.Format(time.RFC3339Nano),
+			"price":        input.Price,
+			"source":       input.Source,
+		},
+	})
+
+	var resp struct {
+		InsertPriceCacheOne *struct {
+			ID string `json:"id"`
+		} `json:"insert_price_cache_one"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to add price cache: %w", err)
+	}
+
+	return nil
+}

--- a/db/price_cache_test.go
+++ b/db/price_cache_test.go
@@ -1,0 +1,161 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/machinebox/graphql"
+	"github.com/zif-terminal/lib/models"
+)
+
+func TestClient_GetCachedPrice(t *testing.T) {
+	ctx := context.Background()
+	ts := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"price_cache": []map[string]interface{}{
+					{
+						"id":           "test-id",
+						"asset":        "SOL",
+						"denomination": "USDC",
+						"timestamp":    ts.Format(time.RFC3339),
+						"price":        150.25,
+						"source":       "coingecko",
+						"created_at":   ts.Format(time.RFC3339),
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	result, err := client.GetCachedPrice(ctx, "SOL", "USDC", ts, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("GetCachedPrice failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected a price cache entry, got nil")
+	}
+	if result.Asset != "SOL" {
+		t.Errorf("Expected asset SOL, got %s", result.Asset)
+	}
+	if result.Price != 150.25 {
+		t.Errorf("Expected price 150.25, got %f", result.Price)
+	}
+}
+
+func TestClient_GetCachedPrice_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"price_cache": []map[string]interface{}{},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	result, err := client.GetCachedPrice(ctx, "SOL", "USDC", time.Now(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("GetCachedPrice failed: %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil, got %v", result)
+	}
+}
+
+func TestClient_GetCachedPrice_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.GetCachedPrice(ctx, "SOL", "USDC", time.Now(), 5*time.Minute)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestClient_AddPriceCache(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"insert_price_cache_one": map[string]interface{}{
+					"id": "new-id",
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	err := client.AddPriceCache(ctx, &models.PriceCacheInput{
+		Asset:        "SOL",
+		Denomination: "USDC",
+		Timestamp:    time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC),
+		Price:        150.25,
+		Source:       "coingecko",
+	})
+	if err != nil {
+		t.Fatalf("AddPriceCache failed: %v", err)
+	}
+}
+
+func TestClient_AddPriceCache_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	err := client.AddPriceCache(ctx, &models.PriceCacheInput{
+		Asset:        "SOL",
+		Denomination: "USDC",
+		Timestamp:    time.Now(),
+		Price:        150.25,
+		Source:       "coingecko",
+	})
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}

--- a/models/position.go
+++ b/models/position.go
@@ -25,6 +25,8 @@ type Position struct {
 	StartTime         time.Time        `json:"start_time"`
 	EndTime           *time.Time       `json:"end_time"`  // nil if open
 	OrderID           string           `json:"order_id"`  // Order ID of the closing trade
+	RealizedPnl       *float64         `json:"realized_pnl"`
+	PnlDenomination   *string          `json:"pnl_denomination"`
 	CreatedAt         time.Time        `json:"created_at"`
 	UpdatedAt         time.Time        `json:"updated_at"`
 	ExchangeAccount   *ExchangeAccount `json:"exchange_account,omitempty"`
@@ -41,6 +43,7 @@ func (p *Position) UnmarshalJSON(data []byte) error {
 		ExitPrice         interface{} `json:"exit_price"`
 		TotalFees         interface{} `json:"total_fees"`
 		CumulativeFunding interface{} `json:"cumulative_funding"`
+		RealizedPnl       interface{} `json:"realized_pnl"`
 		*Alias
 	}{
 		Alias: (*Alias)(p),
@@ -82,6 +85,13 @@ func (p *Position) UnmarshalJSON(data []byte) error {
 	if aux.CumulativeFunding != nil {
 		p.CumulativeFunding = convertToString(aux.CumulativeFunding)
 	}
+	if aux.RealizedPnl != nil {
+		v, err := convertToFloat64(aux.RealizedPnl)
+		if err != nil {
+			return fmt.Errorf("failed to parse realized_pnl: %w", err)
+		}
+		p.RealizedPnl = &v
+	}
 
 	return nil
 }
@@ -102,6 +112,8 @@ type PositionInput struct {
 	StartTime         int64  // Unix ms
 	EndTime           int64  // 0 if open
 	OrderID           string // Order ID that closed this position (closed positions only)
+	RealizedPnl       *float64 // nil = NULL (PnL not yet computed)
+	PnlDenomination   *string  // nil = NULL
 }
 
 // PositionEvent represents a link between a position and a source event.

--- a/models/position_test.go
+++ b/models/position_test.go
@@ -115,3 +115,107 @@ func TestPosition_UnmarshalJSON_NumericAsFloat(t *testing.T) {
 		t.Error("Expected entry_price to be non-empty")
 	}
 }
+
+func TestPosition_UnmarshalJSON_WithRealizedPnl(t *testing.T) {
+	jsonData := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"exchange_account_id": "00000000-0000-0000-0000-000000000002",
+		"market": "SOL-PERP",
+		"market_type": "perp",
+		"side": "long",
+		"status": "closed",
+		"quantity": "100",
+		"entry_price": "150",
+		"exit_price": "160",
+		"total_fees": "1.5",
+		"cumulative_funding": "0.5",
+		"realized_pnl": 998.5,
+		"pnl_denomination": "USDC",
+		"start_time": 1700000000000,
+		"end_time": 1700100000000
+	}`
+
+	var pos Position
+	err := json.Unmarshal([]byte(jsonData), &pos)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+
+	if pos.RealizedPnl == nil {
+		t.Fatal("Expected realized_pnl to be non-nil")
+	}
+	if *pos.RealizedPnl != 998.5 {
+		t.Errorf("Expected realized_pnl 998.5, got %f", *pos.RealizedPnl)
+	}
+	if pos.PnlDenomination == nil {
+		t.Fatal("Expected pnl_denomination to be non-nil")
+	}
+	if *pos.PnlDenomination != "USDC" {
+		t.Errorf("Expected pnl_denomination USDC, got %s", *pos.PnlDenomination)
+	}
+}
+
+func TestPosition_UnmarshalJSON_WithNullPnl(t *testing.T) {
+	jsonData := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"exchange_account_id": "00000000-0000-0000-0000-000000000002",
+		"market": "SOL-PERP",
+		"market_type": "perp",
+		"side": "long",
+		"status": "open",
+		"quantity": "100",
+		"entry_price": "150",
+		"total_fees": "1.5",
+		"cumulative_funding": "0.5",
+		"realized_pnl": null,
+		"pnl_denomination": null,
+		"start_time": 1700000000000
+	}`
+
+	var pos Position
+	err := json.Unmarshal([]byte(jsonData), &pos)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+
+	if pos.RealizedPnl != nil {
+		t.Errorf("Expected nil realized_pnl, got %v", *pos.RealizedPnl)
+	}
+	if pos.PnlDenomination != nil {
+		t.Errorf("Expected nil pnl_denomination, got %v", *pos.PnlDenomination)
+	}
+}
+
+func TestPosition_UnmarshalJSON_RealizedPnlAsString(t *testing.T) {
+	// Hasura may return NUMERIC(36,18) as a string
+	jsonData := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"exchange_account_id": "00000000-0000-0000-0000-000000000002",
+		"market": "SOL-PERP",
+		"market_type": "perp",
+		"side": "long",
+		"status": "closed",
+		"quantity": "100",
+		"entry_price": "150",
+		"exit_price": "160",
+		"total_fees": "1.5",
+		"cumulative_funding": "0.5",
+		"realized_pnl": "1234.567890",
+		"pnl_denomination": "USDC",
+		"start_time": 1700000000000,
+		"end_time": 1700100000000
+	}`
+
+	var pos Position
+	err := json.Unmarshal([]byte(jsonData), &pos)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+
+	if pos.RealizedPnl == nil {
+		t.Fatal("Expected realized_pnl to be non-nil")
+	}
+	if *pos.RealizedPnl != 1234.567890 {
+		t.Errorf("Expected realized_pnl 1234.567890, got %f", *pos.RealizedPnl)
+	}
+}

--- a/models/price_cache.go
+++ b/models/price_cache.go
@@ -1,0 +1,23 @@
+package models
+
+import "time"
+
+// PriceCache represents a cached price lookup in the database.
+type PriceCache struct {
+	ID           string    `json:"id"`
+	Asset        string    `json:"asset"`
+	Denomination string    `json:"denomination"`
+	Timestamp    time.Time `json:"timestamp"`
+	Price        float64   `json:"price"`
+	Source       string    `json:"source"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// PriceCacheInput represents input for inserting a price cache entry.
+type PriceCacheInput struct {
+	Asset        string
+	Denomination string
+	Timestamp    time.Time
+	Price        float64
+	Source       string
+}

--- a/models/trade.go
+++ b/models/trade.go
@@ -99,6 +99,22 @@ func convertToString(v interface{}) string {
 	}
 }
 
+// convertToFloat64 converts a JSON value (string or number) to float64.
+func convertToFloat64(v interface{}) (float64, error) {
+	switch val := v.(type) {
+	case float64:
+		return val, nil
+	case string:
+		var f float64
+		_, err := fmt.Sscanf(val, "%f", &f)
+		return f, err
+	case json.Number:
+		return val.Float64()
+	default:
+		return 0, fmt.Errorf("unsupported type %T for float64 conversion", v)
+	}
+}
+
 // parseInt64 parses a string to int64
 func parseInt64(s string) (int64, error) {
 	var result int64


### PR DESCRIPTION
## Summary
- Add `RealizedPnl` and `PnlDenomination` nullable fields to `Position` and `PositionInput` models
- Add `PriceCache` model with `GetCachedPrice` (tolerance-window lookup) and `AddPriceCache` (upsert) DB methods
- Add `GetPositionEventsByPositionID` (chronological event walk for PnL computation)
- Add `UpdatePositionPnL` (set realized PnL on a position)
- Add `GetPositionsWithNullPnL` (find closed positions needing PnL computation)
- Update `DBClient` interface with all new methods
- Full unit test coverage for all new methods and model deserialization

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New model tests: WithRealizedPnl, WithNullPnl, RealizedPnlAsString
- [x] New DB tests: GetPositionEventsByPositionID, UpdatePositionPnL, GetPositionsWithNullPnL, GetCachedPrice, AddPriceCache

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)