### PR TITLE
feat: price cache, oracle prices, and position PnL support

### DIFF
--- a/db/client.go
+++ b/db/client.go
@@ -119,7 +119,13 @@ type DBClient interface {
 	AddPositions(ctx context.Context, inputs []*PositionInput) ([]*Position, error)
 	AddPositionEvents(ctx context.Context, inputs []*PositionEventInput) (int, error)
 	GetPositions(ctx context.Context, filter PositionFilter) ([]*Position, error)
+	GetPositionsByIDs(ctx context.Context, ids []uuid.UUID) ([]*Position, error)
 	GetPositionEventsByPositionID(ctx context.Context, positionID uuid.UUID) ([]*PositionEvent, error)
+
+	// Position PnL methods
+	ListMissingPositionPnL(ctx context.Context, limit int) ([]*MissingPositionPnL, error)
+	AddPositionPnL(ctx context.Context, inputs []*PositionPnLInput) (int, error)
+
 	// Wallet methods
 	GetWallet(ctx context.Context, id string) (*Wallet, error)
 	GetWalletByAddress(ctx context.Context, address string, chain string) (*Wallet, error)
@@ -158,6 +164,11 @@ type DBClient interface {
 	ListSupportedDenominations(ctx context.Context) ([]string, error)
 	ListMissingEventValues(ctx context.Context, limit int) ([]*MissingEventValue, error)
 	AddEventValues(ctx context.Context, inputs []*EventValueInput) (int, error)
+	GetEventValuesByEventIDs(ctx context.Context, eventIDs []uuid.UUID, denomination string) ([]*EventValue, error)
+
+	// Price cache methods
+	AddPrices(ctx context.Context, inputs []*PriceInput) (int, error)
+	GetNearestPrice(ctx context.Context, asset string, denomination string, timestampMs int64, toleranceMs int64) (*Price, error)
 }
 
 // Ensure Client implements DBClient

--- a/db/position_pnl.go
+++ b/db/position_pnl.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/models"
+)
+
+// PositionPnLInput type alias
+type PositionPnLInput = models.PositionPnLInput
+
+// MissingPositionPnL type alias
+type MissingPositionPnL = models.MissingPositionPnL
+
+// ListMissingPositionPnL returns closed positions that are missing PnL for supported denominations.
+// Results are limited by the limit parameter to support batch processing.
+func (c *Client) ListMissingPositionPnL(ctx context.Context, limit int) ([]*MissingPositionPnL, error) {
+	query := `
+		query ListMissingPositionPnL($limit: Int!) {
+			missing_position_pnl(limit: $limit) {
+				position_id
+				denomination
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"limit": limit,
+	})
+
+	var resp struct {
+		MissingPositionPnL []*MissingPositionPnL `json:"missing_position_pnl"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list missing position pnl: %w", err)
+	}
+
+	return resp.MissingPositionPnL, nil
+}
+
+// AddPositionPnL batch-inserts position PnL records. Uses on_conflict to update existing rows.
+func (c *Client) AddPositionPnL(ctx context.Context, inputs []*PositionPnLInput) (int, error) {
+	if len(inputs) == 0 {
+		return 0, nil
+	}
+
+	query := `
+		mutation AddPositionPnL($objects: [position_pnl_insert_input!]!) {
+			insert_position_pnl(
+				objects: $objects
+				on_conflict: {
+					constraint: position_pnl_position_id_denomination_key
+					update_columns: [realized_pnl]
+				}
+			) {
+				affected_rows
+			}
+		}
+	`
+
+	objects := make([]map[string]interface{}, len(inputs))
+	for i, input := range inputs {
+		objects[i] = map[string]interface{}{
+			"position_id":  input.PositionID.String(),
+			"denomination": input.Denomination,
+			"realized_pnl": input.RealizedPnL,
+		}
+	}
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"objects": objects,
+	})
+
+	var resp struct {
+		InsertPositionPnL struct {
+			AffectedRows int `json:"affected_rows"`
+		} `json:"insert_position_pnl"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return 0, fmt.Errorf("failed to add position pnl: %w", err)
+	}
+
+	return resp.InsertPositionPnL.AffectedRows, nil
+}
+
+// GetPositionsByIDs fetches positions by their IDs. Returns all matching positions.
+func (c *Client) GetPositionsByIDs(ctx context.Context, ids []uuid.UUID) ([]*Position, error) {
+	if len(ids) == 0 {
+		return []*Position{}, nil
+	}
+
+	query := `
+		query GetPositionsByIDs($ids: [uuid!]!) {
+			positions(where: { id: { _in: $ids } }) {
+				id
+				exchange_account_id
+				market
+				market_type
+				side
+				status
+				quantity
+				start_time
+				end_time
+				updated_at
+			}
+		}
+	`
+
+	idStrings := make([]string, len(ids))
+	for i, id := range ids {
+		idStrings[i] = id.String()
+	}
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"ids": idStrings,
+	})
+
+	var resp struct {
+		Positions []*Position `json:"positions"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get positions by IDs: %w", err)
+	}
+
+	return resp.Positions, nil
+}
+
+// GetEventValuesByEventIDs fetches event values for the given event IDs and denomination.
+// Returns a map keyed by a composite of (event_id, event_type) for quick lookup.
+func (c *Client) GetEventValuesByEventIDs(ctx context.Context, eventIDs []uuid.UUID, denomination string) ([]*EventValue, error) {
+	if len(eventIDs) == 0 {
+		return []*EventValue{}, nil
+	}
+
+	query := `
+		query GetEventValuesByEventIDs($event_ids: [uuid!]!, $denomination: String!) {
+			event_values(where: {
+				event_id: { _in: $event_ids }
+				denomination: { _eq: $denomination }
+			}) {
+				id
+				event_id
+				event_type
+				denomination
+				quantity
+			}
+		}
+	`
+
+	idStrings := make([]string, len(eventIDs))
+	for i, id := range eventIDs {
+		idStrings[i] = id.String()
+	}
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"event_ids":    idStrings,
+		"denomination": denomination,
+	})
+
+	var resp struct {
+		EventValues []*EventValue `json:"event_values"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get event values by event IDs: %w", err)
+	}
+
+	return resp.EventValues, nil
+}

--- a/db/position_pnl_test.go
+++ b/db/position_pnl_test.go
@@ -1,0 +1,377 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/machinebox/graphql"
+)
+
+func TestClient_ListMissingPositionPnL(t *testing.T) {
+	ctx := context.Background()
+	posID := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"missing_position_pnl": []map[string]interface{}{
+					{
+						"position_id":  posID.String(),
+						"denomination": "USDC",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	missing, err := client.ListMissingPositionPnL(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListMissingPositionPnL failed: %v", err)
+	}
+
+	if len(missing) != 1 {
+		t.Fatalf("Expected 1 missing position pnl, got %d", len(missing))
+	}
+
+	if missing[0].PositionID != posID {
+		t.Errorf("Expected position_id %s, got %s", posID, missing[0].PositionID)
+	}
+
+	if missing[0].Denomination != "USDC" {
+		t.Errorf("Expected denomination USDC, got %s", missing[0].Denomination)
+	}
+}
+
+func TestClient_ListMissingPositionPnL_Empty(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"missing_position_pnl": []map[string]interface{}{},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	missing, err := client.ListMissingPositionPnL(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListMissingPositionPnL failed: %v", err)
+	}
+
+	if len(missing) != 0 {
+		t.Errorf("Expected 0 missing position pnl, got %d", len(missing))
+	}
+}
+
+func TestClient_ListMissingPositionPnL_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.ListMissingPositionPnL(ctx, 100)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestClient_AddPositionPnL(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"insert_position_pnl": map[string]interface{}{
+					"affected_rows": float64(2),
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	inputs := []*PositionPnLInput{
+		{PositionID: uuid.New(), Denomination: "USDC", RealizedPnL: "150.50"},
+		{PositionID: uuid.New(), Denomination: "BTC", RealizedPnL: "-25.00"},
+	}
+
+	rows, err := client.AddPositionPnL(ctx, inputs)
+	if err != nil {
+		t.Fatalf("AddPositionPnL failed: %v", err)
+	}
+
+	if rows != 2 {
+		t.Errorf("Expected 2 affected rows, got %d", rows)
+	}
+}
+
+func TestClient_AddPositionPnL_Empty(t *testing.T) {
+	ctx := context.Background()
+
+	client := NewClientWithGraphQL(nil, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	rows, err := client.AddPositionPnL(ctx, []*PositionPnLInput{})
+	if err != nil {
+		t.Fatalf("AddPositionPnL failed: %v", err)
+	}
+
+	if rows != 0 {
+		t.Errorf("Expected 0 affected rows, got %d", rows)
+	}
+}
+
+func TestClient_AddPositionPnL_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	inputs := []*PositionPnLInput{
+		{PositionID: uuid.New(), Denomination: "USDC", RealizedPnL: "100.00"},
+	}
+
+	_, err := client.AddPositionPnL(ctx, inputs)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestClient_GetPositionsByIDs(t *testing.T) {
+	ctx := context.Background()
+	id1 := uuid.New()
+	id2 := uuid.New()
+	accountID := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"positions": []map[string]interface{}{
+					{
+						"id":                  id1.String(),
+						"exchange_account_id": accountID.String(),
+						"market":              "SOL-PERP",
+						"market_type":         "perp",
+						"side":                "long",
+						"status":              "closed",
+						"quantity":            "100.5",
+						"start_time":          float64(1700000000000),
+						"end_time":            float64(1700100000000),
+						"updated_at":          "2023-11-14T22:13:20Z",
+					},
+					{
+						"id":                  id2.String(),
+						"exchange_account_id": accountID.String(),
+						"market":              "BTC-PERP",
+						"market_type":         "perp",
+						"side":                "short",
+						"status":              "closed",
+						"quantity":            "0.5",
+						"start_time":          float64(1700000000000),
+						"end_time":            float64(1700200000000),
+						"updated_at":          "2023-11-16T01:46:40Z",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	positions, err := client.GetPositionsByIDs(ctx, []uuid.UUID{id1, id2})
+	if err != nil {
+		t.Fatalf("GetPositionsByIDs failed: %v", err)
+	}
+
+	if len(positions) != 2 {
+		t.Fatalf("Expected 2 positions, got %d", len(positions))
+	}
+
+	if positions[0].Market != "SOL-PERP" {
+		t.Errorf("Expected market SOL-PERP, got %s", positions[0].Market)
+	}
+
+	if positions[1].Side != "short" {
+		t.Errorf("Expected side short, got %s", positions[1].Side)
+	}
+}
+
+func TestClient_GetPositionsByIDs_Empty(t *testing.T) {
+	ctx := context.Background()
+
+	client := NewClientWithGraphQL(nil, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	positions, err := client.GetPositionsByIDs(ctx, []uuid.UUID{})
+	if err != nil {
+		t.Fatalf("GetPositionsByIDs failed: %v", err)
+	}
+
+	if len(positions) != 0 {
+		t.Errorf("Expected 0 positions, got %d", len(positions))
+	}
+}
+
+func TestClient_GetPositionsByIDs_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.GetPositionsByIDs(ctx, []uuid.UUID{uuid.New()})
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestClient_GetEventValuesByEventIDs(t *testing.T) {
+	ctx := context.Background()
+	eventID1 := uuid.New()
+	eventID2 := uuid.New()
+	valueID1 := uuid.New()
+	valueID2 := uuid.New()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"event_values": []map[string]interface{}{
+					{
+						"id":           valueID1.String(),
+						"event_id":     eventID1.String(),
+						"event_type":   "trade",
+						"denomination": "USDC",
+						"quantity":     "500.25",
+					},
+					{
+						"id":           valueID2.String(),
+						"event_id":     eventID2.String(),
+						"event_type":   "settlement",
+						"denomination": "USDC",
+						"quantity":     "-100.50",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	values, err := client.GetEventValuesByEventIDs(ctx, []uuid.UUID{eventID1, eventID2}, "USDC")
+	if err != nil {
+		t.Fatalf("GetEventValuesByEventIDs failed: %v", err)
+	}
+
+	if len(values) != 2 {
+		t.Fatalf("Expected 2 event values, got %d", len(values))
+	}
+
+	if values[0].EventType != "trade" {
+		t.Errorf("Expected event_type trade, got %s", values[0].EventType)
+	}
+
+	if values[0].Quantity != "500.25" {
+		t.Errorf("Expected quantity 500.25, got %s", values[0].Quantity)
+	}
+
+	if values[1].Denomination != "USDC" {
+		t.Errorf("Expected denomination USDC, got %s", values[1].Denomination)
+	}
+}
+
+func TestClient_GetEventValuesByEventIDs_Empty(t *testing.T) {
+	ctx := context.Background()
+
+	client := NewClientWithGraphQL(nil, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	values, err := client.GetEventValuesByEventIDs(ctx, []uuid.UUID{}, "USDC")
+	if err != nil {
+		t.Fatalf("GetEventValuesByEventIDs failed: %v", err)
+	}
+
+	if len(values) != 0 {
+		t.Errorf("Expected 0 event values, got %d", len(values))
+	}
+}
+
+func TestClient_GetEventValuesByEventIDs_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.GetEventValuesByEventIDs(ctx, []uuid.UUID{uuid.New()}, "USDC")
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}

--- a/db/price_cache.go
+++ b/db/price_cache.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// Price cache type aliases
+type Price = models.Price
+type PriceInput = models.PriceInput
+type PriceRecord = models.PriceRecord
+
+// AddPrices batch upserts price records into the price_cache table.
+// On conflict (same asset, denomination, timestamp, source), the price is updated.
+// Returns the number of affected rows.
+func (c *Client) AddPrices(ctx context.Context, inputs []*PriceInput) (int, error) {
+	if len(inputs) == 0 {
+		return 0, nil
+	}
+
+	// Deduplicate: PostgreSQL ON CONFLICT cannot affect the same row twice in one INSERT.
+	// Keep the last price for each (asset, denomination, timestamp, source) key.
+	type priceKey struct {
+		Asset, Denomination, Source string
+		TimestampMs                int64
+	}
+	seen := make(map[priceKey]int, len(inputs))
+	deduped := make([]*PriceInput, 0, len(inputs))
+	for _, input := range inputs {
+		key := priceKey{input.Asset, input.Denomination, input.Source, input.TimestampMs}
+		if idx, ok := seen[key]; ok {
+			deduped[idx] = input // overwrite with latest
+		} else {
+			seen[key] = len(deduped)
+			deduped = append(deduped, input)
+		}
+	}
+
+	const batchSize = 500
+	totalAffected := 0
+
+	for start := 0; start < len(deduped); start += batchSize {
+		end := start + batchSize
+		if end > len(deduped) {
+			end = len(deduped)
+		}
+		batch := deduped[start:end]
+
+		affected, err := c.addPricesBatch(ctx, batch)
+		if err != nil {
+			return totalAffected, err
+		}
+		totalAffected += affected
+	}
+
+	return totalAffected, nil
+}
+
+func (c *Client) addPricesBatch(ctx context.Context, inputs []*PriceInput) (int, error) {
+	query := `
+		mutation AddPrices($objects: [price_cache_insert_input!]!) {
+			insert_price_cache(
+				objects: $objects
+				on_conflict: {
+					constraint: price_cache_asset_denomination_timestamp_source_key
+					update_columns: [price]
+				}
+			) {
+				affected_rows
+			}
+		}
+	`
+
+	objects := make([]map[string]interface{}, len(inputs))
+	for i, input := range inputs {
+		objects[i] = map[string]interface{}{
+			"asset":        input.Asset,
+			"denomination": input.Denomination,
+			"timestamp":    input.TimestampMs,
+			"price":        input.Price,
+			"source":       input.Source,
+		}
+	}
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"objects": objects,
+	})
+
+	var resp struct {
+		InsertPriceCache struct {
+			AffectedRows int `json:"affected_rows"`
+		} `json:"insert_price_cache"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return 0, fmt.Errorf("failed to add prices: %w", err)
+	}
+
+	return resp.InsertPriceCache.AffectedRows, nil
+}
+
+// GetNearestPrice finds the closest price record within a tolerance window.
+// It queries for prices where the timestamp is within ±toleranceMs of the given timestampMs,
+// then picks the one closest to the target timestamp.
+// Returns nil (not an error) if no price is found within the tolerance.
+func (c *Client) GetNearestPrice(ctx context.Context, asset string, denomination string, timestampMs int64, toleranceMs int64) (*Price, error) {
+	query := `
+		query GetNearestPrice($asset: String!, $denomination: String!, $ts_min: bigint!, $ts_max: bigint!) {
+			price_cache(
+				where: {
+					asset: { _eq: $asset }
+					denomination: { _eq: $denomination }
+					timestamp: { _gte: $ts_min, _lte: $ts_max }
+				}
+				order_by: { timestamp: asc }
+			) {
+				asset
+				denomination
+				timestamp
+				price
+				source
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"asset":        asset,
+		"denomination": denomination,
+		"ts_min":       timestampMs - toleranceMs,
+		"ts_max":       timestampMs + toleranceMs,
+	})
+
+	var resp struct {
+		PriceCache []*Price `json:"price_cache"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get nearest price: %w", err)
+	}
+
+	if len(resp.PriceCache) == 0 {
+		return nil, nil
+	}
+
+	// Find the price closest to the target timestamp
+	var closest *Price
+	var minDist int64
+	for _, p := range resp.PriceCache {
+		dist := timestampMs - p.Timestamp
+		if dist < 0 {
+			dist = -dist
+		}
+		if closest == nil || dist < minDist {
+			closest = p
+			minDist = dist
+		}
+	}
+
+	return closest, nil
+}

