### PR TITLE
fix: prevent UNKNOWN market fallback in Drift client

### DIFF
--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/big"
 	"net/http"
 	"sort"
@@ -301,11 +302,15 @@ func (c *Client) createTradePageFetcher(accountUUID uuid.UUID) pageFetcher[trade
 			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned success=false")
 		}
 
+		// Pre-warm market cache before processing the batch
+		_ = c.ensureMarketCache(ctx)
+
 		results := make([]tradeWithPrices, 0, len(response.Records))
 		for _, record := range response.Records {
 			trade, price, err := c.transformTrade(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[tradeWithPrices]{}, fmt.Errorf("failed to transform trade: %w", err)
+				log.Printf("drift/trades: skipping trade %s (market resolution failed): %v", record.FillRecordID, err)
+				continue
 			}
 			var prices []*models.PriceRecord
 			if price != nil {
@@ -376,11 +381,15 @@ func (c *Client) createFundingPageFetcher(accountUUID uuid.UUID) pageFetcher[*mo
 			return pageResult[*models.TransferInput]{}, fmt.Errorf("API returned success=false")
 		}
 
+		// Pre-warm market cache before processing the batch
+		_ = c.ensureMarketCache(ctx)
+
 		payments := make([]*models.TransferInput, 0, len(response.Records))
 		for _, record := range response.Records {
 			payment, err := c.transformFundingPayment(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[*models.TransferInput]{}, fmt.Errorf("failed to transform funding payment: %w", err)
+				log.Printf("drift/funding: skipping payment at ts=%d (market resolution failed): %v", record.Ts, err)
+				continue
 			}
 			payments = append(payments, payment)
 		}
@@ -413,11 +422,15 @@ func (c *Client) createDepositPageFetcher(accountUUID uuid.UUID) pageFetcher[dep
 			return pageResult[depositWithPrice]{}, fmt.Errorf("API returned success=false")
 		}
 
+		// Pre-warm market cache before processing the batch
+		_ = c.ensureMarketCache(ctx)
+
 		results := make([]depositWithPrice, 0, len(response.Records))
 		for _, record := range response.Records {
 			transfer, price, err := c.transformDeposit(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[depositWithPrice]{}, fmt.Errorf("failed to transform deposit: %w", err)
+				log.Printf("drift/deposits: skipping deposit %s (market resolution failed): %v", record.DepositRecordID, err)
+				continue
 			}
 			results = append(results, depositWithPrice{transfer: transfer, price: price})
 		}

--- a/exchange/drift/client_test.go
+++ b/exchange/drift/client_test.go
@@ -14,6 +14,21 @@ import (
 	"github.com/zif-terminal/lib/models"
 )
 
+// marketsJSON is a minimal valid response for /stats/markets used by tests.
+const marketsJSON = `{"success":true,"markets":[{"marketIndex":0,"symbol":"SOL-PERP","baseAsset":"SOL","marketType":"perp"},{"marketIndex":1,"symbol":"BTC-PERP","baseAsset":"BTC","marketType":"perp"},{"marketIndex":2,"symbol":"ETH-PERP","baseAsset":"ETH","marketType":"perp"},{"marketIndex":0,"symbol":"USDC","baseAsset":"USDC","marketType":"spot"},{"marketIndex":1,"symbol":"SOL","baseAsset":"SOL","marketType":"spot"},{"marketIndex":2,"symbol":"mSOL","baseAsset":"mSOL","marketType":"spot"},{"marketIndex":3,"symbol":"wBTC","baseAsset":"wBTC","marketType":"spot"},{"marketIndex":4,"symbol":"wETH","baseAsset":"wETH","marketType":"spot"},{"marketIndex":5,"symbol":"USDT","baseAsset":"USDT","marketType":"spot"},{"marketIndex":13,"symbol":"bSOL","baseAsset":"bSOL","marketType":"spot"},{"marketIndex":19,"symbol":"JUP","baseAsset":"JUP","marketType":"spot"},{"marketIndex":27,"symbol":"FARTCOIN","baseAsset":"FARTCOIN","marketType":"spot"}]}`
+
+// withMarkets wraps an http.Handler to also serve /stats/markets.
+func withMarkets(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/stats/markets" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(marketsJSON))
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
 func TestDriftClient_Name(t *testing.T) {
 	client := NewClient()
 	if client.Name() != "drift" {
@@ -23,7 +38,7 @@ func TestDriftClient_Name(t *testing.T) {
 
 func TestDriftClient_FetchTrades_Success(t *testing.T) {
 	// Mock Drift API server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			t.Errorf("Expected GET, got %s", r.Method)
 		}
@@ -89,7 +104,7 @@ func TestDriftClient_FetchTrades_Success(t *testing.T) {
 		}
 
 		json.NewEncoder(w).Encode(response)
-	}))
+	})))
 	defer server.Close()
 
 	// Create client with test server URL
