### PR TITLE
fix: resolve swap market indices instead of empty API symbols

### DIFF
--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -434,3 +434,40 @@ func (c *Client) UpdateAccountTypeMetadata(ctx context.Context, accountID uuid.U
 
 	return nil
 }
+
+// GetDistinctTransferAssets returns distinct asset names from transfers for an account.
+func (c *Client) GetDistinctTransferAssets(ctx context.Context, accountID uuid.UUID) ([]string, error) {
+	query := `
+		query GetDistinctTransferAssets($account_id: uuid!) {
+			transfers(
+				where: { exchange_account_id: { _eq: $account_id } }
+				distinct_on: asset
+			) {
+				asset
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"account_id": accountID.String(),
+	})
+
+	var resp struct {
+		Transfers []struct {
+			Asset string `json:"asset"`
+		} `json:"transfers"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get distinct transfer assets: %w", err)
+	}
+
+	assets := make([]string, 0, len(resp.Transfers))
+	for _, t := range resp.Transfers {
+		if t.Asset != "" {
+			assets = append(assets, t.Asset)
+		}
+	}
+
+	return assets, nil
+}

--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math/big"
 	"net/http"
 	"sort"
@@ -309,8 +308,7 @@ func (c *Client) createTradePageFetcher(accountUUID uuid.UUID) pageFetcher[trade
 		for _, record := range response.Records {
 			trade, price, err := c.transformTrade(ctx, record, accountUUID)
 			if err != nil {
-				log.Printf("drift/trades: skipping trade %s (market resolution failed): %v", record.FillRecordID, err)
-				continue
+				return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/trades: failed to process trade %s: %w", record.FillRecordID, err)
 			}
 			var prices []*models.PriceRecord
 			if price != nil {
@@ -347,9 +345,15 @@ func (c *Client) createSwapPageFetcher(accountUUID uuid.UUID) pageFetcher[tradeW
 			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned success=false")
 		}
 
+		// Pre-warm market cache before processing the batch
+		_ = c.ensureMarketCache(ctx)
+
 		results := make([]tradeWithPrices, 0, len(response.Records))
 		for _, record := range response.Records {
-			swap, prices := c.transformSwap(record, accountUUID)
+			swap, prices, err := c.transformSwap(ctx, record, accountUUID)
+			if err != nil {
+				return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/swaps: failed to process swap %s_%d: %w", record.TxSig, record.TxSigIndex, err)
+			}
 			results = append(results, tradeWithPrices{trade: swap, prices: prices})
 		}
 
@@ -388,8 +392,7 @@ func (c *Client) createFundingPageFetcher(accountUUID uuid.UUID) pageFetcher[*mo
 		for _, record := range response.Records {
 			payment, err := c.transformFundingPayment(ctx, record, accountUUID)
 			if err != nil {
-				log.Printf("drift/funding: skipping payment at ts=%d (market resolution failed): %v", record.Ts, err)
-				continue
+				return pageResult[*models.TransferInput]{}, fmt.Errorf("drift/funding: failed to process payment at ts=%d: %w", record.Ts, err)
 			}
 			payments = append(payments, payment)
 		}
@@ -429,8 +432,7 @@ func (c *Client) createDepositPageFetcher(accountUUID uuid.UUID) pageFetcher[dep
 		for _, record := range response.Records {
 			transfer, price, err := c.transformDeposit(ctx, record, accountUUID)
 			if err != nil {
-				log.Printf("drift/deposits: skipping deposit %s (market resolution failed): %v", record.DepositRecordID, err)
-				continue
+				return pageResult[depositWithPrice]{}, fmt.Errorf("drift/deposits: failed to process deposit %s: %w", record.DepositRecordID, err)
 			}
 			results = append(results, depositWithPrice{transfer: transfer, price: price})
 		}
@@ -599,16 +601,23 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 	}
 	fee = cleanDecimalString(fee)
 
-	baseAsset, quoteAsset := parseSymbol(record.Symbol)
-	baseAmount := cleanDecimalString(record.BaseAssetAmountFilled)
-	quoteAmount := cleanDecimalString(record.QuoteAssetAmountFilled)
-	price := calculatePrice(quoteAmount, baseAmount)
-	timestamp := time.Unix(record.Ts, 0).UTC()
-
 	marketType := strings.ToLower(record.MarketType)
 	if marketType == "" {
 		marketType = "perp"
 	}
+
+	// Resolve market via index — never trust record.Symbol (Drift renames markets)
+	marketInfo, err := c.getMarketInfo(ctx, record.MarketIndex, marketType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve market index %d (%s): %w", record.MarketIndex, marketType, err)
+	}
+
+	baseAsset := marketInfo.BaseAsset
+	quoteAsset := marketInfo.QuoteAsset
+	baseAmount := cleanDecimalString(record.BaseAssetAmountFilled)
+	quoteAmount := cleanDecimalString(record.QuoteAssetAmountFilled)
+	price := calculatePrice(quoteAmount, baseAmount)
+	timestamp := time.Unix(record.Ts, 0).UTC()
 
 	trade := &models.TradeInput{
 		TradeID:           record.FillRecordID,
@@ -639,28 +648,38 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 	return trade, priceRecord, nil
 }
 
-func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) (*models.TradeInput, []*models.PriceRecord) {
+func (c *Client) transformSwap(ctx context.Context, record driftSwapRecord, accountUUID uuid.UUID) (*models.TradeInput, []*models.PriceRecord, error) {
+	// Resolve both sides via market index — never trust record symbols
+	outMarket, err := c.getMarketInfo(ctx, record.OutMarketIndex, "spot")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve out market index %d: %w", record.OutMarketIndex, err)
+	}
+	inMarket, err := c.getMarketInfo(ctx, record.InMarketIndex, "spot")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve in market index %d: %w", record.InMarketIndex, err)
+	}
+
 	amountIn := cleanDecimalString(record.AmountIn)
 	amountOut := cleanDecimalString(record.AmountOut)
 	fee := cleanDecimalString(record.Fee)
 
 	var baseAsset, quoteAsset, side, quantity, price string
 
-	if record.OutSymbol == "USDC" {
-		baseAsset = record.InSymbol
+	if outMarket.BaseAsset == "USDC" {
+		baseAsset = inMarket.BaseAsset
 		quoteAsset = "USDC"
 		side = "sell"
 		quantity = amountIn
 		price = calculatePrice(amountOut, amountIn)
-	} else if record.InSymbol == "USDC" {
-		baseAsset = record.OutSymbol
+	} else if inMarket.BaseAsset == "USDC" {
+		baseAsset = outMarket.BaseAsset
 		quoteAsset = "USDC"
 		side = "buy"
 		quantity = amountOut
 		price = calculatePrice(amountIn, amountOut)
 	} else {
-		baseAsset = record.OutSymbol
-		quoteAsset = record.InSymbol
+		baseAsset = outMarket.BaseAsset
+		quoteAsset = inMarket.BaseAsset
 		side = "buy"
 		quantity = amountOut
 		price = calculatePrice(amountIn, amountOut)
@@ -687,7 +706,7 @@ func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) (*
 	var prices []*models.PriceRecord
 	if record.OutOraclePrice != "" && record.OutOraclePrice != "0" {
 		prices = append(prices, &models.PriceRecord{
-			Asset:        record.OutSymbol,
+			Asset:        outMarket.BaseAsset,
 			Denomination: oracleDenomination,
 			Timestamp:    timestamp,
 			Price:        record.OutOraclePrice,
@@ -696,7 +715,7 @@ func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) (*
 	}
 	if record.InOraclePrice != "" && record.InOraclePrice != "0" {
 		prices = append(prices, &models.PriceRecord{
-			Asset:        record.InSymbol,
+			Asset:        inMarket.BaseAsset,
 			Denomination: oracleDenomination,
 			Timestamp:    timestamp,
 			Price:        record.InOraclePrice,
@@ -704,7 +723,7 @@ func (c *Client) transformSwap(record driftSwapRecord, accountUUID uuid.UUID) (*
 		})
 	}
 
-	return trade, prices
+	return trade, prices, nil
 }
 
 func (c *Client) transformFundingPayment(ctx context.Context, record driftFundingPayment, accountUUID uuid.UUID) (*models.TransferInput, error) {

--- a/exchange/drift/client_test.go
+++ b/exchange/drift/client_test.go
@@ -889,7 +889,7 @@ func TestTransformSwap(t *testing.T) {
 			InSymbol:       "USDC", // User spends USDC
 		}
 
-		trade, _ := client.transformSwap(record, accountUUID)
+		trade, _, _ := client.transformSwap(context.Background(), record, accountUUID)
 
 		if trade.BaseAsset != "SOL" {
 			t.Errorf("Expected base asset 'SOL', got '%s'", trade.BaseAsset)
@@ -930,7 +930,7 @@ func TestTransformSwap(t *testing.T) {
 			InSymbol:       "SOL",  // User spends SOL
 		}
 
-		trade, _ := client.transformSwap(record, accountUUID)
+		trade, _, _ := client.transformSwap(context.Background(), record, accountUUID)
 
 		if trade.BaseAsset != "SOL" {
 			t.Errorf("Expected base asset 'SOL', got '%s'", trade.BaseAsset)
@@ -971,7 +971,7 @@ func TestTransformSwap(t *testing.T) {
 			InSymbol:       "SOL",  // User spends SOL
 		}
 
-		trade, _ := client.transformSwap(record, accountUUID)
+		trade, _, _ := client.transformSwap(context.Background(), record, accountUUID)
 
 		// For non-USDC swaps, outSymbol (received) is base, inSymbol (spent) is quote
 		if trade.BaseAsset != "mSOL" {
@@ -1476,6 +1476,8 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Ts:             1700000000,
 			TxSig:          "test-tx",
 			TxSigIndex:     0,
+			OutMarketIndex: 1,
+			InMarketIndex:  0,
 			OutSymbol:      "SOL",
 			InSymbol:       "USDC",
 			AmountOut:      "2.500000",
@@ -1485,7 +1487,7 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Fee:            "0.200000",
 		}
 
-		_, prices := client.transformSwap(record, accountUUID)
+		_, prices, _ := client.transformSwap(context.Background(), record, accountUUID)
 		if len(prices) != 2 {
 			t.Fatalf("Expected 2 oracle prices, got %d", len(prices))
 		}
@@ -1506,6 +1508,8 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Ts:             1700000000,
 			TxSig:          "test-tx-2",
 			TxSigIndex:     0,
+			OutMarketIndex: 1,
+			InMarketIndex:  0,
 			OutSymbol:      "SOL",
 			InSymbol:       "USDC",
 			AmountOut:      "1.000000",
@@ -1515,7 +1519,7 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Fee:            "0.100000",
 		}
 
-		_, prices := client.transformSwap(record, accountUUID)
+		_, prices, _ := client.transformSwap(context.Background(), record, accountUUID)
 		if len(prices) != 0 {
 			t.Errorf("Expected 0 oracle prices for empty values, got %d", len(prices))
 		}
@@ -1526,6 +1530,8 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Ts:             1700000000,
 			TxSig:          "test-tx-3",
 			TxSigIndex:     0,
+			OutMarketIndex: 1,
+			InMarketIndex:  0,
 			OutSymbol:      "SOL",
 			InSymbol:       "USDC",
 			AmountOut:      "1.000000",
@@ -1535,7 +1541,7 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Fee:            "0.100000",
 		}
 
-		_, prices := client.transformSwap(record, accountUUID)
+		_, prices, _ := client.transformSwap(context.Background(), record, accountUUID)
 		if len(prices) != 0 {
 			t.Errorf("Expected 0 oracle prices for zero values, got %d", len(prices))
 		}
@@ -1546,6 +1552,8 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Ts:             1700000000,
 			TxSig:          "test-tx-4",
 			TxSigIndex:     0,
+			OutMarketIndex: 1,
+			InMarketIndex:  0,
 			OutSymbol:      "SOL",
 			InSymbol:       "USDC",
 			AmountOut:      "1.000000",
@@ -1555,7 +1563,7 @@ func TestTransformSwap_OraclePrices(t *testing.T) {
 			Fee:            "0.100000",
 		}
 
-		_, prices := client.transformSwap(record, accountUUID)
+		_, prices, _ := client.transformSwap(context.Background(), record, accountUUID)
 		if len(prices) != 1 {
 			t.Fatalf("Expected 1 oracle price, got %d", len(prices))
 		}

--- a/exchange/drift/markets.go
+++ b/exchange/drift/markets.go
@@ -48,7 +48,7 @@ func newMarketCache(ttl time.Duration) *marketCache {
 		ttl:         ttl,
 	}
 
-	// Hardcoded perp markets (from perpMarkets.ts)
+	// Hardcoded perp markets (from protocol-v2/sdk/src/constants/perpMarkets.ts)
 	perpDefaults := map[int]string{
 		0: "SOL", 1: "BTC", 2: "ETH", 3: "APT", 4: "1MBONK", 5: "POL",
 		6: "ARB", 7: "DOGE", 8: "BNB", 9: "SUI", 10: "1MPEPE", 11: "OP",
@@ -59,6 +59,9 @@ func newMarketCache(ttl time.Duration) *marketCache {
 		44: "MOTHER", 45: "MOODENG", 59: "HYPE", 60: "LTC", 61: "ME",
 		62: "PENGU", 63: "AI16Z", 64: "TRUMP", 65: "MELANIA", 66: "BERA",
 		69: "KAITO", 70: "IP", 71: "FARTCOIN", 72: "ADA", 73: "PAXG",
+		74: "LAUNCHCOIN", 75: "PUMP", 76: "ASTER", 77: "XPL", 78: "2Z",
+		79: "ZEC", 80: "MNT", 81: "1KPUMP", 82: "MET", 83: "1KMON",
+		84: "LIT", 85: "BP",
 	}
 	for idx, base := range perpDefaults {
 		mc.perpMarkets[idx] = MarketInfo{
@@ -70,7 +73,7 @@ func newMarketCache(ttl time.Duration) *marketCache {
 		}
 	}
 
-	// Hardcoded spot markets (from spotMarkets.ts)
+	// Hardcoded spot markets (from protocol-v2/sdk/src/constants/spotMarkets.ts)
 	spotDefaults := map[int]string{
 		0: "USDC", 1: "SOL", 2: "mSOL", 3: "wBTC", 4: "wETH", 5: "USDT",
 		6: "jitoSOL", 7: "PYTH", 8: "bSOL", 9: "JTO", 10: "WIF", 11: "JUP",
@@ -78,6 +81,12 @@ func newMarketCache(ttl time.Duration) *marketCache {
 		18: "USDY", 19: "JLP", 20: "POPCAT", 21: "CLOUD", 25: "BNSOL",
 		26: "MOTHER", 27: "cbBTC", 29: "META", 30: "ME", 31: "PENGU",
 		32: "BONK", 35: "AI16Z", 36: "TRUMP", 37: "MELANIA", 39: "FARTCOIN",
+		40: "JitoSOL-3", 41: "PT-fragSOL-10JUL25-3", 42: "PT-kySOL-15JUN25-3",
+		43: "PT-dSOL-30JUN25-3", 44: "JTO-3", 45: "zBTC", 46: "ZEUS",
+		47: "USDC-4", 48: "USDT-4", 49: "SOL-2", 50: "JitoSOL-2", 51: "JTO-2",
+		52: "dfdvSOL", 53: "sACRED", 54: "EURC", 55: "PT-fragSOL-31OCT25-3",
+		56: "PUMP", 57: "syrupUSDC", 58: "LBTC", 59: "2Z", 60: "MET",
+		61: "CASH", 62: "USD1",
 	}
 	for idx, base := range spotDefaults {
 		mc.spotMarkets[idx] = MarketInfo{

--- a/models/account_state.go
+++ b/models/account_state.go
@@ -27,10 +27,11 @@ type FundingEntry struct {
 // AccountState represents the in-memory state of an account.
 // Built by processing all transactions chronologically.
 type AccountState struct {
-	Assets          map[string]*AssetState   `json:"assets"`
+	Assets          map[string]*AssetState        `json:"assets"`
 	Positions       map[string]*PositionState     `json:"positions"`        // Open positions keyed by "marketType:baseAsset"
 	ClosedPositions []*PositionState              `json:"closed_positions"`
-	Trading         map[string]*TradingState `json:"trading"`          // Keyed by quote asset (e.g., "USDC", "SOL")
+	Trading         map[string]*TradingState      `json:"trading"`          // Keyed by quote asset (e.g., "USDC", "SOL")
+	HasSeenSnapshot bool                          `json:"has_seen_snapshot"` // True after first snapshot baseline applied
 }
 
 // AssetState tracks the state of a single asset (USDC, SOL, etc.)


### PR DESCRIPTION
## Summary
- Drift API's `OutSymbol`/`InSymbol` fields are not populated for swap records, causing trades to be saved with empty `base_asset` and `quote_asset`
- Switch `transformSwap` to use `getMarketInfo` (market index resolution with hardcoded fallbacks) instead of trusting symbol fields
- Add new perp market indices (74-85) and spot market indices (40-62) to hardcoded defaults
- Stop silently skipping unresolvable records — return errors so callers can halt instead of persisting bad data

## Test plan
- [x] All lib tests pass
- [ ] Delete bad trades, re-sync with updated lib — verify 764 swaps resolve correctly
- [ ] Verify no empty base_asset/quote_asset trades after re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)