--- a/db/price_cache_test.go
+++ b/db/price_cache_test.go
@@ -1,0 +1,194 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/machinebox/graphql"
+)
+
+func TestClient_AddPrices(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"insert_price_cache": map[string]interface{}{
+					"affected_rows": float64(2),
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	inputs := []*PriceInput{
+		{Asset: "SOL", Denomination: "USDC", TimestampMs: 1700000000000, Price: "100.50", Source: "drift"},
+		{Asset: "BTC", Denomination: "USDC", TimestampMs: 1700000000000, Price: "43000.00", Source: "drift"},
+	}
+
+	rows, err := client.AddPrices(ctx, inputs)
+	if err != nil {
+		t.Fatalf("AddPrices failed: %v", err)
+	}
+
+	if rows != 2 {
+		t.Errorf("Expected 2 affected rows, got %d", rows)
+	}
+}
+
+func TestClient_AddPrices_Empty(t *testing.T) {
+	ctx := context.Background()
+
+	client := NewClientWithGraphQL(nil, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	rows, err := client.AddPrices(ctx, []*PriceInput{})
+	if err != nil {
+		t.Fatalf("AddPrices failed: %v", err)
+	}
+
+	if rows != 0 {
+		t.Errorf("Expected 0 affected rows, got %d", rows)
+	}
+}
+
+func TestClient_AddPrices_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	inputs := []*PriceInput{
+		{Asset: "SOL", Denomination: "USDC", TimestampMs: 1700000000000, Price: "100.50", Source: "drift"},
+	}
+
+	_, err := client.AddPrices(ctx, inputs)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestClient_GetNearestPrice(t *testing.T) {
+	ctx := context.Background()
+
+	targetTs := int64(1700000005000)
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			// Return two prices: one before and one after the target
+			respData := map[string]interface{}{
+				"price_cache": []map[string]interface{}{
+					{
+						"asset":        "SOL",
+						"denomination": "USDC",
+						"timestamp":    float64(1700000003000), // 2s before target
+						"price":        "100.00",
+						"source":       "drift",
+					},
+					{
+						"asset":        "SOL",
+						"denomination": "USDC",
+						"timestamp":    float64(1700000006000), // 1s after target
+						"price":        "101.00",
+						"source":       "drift",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	price, err := client.GetNearestPrice(ctx, "SOL", "USDC", targetTs, 10000)
+	if err != nil {
+		t.Fatalf("GetNearestPrice failed: %v", err)
+	}
+
+	if price == nil {
+		t.Fatal("Expected a price, got nil")
+	}
+
+	// The closer price is 1700000006000 (1s away vs 2s away)
+	if price.Timestamp != 1700000006000 {
+		t.Errorf("Expected timestamp 1700000006000 (closest), got %d", price.Timestamp)
+	}
+
+	if price.Price != "101.00" {
+		t.Errorf("Expected price 101.00, got %s", price.Price)
+	}
+
+	if price.Asset != "SOL" {
+		t.Errorf("Expected asset SOL, got %s", price.Asset)
+	}
+}
+
+func TestClient_GetNearestPrice_NoResult(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			respData := map[string]interface{}{
+				"price_cache": []map[string]interface{}{},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	price, err := client.GetNearestPrice(ctx, "SOL", "USDC", 1700000000000, 5000)
+	if err != nil {
+		t.Fatalf("GetNearestPrice failed: %v", err)
+	}
+
+	if price != nil {
+		t.Errorf("Expected nil price, got %+v", price)
+	}
+}
+
+func TestClient_GetNearestPrice_Error(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			return fmt.Errorf("connection refused")
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	_, err := client.GetNearestPrice(ctx, "SOL", "USDC", 1700000000000, 5000)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}

--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -24,6 +24,10 @@ const (
 	backoffMultiplier = 2.0
 )
 
+// oracleDenomination is the denomination used by Drift's oracle prices.
+// Drift oracles report prices in USDC. Other exchanges may use different denominations.
+const oracleDenomination = "USDC"
+
 // Client implements iface.ExchangeClient for Drift
 type Client struct {
 	baseURL     string
@@ -103,63 +107,77 @@ func (c *Client) Name() string {
 	return "drift"
 }
 
+// tradeWithPrices pairs a trade with its oracle price records
+type tradeWithPrices struct {
+	trade  *models.TradeInput
+	prices []*models.PriceRecord
+}
+
 // FetchTrades fetches trades and swaps from Drift API
 func (c *Client) FetchTrades(
 	ctx context.Context,
 	account *models.ExchangeAccount,
 	since time.Time,
-) ([]*models.TradeInput, error) {
+) ([]*models.TradeInput, []*models.PriceRecord, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	}
 
 	accountUUID, err := uuid.Parse(account.ID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid account ID: %w", err)
+		return nil, nil, fmt.Errorf("invalid account ID: %w", err)
 	}
 
 	accountID := account.AccountIdentifier
 	if accountID == "" {
-		return nil, fmt.Errorf("account identifier (subaccount public key) is required")
+		return nil, nil, fmt.Errorf("account identifier (subaccount public key) is required")
 	}
 
 	// Fetch trades using generic pagination
-	trades, err := fetchWithHistory(
+	tradeResults, err := fetchWithHistory(
 		ctx,
 		c.baseURL,
 		accountID,
 		"trades",
 		since,
 		c.createTradePageFetcher(accountUUID),
-		func(t *models.TradeInput) time.Time { return t.Timestamp },
+		func(t tradeWithPrices) time.Time { return t.trade.Timestamp },
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Fetch swaps using generic pagination
-	swaps, err := fetchWithHistory(
+	swapResults, err := fetchWithHistory(
 		ctx,
 		c.baseURL,
 		accountID,
 		"swaps",
 		since,
 		c.createSwapPageFetcher(accountUUID),
-		func(t *models.TradeInput) time.Time { return t.Timestamp },
+		func(t tradeWithPrices) time.Time { return t.trade.Timestamp },
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Combine trades and swaps
-	allTrades := append(trades, swaps...)
+	allResults := append(tradeResults, swapResults...)
 
 	// Sort by timestamp (oldest first)
-	sort.Slice(allTrades, func(i, j int) bool {
-		return allTrades[i].Timestamp.Before(allTrades[j].Timestamp)
+	sort.Slice(allResults, func(i, j int) bool {
+		return allResults[i].trade.Timestamp.Before(allResults[j].trade.Timestamp)
 	})
 
-	return allTrades, nil
+	// Separate into trades and prices
+	allTrades := make([]*models.TradeInput, 0, len(allResults))
+	var allPrices []*models.PriceRecord
+	for _, r := range allResults {
+		allTrades = append(allTrades, r.trade)
+		allPrices = append(allPrices, r.prices...)
+	}
+
+	return allTrades, allPrices, nil
 }
 
 // FetchFundingPayments fetches funding payments from Drift API
@@ -203,115 +221,135 @@ func (c *Client) FetchFundingPayments(
 	return payments, nil
 }
 
+// depositWithPrice pairs a transfer with its oracle price record
+type depositWithPrice struct {
+	transfer *models.TransferInput
+	price    *models.PriceRecord
+}
+
 // FetchDeposits fetches deposits and withdrawals from Drift API
 func (c *Client) FetchDeposits(
 	ctx context.Context,
 	account *models.ExchangeAccount,
 	since time.Time,
-) ([]*models.TransferInput, error) {
+) ([]*models.TransferInput, []*models.PriceRecord, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	}
 
 	accountUUID, err := uuid.Parse(account.ID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid account ID: %w", err)
+		return nil, nil, fmt.Errorf("invalid account ID: %w", err)
 	}
 
 	accountID := account.AccountIdentifier
 	if accountID == "" {
-		return nil, fmt.Errorf("account identifier (subaccount public key) is required")
+		return nil, nil, fmt.Errorf("account identifier (subaccount public key) is required")
 	}
 
-	deposits, err := fetchWithHistory(
+	results, err := fetchWithHistory(
 		ctx,
 		c.baseURL,
 		accountID,
 		"deposits",
 		since,
 		c.createDepositPageFetcher(accountUUID),
-		func(d *models.TransferInput) time.Time { return d.Timestamp },
+		func(d depositWithPrice) time.Time { return d.transfer.Timestamp },
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Sort by timestamp (oldest first)
-	sort.Slice(deposits, func(i, j int) bool {
-		return deposits[i].Timestamp.Before(deposits[j].Timestamp)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].transfer.Timestamp.Before(results[j].transfer.Timestamp)
 	})
 
-	return deposits, nil
+	// Separate into transfers and prices
+	deposits := make([]*models.TransferInput, 0, len(results))
+	var prices []*models.PriceRecord
+	for _, r := range results {
+		deposits = append(deposits, r.transfer)
+		if r.price != nil {
+			prices = append(prices, r.price)
+		}
+	}
+
+	return deposits, prices, nil
 }
 
 // Page fetcher factories - these create page fetchers for each data type
 
-func (c *Client) createTradePageFetcher(accountUUID uuid.UUID) pageFetcher[*models.TradeInput] {
-	return func(ctx context.Context, url string) (pageResult[*models.TradeInput], error) {
+func (c *Client) createTradePageFetcher(accountUUID uuid.UUID) pageFetcher[tradeWithPrices] {
+	return func(ctx context.Context, url string) (pageResult[tradeWithPrices], error) {
 		resp, err := c.doRequestWithRetry(ctx, url)
 		if err != nil {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("failed to fetch trades: %w", err)
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("failed to fetch trades: %w", err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
 		}
 
 		var response driftTradesResponse
 		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("failed to decode response: %w", err)
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("failed to decode response: %w", err)
 		}
 
 		if !response.Success {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("API returned success=false")
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned success=false")
 		}
 
-		trades := make([]*models.TradeInput, 0, len(response.Records))
+		results := make([]tradeWithPrices, 0, len(response.Records))
 		for _, record := range response.Records {
-			trade, err := c.transformTrade(ctx, record, accountUUID)
+			trade, price, err := c.transformTrade(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[*models.TradeInput]{}, fmt.Errorf("failed to transform trade: %w", err)
+				return pageResult[tradeWithPrices]{}, fmt.Errorf("failed to transform trade: %w", err)
 			}
-			trades = append(trades, trade)
+			var prices []*models.PriceRecord
+			if price != nil {
+				prices = []*models.PriceRecord{price}
+			}
+			results = append(results, tradeWithPrices{trade: trade, prices: prices})
 		}
 
-		return pageResult[*models.TradeInput]{
-			items:    trades,
+		return pageResult[tradeWithPrices]{
+			items:    results,
 			nextPage: extractNextPage(response.Meta),
 		}, nil
 	}
 }
 
-func (c *Client) createSwapPageFetcher(accountUUID uuid.UUID) pageFetcher[*models.TradeInput] {
-	return func(ctx context.Context, url string) (pageResult[*models.TradeInput], error) {
+func (c *Client) createSwapPageFetcher(accountUUID uuid.UUID) pageFetcher[tradeWithPrices] {
+	return func(ctx context.Context, url string) (pageResult[tradeWithPrices], error) {
 		resp, err := c.doRequestWithRetry(ctx, url)
 		if err != nil {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("failed to fetch swaps: %w", err)
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("failed to fetch swaps: %w", err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
 		}
 
 		var response driftSwapsResponse
 		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("failed to decode response: %w", err)
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("failed to decode response: %w", err)
 		}
 
 		if !response.Success {
-			return pageResult[*models.TradeInput]{}, fmt.Errorf("API returned success=false")
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned success=false")
 		}
 
-		swaps := make([]*models.TradeInput, 0, len(response.Records))
+		results := make([]tradeWithPrices, 0, len(response.Records))
 		for _, record := range response.Records {
-			swap := c.transformSwap(record, accountUUID)
-			swaps = append(swaps, swap)
+			swap, prices := c.transformSwap(record, accountUUID)
+			results = append(results, tradeWithPrices{trade: swap, prices: prices})
 		}
 
-		return pageResult[*models.TradeInput]{
-			items:    swaps,
+		return pageResult[tradeWithPrices]{
+			items:    results,
 			nextPage: extractNextPage(response.Meta),
 		}, nil
 	}
@@ -354,38 +392,38 @@ func (c *Client) createFundingPageFetcher(accountUUID uuid.UUID) pageFetcher[*mo
 	}
 }
 
-func (c *Client) createDepositPageFetcher(accountUUID uuid.UUID) pageFetcher[*models.TransferInput] {
-	return func(ctx context.Context, url string) (pageResult[*models.TransferInput], error) {
+func (c *Client) createDepositPageFetcher(accountUUID uuid.UUID) pageFetcher[depositWithPrice] {
+	return func(ctx context.Context, url string) (pageResult[depositWithPrice], error) {
 		resp, err := c.doRequestWithRetry(ctx, url)
 		if err != nil {
-			return pageResult[*models.TransferInput]{}, fmt.Errorf("failed to fetch deposits: %w", err)
+			return pageResult[depositWithPrice]{}, fmt.Errorf("failed to fetch deposits: %w", err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[*models.TransferInput]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[depositWithPrice]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
 		}
 
 		var response driftDepositsResponse
 		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-			return pageResult[*models.TransferInput]{}, fmt.Errorf("failed to decode response: %w", err)
+			return pageResult[depositWithPrice]{}, fmt.Errorf("failed to decode response: %w", err)
 		}
 
 		if !response.Success {
-			return pageResult[*models.TransferInput]{}, fmt.Errorf("API returned success=false")
+			return pageResult[depositWithPrice]{}, fmt.Errorf("API returned success=false")
 		}
 
-		deposits := make([]*models.TransferInput, 0, len(response.Records))
+		results := make([]depositWithPrice, 0, len(response.Records))
 		for _, record := range response.Records {
-			deposit, err := c.transformDeposit(ctx, record, accountUUID)
+			transfer, price, err := c.transformDeposit(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[*models.TransferInput]{}, fmt.Errorf("failed to transform deposit: %w", err)
+				return pageResult[depositWithPrice]{}, fmt.Errorf("failed to transform deposit: %w", err)
 			}
-			deposits = append(deposits, deposit)
+			results = append(results, depositWithPrice{transfer: transfer, price: price})
 		}
 
-		return pageResult[*models.TransferInput]{
-			items:    deposits,
+		return pageResult[depositWithPrice]{
+			items:    results,
 			nextPage: extractNextPage(response.Meta),
 		}, nil
 	}
@@ -522,7 +560,7 @@ func extractNextPage(meta driftMeta) string {
 
 // Transform functions - convert API records to model types
 
-func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, accountUUID uuid.UUID) (*models.TradeInput, error) {
+func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, accountUUID uuid.UUID) (*models.TradeInput, *models.PriceRecord, error) {
 	isTaker := record.User == record.Taker
 
 	var direction string
@@ -559,7 +597,7 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 		marketType = "perp"
 	}
 
-	return &models.TradeInput{
+	trade := &models.TradeInput{
 		TradeID:           record.FillRecordID,
 		OrderID:           orderID,
 		BaseAsset:         baseAsset,
@@ -571,10 +609,24 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 		Timestamp:         timestamp,
 		ExchangeAccountID: accountUUID,
 		MarketType:        marketType,
-	}, nil
+	}
+
+	// Extract oracle price if available
+	var priceRecord *models.PriceRecord
+	if record.OraclePrice != "" && record.OraclePrice != "0" {
+		priceRecord = &models.PriceRecord{
+			Asset:        baseAsset,
+			Denomination: quoteAsset,
+			Timestamp:    timestamp,
+			Price:        record.OraclePrice,
+			Source:       "oracle",
+		}
+	}
+
+	return trade, priceRecord, nil
 }
 
-func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) *models.TradeInput {
+func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) (*models.TradeInput, []*models.PriceRecord) {
 	amountIn := cleanDecimalString(record.AmountIn)
 	amountOut := cleanDecimalString(record.AmountOut)
 	fee := cleanDecimalString(record.Fee)
@@ -604,7 +656,7 @@ func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) *m
 	timestamp := time.Unix(record.Ts, 0).UTC()
 	tradeID := fmt.Sprintf("swap_%s_%d", record.TxSig, record.TxSigIndex)
 
-	return &models.TradeInput{
+	trade := &models.TradeInput{
 		TradeID:           tradeID,
 		OrderID:           record.TxSig,
 		BaseAsset:         baseAsset,
@@ -617,6 +669,29 @@ func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) *m
 		ExchangeAccountID: accountUUID,
 		MarketType:        "swap",
 	}
+
+	// Extract oracle prices for both sides of the swap
+	var prices []*models.PriceRecord
+	if record.OutOraclePrice != "" && record.OutOraclePrice != "0" {
+		prices = append(prices, &models.PriceRecord{
+			Asset:        record.OutSymbol,
+			Denomination: oracleDenomination,
+			Timestamp:    timestamp,
+			Price:        record.OutOraclePrice,
+			Source:       "oracle",
+		})
+	}
+	if record.InOraclePrice != "" && record.InOraclePrice != "0" {
+		prices = append(prices, &models.PriceRecord{
+			Asset:        record.InSymbol,
+			Denomination: oracleDenomination,
+			Timestamp:    timestamp,
+			Price:        record.InOraclePrice,
+			Source:       "oracle",
+		})
+	}
+
+	return trade, prices
 }
 
 func (c *Client) transformFundingPayment(ctx context.Context, record driftFundingPayment, accountUUID uuid.UUID) (*models.TransferInput, error) {
@@ -642,10 +717,10 @@ func (c *Client) transformFundingPayment(ctx context.Context, record driftFundin
 	}, nil
 }
 
-func (c *Client) transformDeposit(ctx context.Context, record driftDepositRecord, accountUUID uuid.UUID) (*models.TransferInput, error) {
+func (c *Client) transformDeposit(ctx context.Context, record driftDepositRecord, accountUUID uuid.UUID) (*models.TransferInput, *models.PriceRecord, error) {
 	marketInfo, err := c.getMarketInfo(ctx, record.MarketIndex, "spot")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get market info for index %d: %w", record.MarketIndex, err)
+		return nil, nil, fmt.Errorf("failed to get market info for index %d: %w", record.MarketIndex, err)
 	}
 
 	amount := cleanDecimalString(record.Amount)
@@ -657,13 +732,27 @@ func (c *Client) transformDeposit(ctx context.Context, record driftDepositRecord
 		transferType = models.TypeWithdraw
 	}
 
-	return &models.TransferInput{
+	transfer := &models.TransferInput{
 		ExchangeAccountID: accountUUID,
 		Asset:             marketInfo.BaseAsset,
 		Type:              transferType,
 		Amount:            amount,
 		Timestamp:         timestamp,
-	}, nil
+	}
+
+	// Extract oracle price if available
+	var priceRecord *models.PriceRecord
+	if record.OraclePrice != "" && record.OraclePrice != "0" {
+		priceRecord = &models.PriceRecord{
+			Asset:        marketInfo.BaseAsset,
+			Denomination: oracleDenomination,
+			Timestamp:    timestamp,
+			Price:        record.OraclePrice,
+			Source:       "oracle",
+		}
+	}
+
+	return transfer, priceRecord, nil
 }
 
 // Helper functions

--- a/exchange/drift/client_test.go
+++ b/exchange/drift/client_test.go
@@ -62,6 +62,7 @@ func TestDriftClient_FetchTrades_Success(t *testing.T) {
 					Symbol:                 "SOL-PERP",
 					MarketIndex:            0,
 					MarketType:             "perp",
+					OraclePrice:            "50.123456",
 				},
 				{
 					Ts:                     time.Now().Unix() - 5,
@@ -81,6 +82,7 @@ func TestDriftClient_FetchTrades_Success(t *testing.T) {
 					Symbol:                 "BTC-PERP",
 					MarketIndex:            1,
 					MarketType:             "perp",
+					OraclePrice:            "68131.590312",
 				},
 			},
 			Meta: driftMeta{NextPage: nil},
@@ -106,7 +108,7 @@ func TestDriftClient_FetchTrades_Success(t *testing.T) {
 	// Use a recent since time (within 31 days) to avoid historical month fetching
 	// which would hit the mock server multiple times
 	since := time.Now().AddDate(0, 0, -30)
-	trades, err := client.FetchTrades(ctx, account, since)
+	trades, _, err := client.FetchTrades(ctx, account, since)
 	if err != nil {
 		t.Fatalf("FetchTrades failed: %v", err)
 	}
@@ -224,7 +226,7 @@ func TestDriftClient_FetchTrades_Pagination(t *testing.T) {
 	ctx := context.Background()
 	// Use a recent since time (within last 31 days) to avoid historical backfilling
 	recentSince := time.Now().Add(-7 * 24 * time.Hour)
-	trades, err := client.FetchTrades(ctx, account, recentSince)
+	trades, _, err := client.FetchTrades(ctx, account, recentSince)
 	if err != nil {
 		t.Fatalf("FetchTrades failed: %v", err)
 	}
@@ -262,7 +264,7 @@ func TestDriftClient_FetchTrades_RateLimit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	_, err := client.FetchTrades(ctx, account, time.Now().Add(-24*time.Hour)) // Recent since to avoid historical fetch
+	_, _, err := client.FetchTrades(ctx, account, time.Now().Add(-24*time.Hour)) // Recent since to avoid historical fetch
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -295,7 +297,7 @@ func TestDriftClient_FetchTrades_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, err := client.FetchTrades(ctx, account, time.Time{})
+	_, _, err := client.FetchTrades(ctx, account, time.Time{})
 	if err == nil {
 		t.Fatal("Expected error due to context cancellation")
 	}
@@ -365,7 +367,7 @@ func TestDriftClient_FetchTrades_FiltersBySince(t *testing.T) {
 
 	ctx := context.Background()
 	since := now.Add(-10 * time.Second)
-	trades, err := client.FetchTrades(ctx, account, since)
+	trades, _, err := client.FetchTrades(ctx, account, since)
 	if err != nil {
 		t.Fatalf("FetchTrades failed: %v", err)
 	}
@@ -388,7 +390,7 @@ func TestDriftClient_FetchTrades_InvalidAccountID(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err := client.FetchTrades(ctx, account, time.Time{})
+	_, _, err := client.FetchTrades(ctx, account, time.Time{})
 	if err == nil {
 		t.Fatal("Expected error for invalid account ID")
 	}
@@ -402,7 +404,7 @@ func TestDriftClient_FetchTrades_EmptyAccountIdentifier(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err := client.FetchTrades(ctx, account, time.Time{})
+	_, _, err := client.FetchTrades(ctx, account, time.Time{})
 	if err == nil {
 		t.Fatal("Expected error for empty account identifier")
 	}
@@ -758,7 +760,7 @@ func TestDriftClient_FetchTrades_WithSwaps(t *testing.T) {
 	ctx := context.Background()
 	// Use a recent since time (within 31 days) to avoid historical month fetching
 	since := time.Now().AddDate(0, 0, -30)
-	trades, err := client.FetchTrades(ctx, account, since)
+	trades, prices, err := client.FetchTrades(ctx, account, since)
 	if err != nil {
 		t.Fatalf("FetchTrades failed: %v", err)
 	}
@@ -813,6 +815,40 @@ func TestDriftClient_FetchTrades_WithSwaps(t *testing.T) {
 	if trades[0].MarketType != "swap" {
 		t.Error("Expected swap trade to be first (oldest)")
 	}
+
+	// Verify oracle prices from swap
+	// Swap has OutOraclePrice="100.000000" (SOL) and InOraclePrice="1.000000" (USDC)
+	if len(prices) != 2 {
+		t.Fatalf("Expected 2 oracle prices from swap, got %d", len(prices))
+	}
+	// Find SOL price
+	var solPrice, usdcPrice *models.PriceRecord
+	for _, p := range prices {
+		if p.Asset == "SOL" {
+			solPrice = p
+		}
+		if p.Asset == "USDC" {
+			usdcPrice = p
+		}
+	}
+	if solPrice == nil {
+		t.Fatal("Expected SOL oracle price")
+	}
+	if solPrice.Price != "100.000000" {
+		t.Errorf("Expected SOL oracle price '100.000000', got '%s'", solPrice.Price)
+	}
+	if solPrice.Denomination != "USDC" {
+		t.Errorf("Expected denomination 'USDC', got '%s'", solPrice.Denomination)
+	}
+	if solPrice.Source != "oracle" {
+		t.Errorf("Expected source 'oracle', got '%s'", solPrice.Source)
+	}
+	if usdcPrice == nil {
+		t.Fatal("Expected USDC oracle price")
+	}
+	if usdcPrice.Price != "1.000000" {
+		t.Errorf("Expected USDC oracle price '1.000000', got '%s'", usdcPrice.Price)
+	}
 }
 
 func TestTransformSwap(t *testing.T) {
@@ -838,7 +874,7 @@ func TestTransformSwap(t *testing.T) {
 			InSymbol:       "USDC", // User spends USDC
 		}
 
-		trade := client.transformSwap(record, accountUUID)
+		trade, _ := client.transformSwap(record, accountUUID)
 
 		if trade.BaseAsset != "SOL" {
 			t.Errorf("Expected base asset 'SOL', got '%s'", trade.BaseAsset)
@@ -879,7 +915,7 @@ func TestTransformSwap(t *testing.T) {
 			InSymbol:       "SOL",  // User spends SOL
 		}
 
-		trade := client.transformSwap(record, accountUUID)
+		trade, _ := client.transformSwap(record, accountUUID)
 
 		if trade.BaseAsset != "SOL" {
 			t.Errorf("Expected base asset 'SOL', got '%s'", trade.BaseAsset)
@@ -920,7 +956,7 @@ func TestTransformSwap(t *testing.T) {
 			InSymbol:       "SOL",  // User spends SOL
 		}
 
-		trade := client.transformSwap(record, accountUUID)
+		trade, _ := client.transformSwap(record, accountUUID)
 
 		// For non-USDC swaps, outSymbol (received) is base, inSymbol (spent) is quote
 		if trade.BaseAsset != "mSOL" {
@@ -1015,7 +1051,7 @@ func TestDriftClient_FetchDeposits_Success(t *testing.T) {
 
 	// Use a recent since time (within 31 days) to avoid historical month fetching
 	since := time.Now().AddDate(0, 0, -30)
-	transfers, err := client.FetchDeposits(context.Background(), account, since)
+	transfers, _, err := client.FetchDeposits(context.Background(), account, since)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1049,7 +1085,7 @@ func TestDriftClient_FetchDeposits_InvalidAccountID(t *testing.T) {
 		AccountIdentifier: "test-account",
 	}
 
-	_, err := client.FetchDeposits(context.Background(), account, time.Time{})
+	_, _, err := client.FetchDeposits(context.Background(), account, time.Time{})
 	if err == nil {
 		t.Error("Expected error for invalid account ID")
 	}
@@ -1063,7 +1099,7 @@ func TestDriftClient_FetchDeposits_EmptyAccountIdentifier(t *testing.T) {
 		AccountIdentifier: "",
 	}
 
-	_, err := client.FetchDeposits(context.Background(), account, time.Time{})
+	_, _, err := client.FetchDeposits(context.Background(), account, time.Time{})
 	if err == nil {
 		t.Error("Expected error for empty account identifier")
 	}
@@ -1142,7 +1178,7 @@ func TestDriftClient_FetchDeposits_FiltersBySince(t *testing.T) {
 
 	// Filter to only get deposits after sinceTimestamp
 	since := time.Unix(sinceTimestamp, 0)
-	transfers, err := client.FetchDeposits(context.Background(), account, since)
+	transfers, _, err := client.FetchDeposits(context.Background(), account, since)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1167,7 +1203,7 @@ func TestDriftClient_FetchDeposits_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, err := client.FetchDeposits(ctx, account, time.Time{})
+	_, _, err := client.FetchDeposits(ctx, account, time.Time{})
 	if err == nil {
 		t.Error("Expected error for cancelled context")
 	}
@@ -1255,7 +1291,7 @@ func TestDriftClient_HistoricalFetchFiltersOverlap(t *testing.T) {
 
 	// Request data from before the 31-day window to trigger historical fetch
 	since := thirtyOneDaysAgo.Add(-72 * time.Hour) // 3 days before the 31-day window
-	deposits, err := client.FetchDeposits(context.Background(), account, since)
+	deposits, _, err := client.FetchDeposits(context.Background(), account, since)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1306,5 +1342,294 @@ func TestDriftClient_HistoricalFetchFiltersOverlap(t *testing.T) {
 	}
 	if hasOverlap {
 		t.Error("Overlapping transfer should have been filtered out")
+	}
+}
+
+func TestDriftClient_FetchTrades_OraclePrices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, "/swaps") {
+			json.NewEncoder(w).Encode(driftSwapsResponse{
+				Success: true,
+				Records: []driftSwapRecord{},
+				Meta:    driftMeta{NextPage: nil},
+			})
+			return
+		}
+
+		response := driftTradesResponse{
+			Success: true,
+			Records: []driftTradeRecord{
+				{
+					Ts:                     time.Now().Unix() - 10,
+					FillRecordID:           "fill-with-oracle",
+					BaseAssetAmountFilled:  "1.000000000",
+					QuoteAssetAmountFilled: "50.000000",
+					TakerFee:               "0.050000",
+					TakerOrderDirection:    "long",
+					Taker:                  "test-account",
+					User:                   "test-account",
+					Symbol:                 "SOL-PERP",
+					MarketType:             "perp",
+					OraclePrice:            "50.123456",
+				},
+				{
+					Ts:                     time.Now().Unix() - 5,
+					FillRecordID:           "fill-no-oracle",
+					BaseAssetAmountFilled:  "2.000000000",
+					QuoteAssetAmountFilled: "100.000000",
+					TakerFee:               "0.100000",
+					TakerOrderDirection:    "short",
+					Taker:                  "test-account",
+					User:                   "test-account",
+					Symbol:                 "BTC-PERP",
+					MarketType:             "perp",
+					OraclePrice:            "", // Empty oracle price
+				},
+				{
+					Ts:                     time.Now().Unix() - 3,
+					FillRecordID:           "fill-zero-oracle",
+					BaseAssetAmountFilled:  "0.500000000",
+					QuoteAssetAmountFilled: "25.000000",
+					TakerFee:               "0.025000",
+					TakerOrderDirection:    "long",
+					Taker:                  "test-account",
+					User:                   "test-account",
+					Symbol:                 "ETH-PERP",
+					MarketType:             "perp",
+					OraclePrice:            "0", // Zero oracle price
+				},
+			},
+			Meta: driftMeta{NextPage: nil},
+		}
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	ctx := context.Background()
+	since := time.Now().AddDate(0, 0, -30)
+	trades, prices, err := client.FetchTrades(ctx, account, since)
+	if err != nil {
+		t.Fatalf("FetchTrades failed: %v", err)
+	}
+
+	if len(trades) != 3 {
+		t.Fatalf("Expected 3 trades, got %d", len(trades))
+	}
+
+	// Only one trade has a valid oracle price
+	if len(prices) != 1 {
+		t.Fatalf("Expected 1 oracle price (empty and zero should be skipped), got %d", len(prices))
+	}
+
+	p := prices[0]
+	if p.Asset != "SOL" {
+		t.Errorf("Expected oracle price asset 'SOL', got '%s'", p.Asset)
+	}
+	if p.Denomination != "USDC" {
+		t.Errorf("Expected oracle price denomination 'USDC', got '%s'", p.Denomination)
+	}
+	if p.Price != "50.123456" {
+		t.Errorf("Expected oracle price '50.123456', got '%s'", p.Price)
+	}
+	if p.Source != "oracle" {
+		t.Errorf("Expected source 'oracle', got '%s'", p.Source)
+	}
+	if p.Timestamp.IsZero() {
+		t.Error("Expected non-zero timestamp on oracle price")
+	}
+}
+
+func TestTransformSwap_OraclePrices(t *testing.T) {
+	client := NewClient()
+	accountUUID := uuid.New()
+
+	t.Run("swap with oracle prices", func(t *testing.T) {
+		record := driftSwapRecord{
+			Ts:             1700000000,
+			TxSig:          "test-tx",
+			TxSigIndex:     0,
+			OutSymbol:      "SOL",
+			InSymbol:       "USDC",
+			AmountOut:      "2.500000",
+			AmountIn:       "200.000000",
+			OutOraclePrice: "80.000000",
+			InOraclePrice:  "1.000000",
+			Fee:            "0.200000",
+		}
+
+		_, prices := client.transformSwap(record, accountUUID)
+		if len(prices) != 2 {
+			t.Fatalf("Expected 2 oracle prices, got %d", len(prices))
+		}
+
+		// Both prices should use the oracleDenomination constant
+		for _, p := range prices {
+			if p.Denomination != oracleDenomination {
+				t.Errorf("Expected denomination '%s', got '%s'", oracleDenomination, p.Denomination)
+			}
+			if p.Source != "oracle" {
+				t.Errorf("Expected source 'oracle', got '%s'", p.Source)
+			}
+		}
+	})
+
+	t.Run("swap with empty oracle prices", func(t *testing.T) {
+		record := driftSwapRecord{
+			Ts:             1700000000,
+			TxSig:          "test-tx-2",
+			TxSigIndex:     0,
+			OutSymbol:      "SOL",
+			InSymbol:       "USDC",
+			AmountOut:      "1.000000",
+			AmountIn:       "100.000000",
+			OutOraclePrice: "",
+			InOraclePrice:  "",
+			Fee:            "0.100000",
+		}
+
+		_, prices := client.transformSwap(record, accountUUID)
+		if len(prices) != 0 {
+			t.Errorf("Expected 0 oracle prices for empty values, got %d", len(prices))
+		}
+	})
+
+	t.Run("swap with zero oracle prices", func(t *testing.T) {
+		record := driftSwapRecord{
+			Ts:             1700000000,
+			TxSig:          "test-tx-3",
+			TxSigIndex:     0,
+			OutSymbol:      "SOL",
+			InSymbol:       "USDC",
+			AmountOut:      "1.000000",
+			AmountIn:       "100.000000",
+			OutOraclePrice: "0",
+			InOraclePrice:  "0",
+			Fee:            "0.100000",
+		}
+
+		_, prices := client.transformSwap(record, accountUUID)
+		if len(prices) != 0 {
+			t.Errorf("Expected 0 oracle prices for zero values, got %d", len(prices))
+		}
+	})
+
+	t.Run("swap with partial oracle prices", func(t *testing.T) {
+		record := driftSwapRecord{
+			Ts:             1700000000,
+			TxSig:          "test-tx-4",
+			TxSigIndex:     0,
+			OutSymbol:      "SOL",
+			InSymbol:       "USDC",
+			AmountOut:      "1.000000",
+			AmountIn:       "100.000000",
+			OutOraclePrice: "80.000000",
+			InOraclePrice:  "", // Missing
+			Fee:            "0.100000",
+		}
+
+		_, prices := client.transformSwap(record, accountUUID)
+		if len(prices) != 1 {
+			t.Fatalf("Expected 1 oracle price, got %d", len(prices))
+		}
+		if prices[0].Asset != "SOL" {
+			t.Errorf("Expected asset 'SOL', got '%s'", prices[0].Asset)
+		}
+	})
+}
+
+func TestDriftClient_FetchDeposits_OraclePrices(t *testing.T) {
+	now := time.Now()
+	depositTs := now.Add(-10 * 24 * time.Hour).Unix()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/stats/markets") {
+			response := `{
+				"success": true,
+				"markets": [
+					{"marketIndex": 1, "symbol": "SOL", "baseAsset": "SOL", "quoteAsset": "USDC", "marketType": "spot"}
+				]
+			}`
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(response))
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/deposits") {
+			response := fmt.Sprintf(`{
+				"success": true,
+				"records": [
+					{
+						"ts": %d,
+						"txSig": "test-tx-1",
+						"slot": 12345,
+						"amount": "10.000000",
+						"marketIndex": 1,
+						"depositRecordId": "deposit-1",
+						"direction": "deposit",
+						"oraclePrice": "145.678900",
+						"user": "test-user"
+					}
+				],
+				"meta": {"nextPage": null}
+			}`, depositTs)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(response))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:     server.URL,
+		httpClient:  &http.Client{Timeout: 10 * time.Second},
+		marketCache: newMarketCache(1 * time.Hour),
+	}
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "test-account",
+	}
+
+	since := time.Now().AddDate(0, 0, -30)
+	transfers, prices, err := client.FetchDeposits(context.Background(), account, since)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(transfers) != 1 {
+		t.Fatalf("Expected 1 transfer, got %d", len(transfers))
+	}
+
+	if len(prices) != 1 {
+		t.Fatalf("Expected 1 oracle price, got %d", len(prices))
+	}
+
+	p := prices[0]
+	if p.Asset != "SOL" {
+		t.Errorf("Expected asset 'SOL', got '%s'", p.Asset)
+	}
+	if p.Denomination != "USDC" {
+		t.Errorf("Expected denomination 'USDC', got '%s'", p.Denomination)
+	}
+	if p.Price != "145.678900" {
+		t.Errorf("Expected price '145.678900', got '%s'", p.Price)
+	}
+	if p.Source != "oracle" {
+		t.Errorf("Expected source 'oracle', got '%s'", p.Source)
 	}
 }

--- a/exchange/iface/client.go
+++ b/exchange/iface/client.go
@@ -14,12 +14,13 @@ type ExchangeClient interface {
 
 	// FetchTrades fetches trades for a given account since a specific timestamp
 	// Returns trades as TradeInput (ready for database insertion), sorted by timestamp (oldest first)
+	// Also returns oracle PriceRecords observed at trade/swap time (may be nil if exchange has no oracle data)
 	// ctx can be cancelled or have a timeout set by the caller (sync service)
 	FetchTrades(
 		ctx context.Context,
 		account *models.ExchangeAccount,
 		since time.Time,
-	) ([]*models.TradeInput, error)
+	) ([]*models.TradeInput, []*models.PriceRecord, error)
 
 	// FetchFundingPayments fetches funding payments for a given account since a specific timestamp
 	// Returns funding payments as TransferInput with type="funding", sorted by timestamp (oldest first)
@@ -42,12 +43,13 @@ type ExchangeClient interface {
 
 	// FetchDeposits fetches deposits and withdrawals for a given account since a specific timestamp
 	// Returns transfers as TransferInput (ready for database insertion), sorted by timestamp (oldest first)
+	// Also returns oracle PriceRecords observed at deposit/withdraw time (may be nil if exchange has no oracle data)
 	// ctx can be cancelled or have a timeout set by the caller (sync service)
 	FetchDeposits(
 		ctx context.Context,
 		account *models.ExchangeAccount,
 		since time.Time,
-	) ([]*models.TransferInput, error)
+	) ([]*models.TransferInput, []*models.PriceRecord, error)
 
 	// FetchBalances fetches current spot balances for a given account
 	FetchBalances(

--- a/exchange/iface/contract.go
+++ b/exchange/iface/contract.go
@@ -35,7 +35,7 @@ func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContrac
 		defer cancel()
 
 		// Should not error with valid account (even if no trades)
-		trades, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		trades, _, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
 		if err != nil {
 			t.Errorf("FetchTrades with valid account should not error: %v", err)
 		}
@@ -53,7 +53,7 @@ func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContrac
 			defer cancel()
 
 			// Should error with invalid account
-			_, err := client.FetchTrades(ctx, contract.InvalidAccount, time.Time{})
+			_, _, err := client.FetchTrades(ctx, contract.InvalidAccount, time.Time{})
 			if err == nil {
 				t.Error("FetchTrades with invalid account should error")
 			}
@@ -66,7 +66,7 @@ func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContrac
 		cancel() // Cancel immediately
 
 		// Should respect context cancellation
-		_, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		_, _, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
 		if err == nil {
 			t.Error("FetchTrades should respect context cancellation")
 		}
@@ -81,7 +81,7 @@ func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContrac
 		defer cancel()
 
 		// Should timeout (or return error quickly)
-		_, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		_, _, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
 		if err == nil {
 			t.Error("FetchTrades should respect timeout")
 		}
@@ -93,7 +93,7 @@ func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContrac
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		trades, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		trades, _, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
 		if err != nil {
 			t.Skip("Skipping sort test due to error:", err)
 		}
@@ -116,7 +116,7 @@ func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContrac
 		defer cancel()
 
 		// Fetch all trades
-		allTrades, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
+		allTrades, _, err := client.FetchTrades(ctx, contract.ValidAccount, time.Time{})
 		if err != nil {
 			t.Skip("Skipping filter test due to error:", err)
 		}
@@ -130,7 +130,7 @@ func RunExchangeClientContractTests(t *testing.T, contract ExchangeClientContrac
 		since := allTrades[middleIdx].Timestamp
 
 		// Fetch trades since that timestamp
-		filteredTrades, err := client.FetchTrades(ctx, contract.ValidAccount, since)
+		filteredTrades, _, err := client.FetchTrades(ctx, contract.ValidAccount, since)
 		if err != nil {
 			t.Fatalf("Failed to fetch filtered trades: %v", err)
 		}

--- a/models/event_value.go
+++ b/models/event_value.go
@@ -1,6 +1,12 @@
 package models
 
-import "github.com/google/uuid"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
 
 // EventValue represents a computed monetary value for an event in a specific denomination.
 // Maps to the 'event_values' table.
@@ -10,6 +16,31 @@ type EventValue struct {
 	EventType    string    `json:"event_type"`    // "trade", "transfer", "settlement"
 	Denomination string    `json:"denomination"`  // e.g. "USDC"
 	Quantity     string    `json:"quantity"`       // NUMERIC(36,18)
+}
+
+// UnmarshalJSON handles Hasura returning NUMERIC fields as JSON numbers.
+func (ev *EventValue) UnmarshalJSON(data []byte) error {
+	type Alias EventValue
+	aux := &struct {
+		Quantity interface{} `json:"quantity"`
+		*Alias
+	}{
+		Alias: (*Alias)(ev),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Quantity != nil {
+		switch val := aux.Quantity.(type) {
+		case string:
+			ev.Quantity = val
+		case float64:
+			ev.Quantity = strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.18f", val), "0"), ".")
+		default:
+			ev.Quantity = fmt.Sprintf("%v", val)
+		}
+	}
+	return nil
 }
 
 // EventValueInput represents input for creating an event value record.

--- a/models/position.go
+++ b/models/position.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -85,6 +86,31 @@ type PositionEvent struct {
 	Direction  string    `json:"direction"`   // "entry", "exit", "received", "paid"
 	Quantity   string    `json:"quantity"`
 	CreatedAt  time.Time `json:"created_at"`
+}
+
+// UnmarshalJSON handles Hasura returning NUMERIC fields as JSON numbers.
+func (pe *PositionEvent) UnmarshalJSON(data []byte) error {
+	type Alias PositionEvent
+	aux := &struct {
+		Quantity interface{} `json:"quantity"`
+		*Alias
+	}{
+		Alias: (*Alias)(pe),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Quantity != nil {
+		switch val := aux.Quantity.(type) {
+		case string:
+			pe.Quantity = val
+		case float64:
+			pe.Quantity = strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.18f", val), "0"), ".")
+		default:
+			pe.Quantity = fmt.Sprintf("%v", val)
+		}
+	}
+	return nil
 }
 
 // PositionEventInput for batch inserts

--- a/models/position_pnl.go
+++ b/models/position_pnl.go
@@ -1,0 +1,17 @@
+package models
+
+import "github.com/google/uuid"
+
+// PositionPnLInput represents input for inserting a position PnL record.
+type PositionPnLInput struct {
+	PositionID   uuid.UUID `json:"position_id"`
+	Denomination string    `json:"denomination"`
+	RealizedPnL  string    `json:"realized_pnl"` // NUMERIC(36,18) as string
+}
+
+// MissingPositionPnL represents a closed position that does not yet have
+// a PnL row for a given denomination. Returned by the missing_position_pnl view.
+type MissingPositionPnL struct {
+	PositionID   uuid.UUID `json:"position_id"`
+	Denomination string    `json:"denomination"`
+}

--- a/models/price.go
+++ b/models/price.go
@@ -1,0 +1,65 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PriceRecord represents a price observation from an exchange (e.g., oracle price at fill time).
+// Exchange clients return these alongside events — the denomination is declared by the exchange,
+// not assumed (Drift oracles are in USDC, other exchanges may differ).
+type PriceRecord struct {
+	Asset        string
+	Denomination string
+	Timestamp    time.Time
+	Price        string
+	Source       string
+}
+
+// PriceInput is the input for writing to price_cache via GraphQL.
+type PriceInput struct {
+	Asset        string
+	Denomination string
+	TimestampMs  int64
+	Price        string
+	Source       string
+}
+
+// Price represents a row from the price_cache table.
+type Price struct {
+	Asset        string `json:"asset"`
+	Denomination string `json:"denomination"`
+	Timestamp    int64  `json:"timestamp"`
+	Price        string `json:"price"`
+	Source       string `json:"source"`
+}
+
+// UnmarshalJSON handles Hasura returning NUMERIC fields as JSON numbers.
+func (p *Price) UnmarshalJSON(data []byte) error {
+	type Alias Price
+	aux := &struct {
+		Price interface{} `json:"price"`
+		*Alias
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.Price != nil {
+		switch val := aux.Price.(type) {
+		case string:
+			p.Price = val
+		case float64:
+			p.Price = strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.18f", val), "0"), ".")
+		default:
+			p.Price = fmt.Sprintf("%v", val)
+		}
+	}
+
+	return nil
+}

--- a/models/unmarshal_test.go
+++ b/models/unmarshal_test.go
@@ -1,0 +1,181 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPrice_UnmarshalJSON_NumericAsFloat(t *testing.T) {
+	data := `{"asset":"SOL","denomination":"USDC","timestamp":1700000000000,"price":100.5,"source":"drift"}`
+	var p Price
+	if err := json.Unmarshal([]byte(data), &p); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if p.Price != "100.5" {
+		t.Errorf("Expected price '100.5', got '%s'", p.Price)
+	}
+	if p.Asset != "SOL" {
+		t.Errorf("Expected asset SOL, got %s", p.Asset)
+	}
+	if p.Denomination != "USDC" {
+		t.Errorf("Expected denomination USDC, got %s", p.Denomination)
+	}
+}
+
+func TestPrice_UnmarshalJSON_NumericAsString(t *testing.T) {
+	data := `{"asset":"BTC","denomination":"USDC","timestamp":1700000000000,"price":"43000.50","source":"drift"}`
+	var p Price
+	if err := json.Unmarshal([]byte(data), &p); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if p.Price != "43000.50" {
+		t.Errorf("Expected price '43000.50', got '%s'", p.Price)
+	}
+}
+
+func TestPrice_UnmarshalJSON_MixedFields(t *testing.T) {
+	// price as float64, other fields normal
+	data := `{"asset":"ETH","denomination":"BTC","timestamp":1700000000000,"price":0.05123,"source":"hyperliquid"}`
+	var p Price
+	if err := json.Unmarshal([]byte(data), &p); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if p.Price == "" {
+		t.Error("Expected non-empty price")
+	}
+	if p.Source != "hyperliquid" {
+		t.Errorf("Expected source hyperliquid, got %s", p.Source)
+	}
+	if p.Timestamp != 1700000000000 {
+		t.Errorf("Expected timestamp 1700000000000, got %d", p.Timestamp)
+	}
+}
+
+func TestPrice_UnmarshalJSON_WholeNumber(t *testing.T) {
+	// Whole number float should not have trailing decimals
+	data := `{"asset":"BTC","denomination":"USDC","timestamp":1700000000000,"price":50000.0,"source":"drift"}`
+	var p Price
+	if err := json.Unmarshal([]byte(data), &p); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if p.Price != "50000" {
+		t.Errorf("Expected price '50000', got '%s'", p.Price)
+	}
+}
+
+func TestPositionEvent_UnmarshalJSON_QuantityAsFloat(t *testing.T) {
+	data := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"position_id": "00000000-0000-0000-0000-000000000002",
+		"event_id": "00000000-0000-0000-0000-000000000003",
+		"event_type": "trade",
+		"direction": "entry",
+		"quantity": 25.5
+	}`
+	var pe PositionEvent
+	if err := json.Unmarshal([]byte(data), &pe); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if pe.Quantity != "25.5" {
+		t.Errorf("Expected quantity '25.5', got '%s'", pe.Quantity)
+	}
+	if pe.EventType != "trade" {
+		t.Errorf("Expected event_type trade, got %s", pe.EventType)
+	}
+	if pe.Direction != "entry" {
+		t.Errorf("Expected direction entry, got %s", pe.Direction)
+	}
+}
+
+func TestPositionEvent_UnmarshalJSON_QuantityAsString(t *testing.T) {
+	data := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"position_id": "00000000-0000-0000-0000-000000000002",
+		"event_id": "00000000-0000-0000-0000-000000000003",
+		"event_type": "transfer",
+		"direction": "exit",
+		"quantity": "100.75"
+	}`
+	var pe PositionEvent
+	if err := json.Unmarshal([]byte(data), &pe); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if pe.Quantity != "100.75" {
+		t.Errorf("Expected quantity '100.75', got '%s'", pe.Quantity)
+	}
+}
+
+func TestPositionEvent_UnmarshalJSON_WholeNumberQuantity(t *testing.T) {
+	data := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"position_id": "00000000-0000-0000-0000-000000000002",
+		"event_id": "00000000-0000-0000-0000-000000000003",
+		"event_type": "funding",
+		"direction": "paid",
+		"quantity": 100.0
+	}`
+	var pe PositionEvent
+	if err := json.Unmarshal([]byte(data), &pe); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if pe.Quantity != "100" {
+		t.Errorf("Expected quantity '100', got '%s'", pe.Quantity)
+	}
+}
+
+func TestEventValue_UnmarshalJSON_QuantityAsFloat(t *testing.T) {
+	data := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"event_id": "00000000-0000-0000-0000-000000000002",
+		"event_type": "trade",
+		"denomination": "USDC",
+		"quantity": 500.25
+	}`
+	var ev EventValue
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if ev.Quantity != "500.25" {
+		t.Errorf("Expected quantity '500.25', got '%s'", ev.Quantity)
+	}
+	if ev.EventType != "trade" {
+		t.Errorf("Expected event_type trade, got %s", ev.EventType)
+	}
+	if ev.Denomination != "USDC" {
+		t.Errorf("Expected denomination USDC, got %s", ev.Denomination)
+	}
+}
+
+func TestEventValue_UnmarshalJSON_QuantityAsString(t *testing.T) {
+	data := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"event_id": "00000000-0000-0000-0000-000000000002",
+		"event_type": "settlement",
+		"denomination": "BTC",
+		"quantity": "-150.75"
+	}`
+	var ev EventValue
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if ev.Quantity != "-150.75" {
+		t.Errorf("Expected quantity '-150.75', got '%s'", ev.Quantity)
+	}
+}
+
+func TestEventValue_UnmarshalJSON_WholeNumberQuantity(t *testing.T) {
+	data := `{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"event_id": "00000000-0000-0000-0000-000000000002",
+		"event_type": "transfer",
+		"denomination": "USDC",
+		"quantity": 1000.0
+	}`
+	var ev EventValue
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if ev.Quantity != "1000" {
+		t.Errorf("Expected quantity '1000', got '%s'", ev.Quantity)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `price_cache` models and DB methods for storing exchange oracle prices
- Add `position_pnl` models and DB methods for per-position realized PnL
- Extend `DBClient` interface with price and PnL methods
- Capture oracle prices from Drift (trades, swaps, deposits) instead of discarding them
- Fix NUMERIC deserialization from Hasura (float64 → string)

## Changes
- **Price cache**: `PriceRecord`, `PriceInput`, `Price` models. `AddPrices` (batch upsert with dedup), `GetNearestPrice` (tolerance-based lookup)
- **Position PnL**: `PositionPnLInput`, `MissingPositionPnL` models. `ListMissingPositionPnL`, `AddPositionPnL`, `GetPositionsByIDs`, `GetEventValuesByEventIDs`
- **Drift client**: `FetchTrades` and `FetchDeposits` now return `[]*PriceRecord` as second value. Oracle denomination is exchange-declared (not hardcoded)
- **NUMERIC fix**: Custom `UnmarshalJSON` on `EventValue`, `PositionEvent`, `Price` to handle Hasura returning NUMERIC as JSON numbers

## Test plan
- [x] Price cache DB method tests (6 tests)
- [x] Position PnL DB method tests (12 tests)
- [x] Drift oracle price extraction tests (4 test suites)
- [x] NUMERIC unmarshal tests (10 tests)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)