@@ -150,7 +165,7 @@ func TestDriftClient_FetchTrades_Success(t *testing.T) {
 
 func TestDriftClient_FetchTrades_Pagination(t *testing.T) {
 	tradeCallCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		// Handle swaps endpoint - return empty response
@@ -209,7 +224,7 @@ func TestDriftClient_FetchTrades_Pagination(t *testing.T) {
 		}
 
 		json.NewEncoder(w).Encode(response)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -242,11 +257,11 @@ func TestDriftClient_FetchTrades_Pagination(t *testing.T) {
 
 func TestDriftClient_FetchTrades_RateLimit(t *testing.T) {
 	retryCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		retryCount++
 		w.Header().Set("Retry-After", "1")
 		w.WriteHeader(http.StatusTooManyRequests)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -276,11 +291,11 @@ func TestDriftClient_FetchTrades_RateLimit(t *testing.T) {
 }
 
 func TestDriftClient_FetchTrades_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(2 * time.Second)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(driftTradesResponse{Success: true})
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -306,7 +321,7 @@ func TestDriftClient_FetchTrades_ContextCancellation(t *testing.T) {
 func TestDriftClient_FetchTrades_FiltersBySince(t *testing.T) {
 	now := time.Now()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		// Handle swaps endpoint - return empty response
@@ -351,7 +366,7 @@ func TestDriftClient_FetchTrades_FiltersBySince(t *testing.T) {
 		}
 
 		json.NewEncoder(w).Encode(response)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -413,7 +428,7 @@ func TestDriftClient_FetchTrades_EmptyAccountIdentifier(t *testing.T) {
 func TestDriftClient_FetchFundingPayments_Success(t *testing.T) {
 	// First call will be for markets, second for funding
 	callCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 
 		if r.URL.Path == "/stats/markets" {
@@ -456,7 +471,7 @@ func TestDriftClient_FetchFundingPayments_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(response)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -685,7 +700,7 @@ func TestDriftClient_Contract(t *testing.T) {
 func TestDriftClient_FetchTrades_WithSwaps(t *testing.T) {
 	now := time.Now()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		// Handle swaps endpoint
@@ -743,7 +758,7 @@ func TestDriftClient_FetchTrades_WithSwaps(t *testing.T) {
 			Meta: driftMeta{NextPage: nil},
 		}
 		json.NewEncoder(w).Encode(response)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -981,7 +996,7 @@ func TestDriftClient_FetchDeposits_Success(t *testing.T) {
 	withdrawTs := now.Add(-5 * 24 * time.Hour).Unix() // 5 days ago
 
 	// Create a mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handle spot markets request for market info lookup
 		if strings.Contains(r.URL.Path, "/spotMarkets") {
 			response := `{
@@ -1034,7 +1049,7 @@ func TestDriftClient_FetchDeposits_Success(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusNotFound)
-	}))
+	})))
 	defer server.Close()
 
 	// Create client with mock server URL
@@ -1113,7 +1128,7 @@ func TestDriftClient_FetchDeposits_FiltersBySince(t *testing.T) {
 	sinceTimestamp := now.Add(-15 * 24 * time.Hour).Unix() // 15 days ago (filters out old)
 
 	// Create a mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/spotMarkets") {
 			response := `{
 				"success": true,
@@ -1162,7 +1177,7 @@ func TestDriftClient_FetchDeposits_FiltersBySince(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusNotFound)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -1223,7 +1238,7 @@ func TestDriftClient_HistoricalFetchFiltersOverlap(t *testing.T) {
 
 	var historicalCalled, recentCalled bool
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		// Handle spot markets
@@ -1275,7 +1290,7 @@ func TestDriftClient_HistoricalFetchFiltersOverlap(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusNotFound)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -1346,7 +1361,7 @@ func TestDriftClient_HistoricalFetchFiltersOverlap(t *testing.T) {
 }
 
 func TestDriftClient_FetchTrades_OraclePrices(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		if strings.Contains(r.URL.Path, "/swaps") {
@@ -1404,7 +1419,7 @@ func TestDriftClient_FetchTrades_OraclePrices(t *testing.T) {
 			Meta: driftMeta{NextPage: nil},
 		}
 		json.NewEncoder(w).Encode(response)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{
@@ -1554,7 +1569,7 @@ func TestDriftClient_FetchDeposits_OraclePrices(t *testing.T) {
 	now := time.Now()
 	depositTs := now.Add(-10 * 24 * time.Hour).Unix()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(withMarkets(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/stats/markets") {
 			response := `{
 				"success": true,
@@ -1591,7 +1606,7 @@ func TestDriftClient_FetchDeposits_OraclePrices(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusNotFound)
-	}))
+	})))
 	defer server.Close()
 
 	client := &Client{

--- a/exchange/drift/markets.go
+++ b/exchange/drift/markets.go
@@ -143,8 +143,19 @@ func (c *Client) fetchMarkets(ctx context.Context) error {
 	return nil
 }
 
-// getMarketInfo returns market information for the given market index and type
-// It will fetch from API if cache is expired or missing
+// ensureMarketCache pre-warms the market cache if it's empty or expired.
+// Call this before processing a batch of records to avoid per-record API calls.
+func (c *Client) ensureMarketCache(ctx context.Context) error {
+	if c.marketCache.isExpired() {
+		return c.fetchMarkets(ctx)
+	}
+	return nil
+}
+
+// getMarketInfo returns market information for the given market index and type.
+// It will fetch from API if cache is expired or missing.
+// Returns an error if the market cannot be resolved — callers should skip the
+// record rather than persist UNKNOWN data.
 func (c *Client) getMarketInfo(ctx context.Context, marketIndex int, marketType string) (MarketInfo, error) {
 	// Try cache first
 	if info, ok := c.marketCache.getMarket(marketIndex, marketType); ok {
@@ -153,15 +164,7 @@ func (c *Client) getMarketInfo(ctx context.Context, marketIndex int, marketType 
 
 	// Fetch markets if cache miss or expired
 	if err := c.fetchMarkets(ctx); err != nil {
-		// Return a fallback if we can't fetch markets
-		// This allows the system to continue working even if markets API is down
-		return MarketInfo{
-			MarketIndex: marketIndex,
-			Symbol:      fmt.Sprintf("UNKNOWN-%d", marketIndex),
-			BaseAsset:   fmt.Sprintf("UNKNOWN-%d", marketIndex),
-			QuoteAsset:  "USDC",
-			MarketType:  marketType,
-		}, nil
+		return MarketInfo{}, fmt.Errorf("failed to resolve market %s index %d: %w", marketType, marketIndex, err)
 	}
 
 	// Try cache again after fetch
@@ -169,12 +172,6 @@ func (c *Client) getMarketInfo(ctx context.Context, marketIndex int, marketType 
 		return info, nil
 	}
 
-	// Market not found even after fetch - return fallback
-	return MarketInfo{
-		MarketIndex: marketIndex,
-		Symbol:      fmt.Sprintf("UNKNOWN-%d", marketIndex),
-		BaseAsset:   fmt.Sprintf("UNKNOWN-%d", marketIndex),
-		QuoteAsset:  "USDC",
-		MarketType:  marketType,
-	}, nil
+	// Market not found even after fetch
+	return MarketInfo{}, fmt.Errorf("market %s index %d not found in Drift markets API", marketType, marketIndex)
 }


### PR DESCRIPTION
## Summary
- `getMarketInfo` returns error instead of `UNKNOWN-{index}` fallback
- `ensureMarketCache` pre-warms cache before processing record batches
- Page fetchers skip individual records on failure instead of aborting entire page
- Prevents bad data from being persisted during rate-limited resyncs

## Test plan
- [x] All existing tests pass (updated with `/stats/markets` mock)
- [x] Downstream services (account_sync, event_value_fetcher) build and test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)