### PR TITLE
fix(phase-0): drift dedup, HL pagination, account filters, price cache

### DIFF
--- a/db/accounts.go
+++ b/db/accounts.go
@@ -347,3 +347,66 @@ func (c *Client) UpdateAccountLastSynced(ctx context.Context, accountID string) 
 
 	return nil
 }
+
+// SetAccountSyncError records a sync error message on the exchange account.
+func (c *Client) SetAccountSyncError(ctx context.Context, accountID string, errorMsg string) error {
+	query := `
+		mutation SetAccountSyncError($id: uuid!, $last_sync_error: String!) {
+			update_exchange_accounts_by_pk(pk_columns: {id: $id}, _set: {last_sync_error: $last_sync_error}) {
+				id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id":              accountID,
+		"last_sync_error": errorMsg,
+	})
+
+	var resp struct {
+		UpdateExchangeAccountsByPk *struct {
+			ID string `json:"id"`
+		} `json:"update_exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to set account sync error: %w", err)
+	}
+
+	if resp.UpdateExchangeAccountsByPk == nil {
+		return notFoundError("account", accountID)
+	}
+
+	return nil
+}
+
+// ClearAccountSyncError clears any sync error on the exchange account.
+func (c *Client) ClearAccountSyncError(ctx context.Context, accountID string) error {
+	query := `
+		mutation ClearAccountSyncError($id: uuid!) {
+			update_exchange_accounts_by_pk(pk_columns: {id: $id}, _set: {last_sync_error: null}) {
+				id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": accountID,
+	})
+
+	var resp struct {
+		UpdateExchangeAccountsByPk *struct {
+			ID string `json:"id"`
+		} `json:"update_exchange_accounts_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to clear account sync error: %w", err)
+	}
+
+	if resp.UpdateExchangeAccountsByPk == nil {
+		return notFoundError("account", accountID)
+	}
+
+	return nil
+}

--- a/db/accounts.go
+++ b/db/accounts.go
@@ -14,6 +14,14 @@ type ExchangeAccount = models.ExchangeAccount
 // ExchangeAccountInput represents exchange account input for mutations (aliased from models package)
 type ExchangeAccountInput = models.ExchangeAccountInput
 
+// AccountListFilter controls which accounts ListAccounts returns.
+// Nil fields mean "don't filter on this flag". When both are nil, all
+// accounts are returned.
+type AccountListFilter struct {
+	SyncEnabled       *bool
+	ProcessingEnabled *bool
+}
+
 // GetAccount retrieves a single exchange account by ID
 func (c *Client) GetAccount(ctx context.Context, id string) (*ExchangeAccount, error) {
 	query := `
@@ -23,10 +31,14 @@ func (c *Client) GetAccount(ctx context.Context, id string) (*ExchangeAccount, e
 				account_identifier
 				account_type
 				account_type_metadata
+				status
+				sync_enabled
+				processing_enabled
 				exchange {
 					id
 					name
 					display_name
+					settles_on_close
 				}
 			}
 		}
@@ -51,25 +63,40 @@ func (c *Client) GetAccount(ctx context.Context, id string) (*ExchangeAccount, e
 	return resp.ExchangeAccountsByPk, nil
 }
 
-// ListAccounts retrieves all exchange accounts
-func (c *Client) ListAccounts(ctx context.Context) ([]*ExchangeAccount, error) {
+// ListAccounts retrieves exchange accounts matching the given filter.
+// Pass AccountListFilter{} to get all accounts.
+func (c *Client) ListAccounts(ctx context.Context, f AccountListFilter) ([]*ExchangeAccount, error) {
+	where := map[string]interface{}{}
+	if f.SyncEnabled != nil {
+		where["sync_enabled"] = map[string]interface{}{"_eq": *f.SyncEnabled}
+	}
+	if f.ProcessingEnabled != nil {
+		where["processing_enabled"] = map[string]interface{}{"_eq": *f.ProcessingEnabled}
+	}
+
 	query := `
-		query ListAccounts {
-			exchange_accounts {
+		query ListAccounts($where: exchange_accounts_bool_exp!) {
+			exchange_accounts(where: $where) {
 				id
 				account_identifier
 				account_type
 				account_type_metadata
+				status
+				sync_enabled
+				processing_enabled
 				exchange {
 					id
 					name
 					display_name
+					settles_on_close
 				}
 			}
 		}
 	`
 
-	req := c.graphqlRequest(query)
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"where": where,
+	})
 
 	var resp struct {
 		ExchangeAccounts []*ExchangeAccount `json:"exchange_accounts"`

--- a/db/accounts_test.go
+++ b/db/accounts_test.go
@@ -142,7 +142,7 @@ func TestClient_ListAccounts(t *testing.T) {
 		AdminSecret: "test-secret",
 	})
 
-	accounts, err := client.ListAccounts(ctx)
+	accounts, err := client.ListAccounts(ctx, AccountListFilter{})
 	if err != nil {
 		t.Fatalf("ListAccounts failed: %v", err)
 	}

--- a/db/checkpoint.go
+++ b/db/checkpoint.go
@@ -13,22 +13,23 @@ import (
 // Validity is determined by comparing per-type timestamps and schema_version
 // against the current DB state.
 type ProcessorCheckpoint struct {
-	ExchangeAccountID      uuid.UUID             `json:"exchange_account_id"`
-	State                  *models.AccountState   `json:"state"`                    // Typed account state
-	SchemaVersion          int                    `json:"schema_version"`           // Bumped when AccountState shape changes
-	LastTradeTimestamp      int64                  `json:"last_trade_timestamp"`     // Unix ms of newest trade
-	LastTransferTimestamp   int64                  `json:"last_transfer_timestamp"`  // Unix ms of newest transfer
-	LastSettlementTimestamp int64                  `json:"last_settlement_timestamp"` // Deprecated: kept for DB compat, no longer used for validation
-	LastSnapshotTimestamp   int64                  `json:"last_snapshot_timestamp"`  // Unix ms of newest snapshot
-	UpdatedAt              string                 `json:"updated_at"`
+	ExchangeAccountID       uuid.UUID            `json:"exchange_account_id"`
+	State                   *models.AccountState `json:"state"`                     // Typed account state
+	SchemaVersion           int                  `json:"schema_version"`            // Bumped when AccountState shape changes
+	LastTradeTimestamp      int64                `json:"last_trade_timestamp"`      // Unix ms of newest trade
+	LastTransferTimestamp   int64                `json:"last_transfer_timestamp"`   // Unix ms of newest transfer
+	LastSettlementTimestamp int64                `json:"last_settlement_timestamp"` // Deprecated: kept for DB compat, no longer used for validation
+	LastSnapshotTimestamp   int64                `json:"last_snapshot_timestamp"`   // Unix ms of newest snapshot
+	LastError               *string              `json:"last_error"`                // Error message from the most recent failed run (NULL on success)
+	UpdatedAt               string               `json:"updated_at"`
 }
 
 // UnmarshalJSON handles Hasura returning BIGINT as string and JSONB as escaped strings.
 func (cp *ProcessorCheckpoint) UnmarshalJSON(data []byte) error {
 	type Alias ProcessorCheckpoint
 	aux := &struct {
-		State                  interface{} `json:"state"`
-		SchemaVersion          interface{} `json:"schema_version"`
+		State                   interface{} `json:"state"`
+		SchemaVersion           interface{} `json:"schema_version"`
 		LastTradeTimestamp      interface{} `json:"last_trade_timestamp"`
 		LastTransferTimestamp   interface{} `json:"last_transfer_timestamp"`
 		LastSettlementTimestamp interface{} `json:"last_settlement_timestamp"`
@@ -117,13 +118,18 @@ func (c *Client) SaveCheckpoint(ctx context.Context, checkpoint *ProcessorCheckp
 				object: $object
 				on_conflict: {
 					constraint: processor_checkpoints_pkey
-					update_columns: [state, schema_version, last_trade_timestamp, last_transfer_timestamp, last_settlement_timestamp, last_snapshot_timestamp, updated_at]
+					update_columns: [state, schema_version, last_trade_timestamp, last_transfer_timestamp, last_settlement_timestamp, last_snapshot_timestamp, last_error, updated_at]
 				}
 			) {
 				exchange_account_id
 			}
 		}
 	`
+
+	var lastError interface{}
+	if checkpoint.LastError != nil {
+		lastError = *checkpoint.LastError
+	}
 
 	object := map[string]interface{}{
 		"exchange_account_id":       checkpoint.ExchangeAccountID.String(),
@@ -133,6 +139,7 @@ func (c *Client) SaveCheckpoint(ctx context.Context, checkpoint *ProcessorCheckp
 		"last_transfer_timestamp":   checkpoint.LastTransferTimestamp,
 		"last_settlement_timestamp": checkpoint.LastSettlementTimestamp,
 		"last_snapshot_timestamp":   checkpoint.LastSnapshotTimestamp,
+		"last_error":                lastError,
 		"updated_at":                "now()",
 	}
 
@@ -166,6 +173,7 @@ func (c *Client) LoadCheckpoint(ctx context.Context, accountID uuid.UUID) (*Proc
 				last_transfer_timestamp
 				last_settlement_timestamp
 				last_snapshot_timestamp
+				last_error
 				updated_at
 			}
 		}
@@ -184,6 +192,70 @@ func (c *Client) LoadCheckpoint(ctx context.Context, accountID uuid.UUID) (*Proc
 	}
 
 	return resp.Checkpoint, nil
+}
+
+// SetProcessorCheckpointError records an error message on the checkpoint row for an account.
+// The checkpoint row must already exist (created by a prior SaveCheckpoint). If no row
+// exists yet, this is a no-op — the error will be surfaced via logs only.
+func (c *Client) SetProcessorCheckpointError(ctx context.Context, accountID uuid.UUID, errorMsg string) error {
+	query := `
+		mutation SetCheckpointError($id: uuid!, $msg: String!) {
+			update_processor_checkpoints_by_pk(
+				pk_columns: {exchange_account_id: $id}
+				_set: {last_error: $msg}
+			) {
+				exchange_account_id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id":  accountID.String(),
+		"msg": errorMsg,
+	})
+
+	var resp struct {
+		Update *struct {
+			ExchangeAccountID string `json:"exchange_account_id"`
+		} `json:"update_processor_checkpoints_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to set checkpoint error: %w", err)
+	}
+
+	return nil
+}
+
+// ClearProcessorCheckpointError sets last_error to NULL on the checkpoint row.
+// No-op if no row exists.
+func (c *Client) ClearProcessorCheckpointError(ctx context.Context, accountID uuid.UUID) error {
+	query := `
+		mutation ClearCheckpointError($id: uuid!) {
+			update_processor_checkpoints_by_pk(
+				pk_columns: {exchange_account_id: $id}
+				_set: {last_error: null}
+			) {
+				exchange_account_id
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"id": accountID.String(),
+	})
+
+	var resp struct {
+		Update *struct {
+			ExchangeAccountID string `json:"exchange_account_id"`
+		} `json:"update_processor_checkpoints_by_pk"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return fmt.Errorf("failed to clear checkpoint error: %w", err)
+	}
+
+	return nil
 }
 
 // DeleteCheckpoint removes the processor checkpoint for an account.

--- a/db/client.go
+++ b/db/client.go
@@ -97,7 +97,7 @@ type DBClient interface {
 
 	// Account methods
 	GetAccount(ctx context.Context, id string) (*ExchangeAccount, error)
-	ListAccounts(ctx context.Context) ([]*ExchangeAccount, error)
+	ListAccounts(ctx context.Context, filter AccountListFilter) ([]*ExchangeAccount, error)
 	CreateAccount(ctx context.Context, input *ExchangeAccountInput) (*ExchangeAccount, error)
 	UpdateAccount(ctx context.Context, id string, input *ExchangeAccountInput) (*ExchangeAccount, error)
 	DeleteAccount(ctx context.Context, id string) error
@@ -110,6 +110,7 @@ type DBClient interface {
 	UpdateTrade(ctx context.Context, id string, input *TradeInput) (*Trade, error)
 	DeleteTrade(ctx context.Context, id string) error
 	LatestTrade(ctx context.Context, exchangeAccountIDs []uuid.UUID) (map[uuid.UUID]*Trade, error)
+	FindTradesByTxSignature(ctx context.Context, txSignature string) ([]*Trade, error)
 
 	// Position methods
 	DeletePositionsForAccount(ctx context.Context, accountID uuid.UUID) (int, error)
@@ -158,6 +159,8 @@ type DBClient interface {
 	SaveCheckpoint(ctx context.Context, checkpoint *ProcessorCheckpoint) error
 	LoadCheckpoint(ctx context.Context, accountID uuid.UUID) (*ProcessorCheckpoint, error)
 	DeleteCheckpoint(ctx context.Context, accountID uuid.UUID) error
+	SetProcessorCheckpointError(ctx context.Context, accountID uuid.UUID, errorMsg string) error
+	ClearProcessorCheckpointError(ctx context.Context, accountID uuid.UUID) error
 
 	// Sync timestamp methods
 	UpdateAccountLastSynced(ctx context.Context, accountID string) error
@@ -179,6 +182,11 @@ type DBClient interface {
 
 	// Upsert positions (stable IDs via natural key)
 	UpsertPositions(ctx context.Context, inputs []*PositionInput) ([]*Position, error)
+
+	// Omni raw events methods
+	ListOmniRawEvents(ctx context.Context, accountID uuid.UUID, eventType string, sinceMs int64) ([]*OmniRawEvent, error)
+	ListOmniRawEventsByTypes(ctx context.Context, accountID uuid.UUID, eventTypes []string, sinceMs int64) ([]*OmniRawEvent, error)
+	AddOmniRawEvents(ctx context.Context, inputs []*OmniRawEventInput) (int, error)
 }
 
 // Ensure Client implements DBClient

--- a/db/client.go
+++ b/db/client.go
@@ -164,6 +164,8 @@ type DBClient interface {
 
 	// Sync timestamp methods
 	UpdateAccountLastSynced(ctx context.Context, accountID string) error
+	SetAccountSyncError(ctx context.Context, accountID string, errorMsg string) error
+	ClearAccountSyncError(ctx context.Context, accountID string) error
 
 	// Event value methods
 	ListSupportedDenominations(ctx context.Context) ([]string, error)

--- a/db/event_value.go
+++ b/db/event_value.go
@@ -69,12 +69,37 @@ func (c *Client) ListMissingEventValues(ctx context.Context, limit int) ([]*Miss
 	return resp.MissingEventValues, nil
 }
 
-// AddEventValues inserts event value records. Uses on_conflict to skip duplicates.
+// AddEventValues upserts event value records: on conflict with the unique
+// (event_id, event_type, denomination) key, the existing row's quantity is
+// updated to the new value. This is a real upsert, not a silent skip — it
+// lets the processor refresh event values when quantities are recomputed.
+// Inputs are written in chunks of 1000 to avoid Hasura payload limits.
 func (c *Client) AddEventValues(ctx context.Context, inputs []*EventValueInput) (int, error) {
 	if len(inputs) == 0 {
 		return 0, nil
 	}
 
+	const chunkSize = 1000
+	totalAffected := 0
+
+	for start := 0; start < len(inputs); start += chunkSize {
+		end := start + chunkSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		chunk := inputs[start:end]
+
+		affected, err := c.addEventValuesChunk(ctx, chunk)
+		if err != nil {
+			return totalAffected, err
+		}
+		totalAffected += affected
+	}
+
+	return totalAffected, nil
+}
+
+func (c *Client) addEventValuesChunk(ctx context.Context, inputs []*EventValueInput) (int, error) {
 	query := `
 		mutation AddEventValues($objects: [event_values_insert_input!]!) {
 			insert_event_values(

--- a/db/exchanges.go
+++ b/db/exchanges.go
@@ -21,6 +21,7 @@ func (c *Client) GetExchange(ctx context.Context, id string) (*Exchange, error) 
 				id
 				name
 				display_name
+				settles_on_close
 			}
 		}
 	`
@@ -52,6 +53,7 @@ func (c *Client) ListExchanges(ctx context.Context) ([]*Exchange, error) {
 				id
 				name
 				display_name
+				settles_on_close
 			}
 		}
 	`
@@ -80,6 +82,7 @@ func (c *Client) CreateExchange(ctx context.Context, input *ExchangeInput) (*Exc
 				id
 				name
 				display_name
+				settles_on_close
 			}
 		}
 	`
@@ -115,6 +118,7 @@ func (c *Client) UpdateExchange(ctx context.Context, id string, input *ExchangeI
 				id
 				name
 				display_name
+				settles_on_close
 			}
 		}
 	`

--- a/db/omni_raw_events.go
+++ b/db/omni_raw_events.go
@@ -1,0 +1,242 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// OmniRawEvent represents a row in the omni_raw_events staging table.
+type OmniRawEvent struct {
+	ID                    uuid.UUID       `json:"id"`
+	ExchangeAccountID     uuid.UUID       `json:"exchange_account_id"`
+	OmniID                string          `json:"omni_id"`
+	CreatedAt             time.Time       `json:"created_at"`
+	TimestampMs           int64           `json:"timestamp_ms"`
+	EventType             string          `json:"event_type"`
+	Side                  *string         `json:"side,omitempty"`
+	InstrumentType        *string         `json:"instrument_type,omitempty"`
+	Underlying            *string         `json:"underlying,omitempty"`
+	Price                 *string         `json:"price,omitempty"`
+	Qty                   *string         `json:"qty,omitempty"`
+	TradeType             *string         `json:"trade_type,omitempty"`
+	LiquidationTriggerPrice *string       `json:"liquidation_trigger_price,omitempty"`
+	Asset                 *string         `json:"asset,omitempty"`
+	TransferType          *string         `json:"transfer_type,omitempty"`
+	FeeType               *string         `json:"fee_type,omitempty"`
+	FundingRate           *string         `json:"funding_rate,omitempty"`
+	Status                *string         `json:"status,omitempty"`
+	RawData               json.RawMessage `json:"raw_data"`
+	UploadBatchID         uuid.UUID       `json:"upload_batch_id"`
+	UploadedAt            time.Time       `json:"uploaded_at"`
+}
+
+// OmniRawEventInput represents input for inserting an omni_raw_event.
+type OmniRawEventInput struct {
+	ExchangeAccountID     uuid.UUID       `json:"exchange_account_id"`
+	OmniID                string          `json:"omni_id"`
+	CreatedAt             time.Time       `json:"created_at"`
+	TimestampMs           int64           `json:"timestamp_ms"`
+	EventType             string          `json:"event_type"`
+	Side                  *string         `json:"side,omitempty"`
+	InstrumentType        *string         `json:"instrument_type,omitempty"`
+	Underlying            *string         `json:"underlying,omitempty"`
+	Price                 *string         `json:"price,omitempty"`
+	Qty                   *string         `json:"qty,omitempty"`
+	TradeType             *string         `json:"trade_type,omitempty"`
+	LiquidationTriggerPrice *string       `json:"liquidation_trigger_price,omitempty"`
+	Asset                 *string         `json:"asset,omitempty"`
+	TransferType          *string         `json:"transfer_type,omitempty"`
+	FeeType               *string         `json:"fee_type,omitempty"`
+	FundingRate           *string         `json:"funding_rate,omitempty"`
+	Status                *string         `json:"status,omitempty"`
+	RawData               json.RawMessage `json:"raw_data"`
+	UploadBatchID         uuid.UUID       `json:"upload_batch_id"`
+}
+
+// omniRawEventFields is the GraphQL field list for omni_raw_events queries.
+const omniRawEventFields = `
+	id
+	exchange_account_id
+	omni_id
+	created_at
+	timestamp_ms
+	event_type
+	side
+	instrument_type
+	underlying
+	price
+	qty
+	trade_type
+	liquidation_trigger_price
+	asset
+	transfer_type
+	fee_type
+	funding_rate
+	status
+	raw_data
+	upload_batch_id
+	uploaded_at
+`
+
+// ListOmniRawEvents queries omni_raw_events by account, event_type, and optional
+// minimum timestamp (inclusive). Results are ordered by timestamp_ms ascending.
+func (c *Client) ListOmniRawEvents(ctx context.Context, accountID uuid.UUID, eventType string, sinceMs int64) ([]*OmniRawEvent, error) {
+	query := fmt.Sprintf(`
+		query ListOmniRawEvents($account_id: uuid!, $event_type: String!, $since_ms: bigint!) {
+			omni_raw_events(
+				where: {
+					exchange_account_id: { _eq: $account_id }
+					event_type: { _eq: $event_type }
+					timestamp_ms: { _gte: $since_ms }
+				}
+				order_by: { timestamp_ms: asc }
+			) {
+				%s
+			}
+		}
+	`, omniRawEventFields)
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"account_id": accountID.String(),
+		"event_type": eventType,
+		"since_ms":   sinceMs,
+	})
+
+	var resp struct {
+		OmniRawEvents []*OmniRawEvent `json:"omni_raw_events"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list omni raw events: %w", err)
+	}
+
+	return resp.OmniRawEvents, nil
+}
+
+// ListOmniRawEventsByTypes queries omni_raw_events by account and multiple event types,
+// with optional minimum timestamp. Results are ordered by timestamp_ms ascending.
+func (c *Client) ListOmniRawEventsByTypes(ctx context.Context, accountID uuid.UUID, eventTypes []string, sinceMs int64) ([]*OmniRawEvent, error) {
+	query := fmt.Sprintf(`
+		query ListOmniRawEventsByTypes($account_id: uuid!, $event_types: [String!]!, $since_ms: bigint!) {
+			omni_raw_events(
+				where: {
+					exchange_account_id: { _eq: $account_id }
+					event_type: { _in: $event_types }
+					timestamp_ms: { _gte: $since_ms }
+				}
+				order_by: { timestamp_ms: asc }
+			) {
+				%s
+			}
+		}
+	`, omniRawEventFields)
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"account_id":  accountID.String(),
+		"event_types": eventTypes,
+		"since_ms":    sinceMs,
+	})
+
+	var resp struct {
+		OmniRawEvents []*OmniRawEvent `json:"omni_raw_events"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list omni raw events by types: %w", err)
+	}
+
+	return resp.OmniRawEvents, nil
+}
+
+// AddOmniRawEvents bulk-inserts omni_raw_event records. Uses ON CONFLICT DO NOTHING
+// on the (exchange_account_id, omni_id) unique constraint to skip duplicates.
+// Returns the number of rows actually inserted.
+func (c *Client) AddOmniRawEvents(ctx context.Context, inputs []*OmniRawEventInput) (int, error) {
+	if len(inputs) == 0 {
+		return 0, nil
+	}
+
+	objects := make([]map[string]interface{}, len(inputs))
+	for i, input := range inputs {
+		obj := map[string]interface{}{
+			"exchange_account_id": input.ExchangeAccountID.String(),
+			"omni_id":             input.OmniID,
+			"created_at":          input.CreatedAt.Format(time.RFC3339Nano),
+			"timestamp_ms":        input.TimestampMs,
+			"event_type":          input.EventType,
+			"raw_data":            input.RawData,
+			"upload_batch_id":     input.UploadBatchID.String(),
+		}
+		if input.Side != nil {
+			obj["side"] = *input.Side
+		}
+		if input.InstrumentType != nil {
+			obj["instrument_type"] = *input.InstrumentType
+		}
+		if input.Underlying != nil {
+			obj["underlying"] = *input.Underlying
+		}
+		if input.Price != nil {
+			obj["price"] = *input.Price
+		}
+		if input.Qty != nil {
+			obj["qty"] = *input.Qty
+		}
+		if input.TradeType != nil {
+			obj["trade_type"] = *input.TradeType
+		}
+		if input.LiquidationTriggerPrice != nil {
+			obj["liquidation_trigger_price"] = *input.LiquidationTriggerPrice
+		}
+		if input.Asset != nil {
+			obj["asset"] = *input.Asset
+		}
+		if input.TransferType != nil {
+			obj["transfer_type"] = *input.TransferType
+		}
+		if input.FeeType != nil {
+			obj["fee_type"] = *input.FeeType
+		}
+		if input.FundingRate != nil {
+			obj["funding_rate"] = *input.FundingRate
+		}
+		if input.Status != nil {
+			obj["status"] = *input.Status
+		}
+		objects[i] = obj
+	}
+
+	query := `
+		mutation AddOmniRawEvents($objects: [omni_raw_events_insert_input!]!) {
+			insert_omni_raw_events(
+				objects: $objects
+				on_conflict: {
+					constraint: omni_raw_events_exchange_account_id_omni_id_key
+					update_columns: []
+				}
+			) {
+				affected_rows
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"objects": objects,
+	})
+
+	var resp struct {
+		InsertOmniRawEvents struct {
+			AffectedRows int `json:"affected_rows"`
+		} `json:"insert_omni_raw_events"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return 0, fmt.Errorf("failed to add omni raw events: %w", err)
+	}
+
+	return resp.InsertOmniRawEvents.AffectedRows, nil
+}

--- a/db/position_pnl.go
+++ b/db/position_pnl.go
@@ -42,18 +42,40 @@ func (c *Client) ListMissingPositionPnL(ctx context.Context, limit int) ([]*Miss
 }
 
 // AddPositionPnL batch-inserts position PnL records. Uses on_conflict to update existing rows.
+// Inputs are written in chunks of 1000 to avoid Hasura payload limits.
 func (c *Client) AddPositionPnL(ctx context.Context, inputs []*PositionPnLInput) (int, error) {
 	if len(inputs) == 0 {
 		return 0, nil
 	}
 
+	const chunkSize = 1000
+	totalAffected := 0
+
+	for start := 0; start < len(inputs); start += chunkSize {
+		end := start + chunkSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		chunk := inputs[start:end]
+
+		affected, err := c.addPositionPnLChunk(ctx, chunk)
+		if err != nil {
+			return totalAffected, err
+		}
+		totalAffected += affected
+	}
+
+	return totalAffected, nil
+}
+
+func (c *Client) addPositionPnLChunk(ctx context.Context, inputs []*PositionPnLInput) (int, error) {
 	query := `
 		mutation AddPositionPnL($objects: [position_pnl_insert_input!]!) {
 			insert_position_pnl(
 				objects: $objects
 				on_conflict: {
 					constraint: position_pnl_position_id_denomination_key
-					update_columns: [realized_pnl]
+					update_columns: [realized_pnl, trade_pnl, funding_pnl, fee_pnl, interest_pnl]
 				}
 			) {
 				affected_rows
@@ -67,6 +89,10 @@ func (c *Client) AddPositionPnL(ctx context.Context, inputs []*PositionPnLInput)
 			"position_id":  input.PositionID.String(),
 			"denomination": input.Denomination,
 			"realized_pnl": input.RealizedPnL,
+			"trade_pnl":    input.TradePnL,
+			"funding_pnl":  input.FundingPnL,
+			"fee_pnl":      input.FeePnL,
+			"interest_pnl": input.InterestPnL,
 		}
 	}
 

--- a/db/price_cache_test.go
+++ b/db/price_cache_test.go
@@ -145,6 +145,51 @@ func TestClient_GetNearestPrice(t *testing.T) {
 	}
 }
 
+func TestClient_GetNearestPrice_StringifiedTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			// HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES=true returns bigint as string
+			respData := map[string]interface{}{
+				"price_cache": []map[string]interface{}{
+					{
+						"asset":        "mSOL",
+						"denomination": "USDC",
+						"timestamp":    "1700000003000",
+						"price":        "150.25",
+						"source":       "drift",
+					},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	price, err := client.GetNearestPrice(ctx, "mSOL", "USDC", 1700000003000, 10000)
+	if err != nil {
+		t.Fatalf("GetNearestPrice failed: %v", err)
+	}
+
+	if price == nil {
+		t.Fatal("Expected a price, got nil")
+	}
+
+	if price.Timestamp != 1700000003000 {
+		t.Errorf("Expected timestamp 1700000003000, got %d", price.Timestamp)
+	}
+
+	if price.Price != "150.25" {
+		t.Errorf("Expected price 150.25, got %s", price.Price)
+	}
+}
+
 func TestClient_GetNearestPrice_NoResult(t *testing.T) {
 	ctx := context.Background()
 

--- a/db/settlement.go
+++ b/db/settlement.go
@@ -17,7 +17,9 @@ type SettlementInput = models.SettlementInput
 // SettlementFilter represents settlement filter (aliased from models package)
 type SettlementFilter = models.SettlementFilter
 
-// AddSettlements inserts settlement records, skipping duplicates via ON CONFLICT.
+// AddSettlements inserts settlement records. Duplicates raise a unique-constraint
+// violation and must be handled by callers — silent ON CONFLICT tolerance is a bug
+// magnet at the re-sync cursor boundary.
 func (c *Client) AddSettlements(ctx context.Context, inputs []*SettlementInput) (int, error) {
 	if len(inputs) == 0 {
 		return 0, nil
@@ -25,7 +27,7 @@ func (c *Client) AddSettlements(ctx context.Context, inputs []*SettlementInput) 
 
 	objects := make([]map[string]interface{}, len(inputs))
 	for i, input := range inputs {
-		objects[i] = map[string]interface{}{
+		obj := map[string]interface{}{
 			"exchange_account_id": input.ExchangeAccountID.String(),
 			"asset":               input.Asset,
 			"amount":              input.Amount,
@@ -33,17 +35,15 @@ func (c *Client) AddSettlements(ctx context.Context, inputs []*SettlementInput) 
 			"timestamp":           input.Timestamp.UnixMilli(),
 			"settlement_id":       input.SettlementID,
 		}
+		if input.ExternalID != "" {
+			obj["external_id"] = input.ExternalID
+		}
+		objects[i] = obj
 	}
 
 	query := `
 		mutation AddSettlements($objects: [settlements_insert_input!]!) {
-			insert_settlements(
-				objects: $objects
-				on_conflict: {
-					constraint: settlements_exchange_account_id_settlement_id_key
-					update_columns: []
-				}
-			) {
+			insert_settlements(objects: $objects) {
 				affected_rows
 			}
 		}
@@ -82,6 +82,7 @@ func (c *Client) GetSettlementsByIDs(ctx context.Context, ids []uuid.UUID) ([]*S
 				market
 				timestamp
 				settlement_id
+				external_id
 			}
 		}
 	`
@@ -138,6 +139,7 @@ func (c *Client) ListSettlements(ctx context.Context, filter SettlementFilter) (
 				market
 				timestamp
 				settlement_id
+				external_id
 			}
 		}
 	`, queryHeader, whereClause)
@@ -171,6 +173,7 @@ func (c *Client) GetLatestSettlement(ctx context.Context, exchangeAccountID uuid
 				market
 				timestamp
 				settlement_id
+				external_id
 			}
 		}
 	`

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
-	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/zif-terminal/lib/models"
@@ -23,7 +21,7 @@ type SpotBalanceSnapshotInput = models.SpotBalanceSnapshotInput
 // GetLatestBalanceSnapshots returns the most recent balance snapshot per asset
 // for the given account. It queries the spot_balance_snapshots table using
 // distinct_on to get only the latest entry per asset.
-// Returns float64-based BalanceSnapshot (used by activity_processor).
+// Returns string-based BalanceSnapshot (used by activity_processor for big.Rat math).
 func (c *Client) GetLatestBalanceSnapshots(ctx context.Context, accountID uuid.UUID) ([]*BalanceSnapshot, error) {
 	query := `
 		query GetLatestBalanceSnapshots($account_id: uuid!) {
@@ -53,35 +51,14 @@ func (c *Client) GetLatestBalanceSnapshots(ctx context.Context, accountID uuid.U
 
 	balances := make([]*BalanceSnapshot, 0, len(resp.Snapshots))
 	for _, s := range resp.Snapshots {
-		balance, err := parseFloat64(s.Balance)
-		if err != nil {
-			return nil, fmt.Errorf("invalid balance %q for asset %s: %w", s.Balance, s.Asset, err)
-		}
 		balances = append(balances, &BalanceSnapshot{
 			Asset:       s.Asset,
-			Balance:     balance,
+			Balance:     s.Balance,
 			TimestampMs: s.Timestamp.UnixMilli(),
 		})
 	}
 
 	return balances, nil
-}
-
-// parseFloat64 parses a numeric string to float64.
-// Returns an error on empty strings, unparseable values, NaN, and Inf
-// to prevent silent data corruption in downstream calculations.
-func parseFloat64(s string) (float64, error) {
-	if s == "" {
-		return 0, nil
-	}
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, fmt.Errorf("cannot parse %q: %w", s, err)
-	}
-	if math.IsNaN(f) || math.IsInf(f, 0) {
-		return 0, fmt.Errorf("invalid value: %v", f)
-	}
-	return f, nil
 }
 
 // GetAllBalanceSnapshots returns balance snapshots for an account, sorted
@@ -121,13 +98,9 @@ func (c *Client) GetAllBalanceSnapshots(ctx context.Context, accountID uuid.UUID
 
 	balances := make([]*BalanceSnapshot, 0, len(resp.Snapshots))
 	for _, s := range resp.Snapshots {
-		balance, err := parseFloat64(s.Balance)
-		if err != nil {
-			return nil, fmt.Errorf("invalid balance %q for asset %s: %w", s.Balance, s.Asset, err)
-		}
 		balances = append(balances, &BalanceSnapshot{
 			Asset:       s.Asset,
-			Balance:     balance,
+			Balance:     s.Balance,
 			TimestampMs: s.Timestamp.UnixMilli(),
 		})
 	}
@@ -336,57 +309,6 @@ func (c *Client) PruneOldSpotBalanceSnapshots(ctx context.Context, beforeMs int6
 	}
 
 	return resp.Delete.AffectedRows, nil
-}
-
-// ---------------------------------------------------------------------------
-// Funding range sum
-// ---------------------------------------------------------------------------
-
-// SumFundingInRange returns the sum of all funding payment amounts for an account
-// in the half-open interval (fromMs, toMs].
-func (c *Client) SumFundingInRange(ctx context.Context, accountID uuid.UUID, fromMs, toMs int64) (string, error) {
-	query := `
-		query SumFundingInRange($account_id: uuid!, $from_ms: bigint!, $to_ms: bigint!) {
-			funding_payments_aggregate(
-				where: {
-					exchange_account_id: { _eq: $account_id }
-					timestamp: { _gt: $from_ms, _lte: $to_ms }
-				}
-			) {
-				aggregate {
-					sum {
-						amount
-					}
-				}
-			}
-		}
-	`
-
-	req := c.graphqlRequestWithVars(query, map[string]interface{}{
-		"account_id": accountID.String(),
-		"from_ms":    fromMs,
-		"to_ms":      toMs,
-	})
-
-	var resp struct {
-		Aggregate struct {
-			Aggregate struct {
-				Sum struct {
-					Amount *string `json:"amount"`
-				} `json:"sum"`
-			} `json:"aggregate"`
-		} `json:"funding_payments_aggregate"`
-	}
-
-	if err := c.execute(ctx, req, &resp); err != nil {
-		return "0", fmt.Errorf("failed to sum funding in range: %w", err)
-	}
-
-	if resp.Aggregate.Aggregate.Sum.Amount == nil {
-		return "0", nil
-	}
-
-	return *resp.Aggregate.Aggregate.Sum.Amount, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -42,8 +42,8 @@ func TestClient_GetAllBalanceSnapshots(t *testing.T) {
 	if balances[0].Asset != "USDC" {
 		t.Errorf("Expected first asset USDC, got %s", balances[0].Asset)
 	}
-	if balances[0].Balance != 1000.50 {
-		t.Errorf("Expected balance 1000.50, got %f", balances[0].Balance)
+	if balances[0].Balance != "1000.50" {
+		t.Errorf("Expected balance 1000.50, got %s", balances[0].Balance)
 	}
 }
 
@@ -294,75 +294,6 @@ func TestClient_PruneOldSpotBalanceSnapshots(t *testing.T) {
 	}
 }
 
-func TestClient_SumFundingInRange(t *testing.T) {
-	ctx := context.Background()
-	accountID := uuid.New()
-
-	mockClient := &mockGraphQLClient{
-		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
-			amount := "123.45"
-			respData := map[string]interface{}{
-				"funding_payments_aggregate": map[string]interface{}{
-					"aggregate": map[string]interface{}{
-						"sum": map[string]interface{}{
-							"amount": &amount,
-						},
-					},
-				},
-			}
-			data, _ := json.Marshal(respData)
-			return json.Unmarshal(data, resp)
-		},
-	}
-
-	client := NewClientWithGraphQL(mockClient, ClientConfig{
-		URL:         "http://localhost:8080/v1/graphql",
-		AdminSecret: "test-secret",
-	})
-
-	sum, err := client.SumFundingInRange(ctx, accountID, 1700000000000, 1700000100000)
-	if err != nil {
-		t.Fatalf("SumFundingInRange failed: %v", err)
-	}
-	if sum != "123.45" {
-		t.Errorf("Expected sum 123.45, got %s", sum)
-	}
-}
-
-func TestClient_SumFundingInRange_Nil(t *testing.T) {
-	ctx := context.Background()
-	accountID := uuid.New()
-
-	mockClient := &mockGraphQLClient{
-		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
-			respData := map[string]interface{}{
-				"funding_payments_aggregate": map[string]interface{}{
-					"aggregate": map[string]interface{}{
-						"sum": map[string]interface{}{
-							"amount": nil,
-						},
-					},
-				},
-			}
-			data, _ := json.Marshal(respData)
-			return json.Unmarshal(data, resp)
-		},
-	}
-
-	client := NewClientWithGraphQL(mockClient, ClientConfig{
-		URL:         "http://localhost:8080/v1/graphql",
-		AdminSecret: "test-secret",
-	})
-
-	sum, err := client.SumFundingInRange(ctx, accountID, 1700000000000, 1700000100000)
-	if err != nil {
-		t.Fatalf("SumFundingInRange failed: %v", err)
-	}
-	if sum != "0" {
-		t.Errorf("Expected sum 0, got %s", sum)
-	}
-}
-
 func TestClient_UpdateAccountTypeMetadata(t *testing.T) {
 	ctx := context.Background()
 	accountID := uuid.New()
@@ -464,15 +395,15 @@ func TestClient_GetLatestBalanceSnapshots(t *testing.T) {
 	if balances[0].Asset != "SOL" {
 		t.Errorf("Expected first asset SOL, got %s", balances[0].Asset)
 	}
-	if balances[0].Balance != 25.5 {
-		t.Errorf("Expected SOL balance 25.5, got %f", balances[0].Balance)
+	if balances[0].Balance != "25.5" {
+		t.Errorf("Expected SOL balance 25.5, got %s", balances[0].Balance)
 	}
 	// Check BTC
 	if balances[1].Asset != "BTC" {
 		t.Errorf("Expected second asset BTC, got %s", balances[1].Asset)
 	}
-	if balances[1].Balance != 0.5 {
-		t.Errorf("Expected BTC balance 0.5, got %f", balances[1].Balance)
+	if balances[1].Balance != "0.5" {
+		t.Errorf("Expected BTC balance 0.5, got %s", balances[1].Balance)
 	}
 }
 
@@ -505,35 +436,3 @@ func TestClient_GetLatestBalanceSnapshots_Empty(t *testing.T) {
 	}
 }
 
-func TestParseFloat64(t *testing.T) {
-	t.Run("valid values", func(t *testing.T) {
-		tests := []struct {
-			input string
-			want  float64
-		}{
-			{"100.5", 100.5},
-			{"-50.25", -50.25},
-			{"0", 0},
-			{"", 0},
-		}
-		for _, tt := range tests {
-			got, err := parseFloat64(tt.input)
-			if err != nil {
-				t.Errorf("parseFloat64(%q) unexpected error: %v", tt.input, err)
-			}
-			if got != tt.want {
-				t.Errorf("parseFloat64(%q) = %f, want %f", tt.input, got, tt.want)
-			}
-		}
-	})
-
-	t.Run("invalid values return error", func(t *testing.T) {
-		invalid := []string{"invalid", "NaN", "Inf", "-Inf"}
-		for _, input := range invalid {
-			_, err := parseFloat64(input)
-			if err == nil {
-				t.Errorf("parseFloat64(%q) expected error, got nil", input)
-			}
-		}
-	})
-}

--- a/db/trade.go
+++ b/db/trade.go
@@ -34,6 +34,8 @@ func (c *Client) GetTrade(ctx context.Context, id string) (*Trade, error) {
 				trade_id
 				exchange_account_id
 				market_type
+				tx_signature
+				fee_asset
 			}
 		}
 	`
@@ -85,6 +87,7 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					quantity
 					timestamp
 					fee
+					fee_asset
 					order_id
 					trade_id
 					exchange_account_id
@@ -118,6 +121,7 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					quantity
 					timestamp
 					fee
+					fee_asset
 					order_id
 					trade_id
 					exchange_account_id
@@ -150,6 +154,7 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					quantity
 					timestamp
 					fee
+					fee_asset
 					order_id
 					trade_id
 					exchange_account_id
@@ -175,6 +180,7 @@ func (c *Client) ListTrades(ctx context.Context, filter TradeFilter) ([]*Trade, 
 					quantity
 					timestamp
 					fee
+					fee_asset
 					order_id
 					trade_id
 					exchange_account_id
@@ -213,6 +219,8 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 			$trade_id: String!
 			$exchange_account_id: uuid!
 			$market_type: String!
+			$tx_signature: String
+			$fee_asset: String!
 		) {
 			insert_trades_one(object: {
 				base_asset: $base_asset
@@ -226,6 +234,8 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 				trade_id: $trade_id
 				exchange_account_id: $exchange_account_id
 				market_type: $market_type
+				tx_signature: $tx_signature
+				fee_asset: $fee_asset
 			}) {
 				id
 				base_asset
@@ -239,6 +249,8 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 				trade_id
 				exchange_account_id
 				market_type
+				tx_signature
+				fee_asset
 			}
 		}
 	`
@@ -261,6 +273,10 @@ func (c *Client) CreateTrade(ctx context.Context, input *TradeInput) (*Trade, er
 		"trade_id":            input.TradeID,
 		"exchange_account_id": input.ExchangeAccountID.String(),
 		"market_type":         marketType,
+		"fee_asset":           input.FeeAsset,
+	}
+	if input.TxSignature != "" {
+		vars["tx_signature"] = input.TxSignature
 	}
 
 	req := c.graphqlRequestWithVars(query, vars)
@@ -296,6 +312,8 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 			$trade_id: String!
 			$exchange_account_id: uuid!
 			$market_type: String!
+			$tx_signature: String
+			$fee_asset: String!
 		) {
 			update_trades_by_pk(
 				pk_columns: { id: $id }
@@ -311,6 +329,8 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 					trade_id: $trade_id
 					exchange_account_id: $exchange_account_id
 					market_type: $market_type
+					tx_signature: $tx_signature
+					fee_asset: $fee_asset
 				}
 			) {
 				id
@@ -325,6 +345,8 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 				trade_id
 				exchange_account_id
 				market_type
+				tx_signature
+				fee_asset
 			}
 		}
 	`
@@ -348,6 +370,10 @@ func (c *Client) UpdateTrade(ctx context.Context, id string, input *TradeInput) 
 		"trade_id":            input.TradeID,
 		"exchange_account_id": input.ExchangeAccountID.String(),
 		"market_type":         marketType,
+		"fee_asset":           input.FeeAsset,
+	}
+	if input.TxSignature != "" {
+		vars["tx_signature"] = input.TxSignature
 	}
 
 	req := c.graphqlRequestWithVars(query, vars)
@@ -419,6 +445,8 @@ func (c *Client) GetTradesByIDs(ctx context.Context, ids []uuid.UUID) ([]*Trade,
 				trade_id
 				exchange_account_id
 				market_type
+				tx_signature
+				fee_asset
 			}
 		}
 	`
@@ -472,6 +500,8 @@ func (c *Client) LatestTrade(ctx context.Context, exchangeAccountIDs []uuid.UUID
 				trade_id
 				exchange_account_id
 				market_type
+				tx_signature
+				fee_asset
 			}
 		}
 	`
@@ -506,4 +536,42 @@ func (c *Client) LatestTrade(ctx context.Context, exchangeAccountIDs []uuid.UUID
 	}
 
 	return result, nil
+}
+
+// FindTradesByTxSignature retrieves trades by transaction signature across all exchange accounts.
+func (c *Client) FindTradesByTxSignature(ctx context.Context, txSignature string) ([]*Trade, error) {
+	query := `
+		query FindTradesByTxSignature($tx_signature: String!) {
+			trades(where: { tx_signature: { _eq: $tx_signature } }) {
+				id
+				base_asset
+				quote_asset
+				side
+				price
+				quantity
+				timestamp
+				fee
+				order_id
+				trade_id
+				exchange_account_id
+				market_type
+				tx_signature
+				fee_asset
+			}
+		}
+	`
+
+	req := c.graphqlRequestWithVars(query, map[string]interface{}{
+		"tx_signature": txSignature,
+	})
+
+	var resp struct {
+		Trades []*Trade `json:"trades"`
+	}
+
+	if err := c.execute(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to find trades by tx signature: %w", err)
+	}
+
+	return resp.Trades, nil
 }

--- a/db/transfer.go
+++ b/db/transfer.go
@@ -100,10 +100,21 @@ func (c *Client) GetTransfersByIDs(ctx context.Context, ids []uuid.UUID) ([]*Tra
 }
 
 // AddTransfers inserts transfer records into the transfers table.
-// Uses ON CONFLICT DO NOTHING to avoid duplicates.
+// Duplicates raise a unique-constraint violation and must be handled by callers —
+// silent ON CONFLICT tolerance is a bug magnet at the re-sync cursor boundary.
+//
+// Before inserting, upgrades any existing rows that have external_id = '' to
+// the real external_id when the base columns (exchange_account_id, type, asset,
+// timestamp) match. This prevents duplicates when the same transfer was
+// originally synced without an external_id and later re-synced with one.
 func (c *Client) AddTransfers(ctx context.Context, inputs []*TransferInput) ([]*Transfer, error) {
 	if len(inputs) == 0 {
 		return []*Transfer{}, nil
+	}
+
+	// Upgrade empty external_ids on existing rows before inserting.
+	if err := c.upgradeTransferExternalIDs(ctx, inputs); err != nil {
+		return nil, fmt.Errorf("failed to upgrade transfer external IDs: %w", err)
 	}
 
 	objects := make([]map[string]interface{}, len(inputs))
@@ -115,6 +126,9 @@ func (c *Client) AddTransfers(ctx context.Context, inputs []*TransferInput) ([]*
 			"amount":              input.Amount,
 			"timestamp":           input.Timestamp.UnixMilli(),
 		}
+		if input.ExternalID != "" {
+			obj["external_id"] = input.ExternalID
+		}
 		if len(input.Metadata) > 0 {
 			obj["metadata"] = input.Metadata
 		}
@@ -123,7 +137,7 @@ func (c *Client) AddTransfers(ctx context.Context, inputs []*TransferInput) ([]*
 
 	query := `
 		mutation AddTransfers($objects: [transfers_insert_input!]!) {
-			insert_transfers(objects: $objects, on_conflict: {constraint: idx_transfers_unique, update_columns: []}) {
+			insert_transfers(objects: $objects) {
 				returning {
 					id
 					exchange_account_id
@@ -131,6 +145,7 @@ func (c *Client) AddTransfers(ctx context.Context, inputs []*TransferInput) ([]*
 					asset
 					amount
 					timestamp
+					external_id
 					metadata
 				}
 			}
@@ -152,6 +167,62 @@ func (c *Client) AddTransfers(ctx context.Context, inputs []*TransferInput) ([]*
 	}
 
 	return resp.InsertTransfers.Returning, nil
+}
+
+// upgradeTransferExternalIDs updates existing transfers that have external_id = ''
+// to the real external_id when all base columns match. This is done one at a time
+// since each transfer has a unique external_id value. Only inputs with non-empty
+// ExternalID are processed.
+func (c *Client) upgradeTransferExternalIDs(ctx context.Context, inputs []*TransferInput) error {
+	for _, input := range inputs {
+		if input.ExternalID == "" {
+			continue
+		}
+
+		query := `
+			mutation UpgradeTransferExternalID(
+				$account_id: uuid!,
+				$type: String!,
+				$asset: String!,
+				$ts: bigint!,
+				$external_id: String!
+			) {
+				update_transfers(
+					where: {
+						exchange_account_id: { _eq: $account_id }
+						type: { _eq: $type }
+						asset: { _eq: $asset }
+						timestamp: { _eq: $ts }
+						external_id: { _eq: "" }
+					}
+					_set: { external_id: $external_id }
+				) {
+					affected_rows
+				}
+			}
+		`
+
+		req := c.graphqlRequestWithVars(query, map[string]interface{}{
+			"account_id":  input.ExchangeAccountID.String(),
+			"type":        input.Type,
+			"asset":       input.Asset,
+			"ts":          input.Timestamp.UnixMilli(),
+			"external_id": input.ExternalID,
+		})
+
+		var resp struct {
+			UpdateTransfers struct {
+				AffectedRows int `json:"affected_rows"`
+			} `json:"update_transfers"`
+		}
+
+		if err := c.execute(ctx, req, &resp); err != nil {
+			return fmt.Errorf("failed to upgrade external_id for transfer %s/%s/%s: %w",
+				input.Type, input.Asset, input.ExternalID, err)
+		}
+	}
+
+	return nil
 }
 
 // DeleteTransfersByAccountAndType deletes transfer records matching account ID and type.

--- a/db/transfer_test.go
+++ b/db/transfer_test.go
@@ -114,6 +114,70 @@ func TestClient_AddTransfers(t *testing.T) {
 	}
 }
 
+func TestClient_AddTransfers_WithExternalID(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+	returnedID := uuid.New()
+
+	callCount := 0
+	mockClient := &mockGraphQLClient{
+		runFunc: func(ctx context.Context, req *graphql.Request, resp interface{}) error {
+			callCount++
+			if callCount == 1 {
+				// First call: upgradeTransferExternalIDs update mutation
+				respData := map[string]interface{}{
+					"update_transfers": map[string]interface{}{
+						"affected_rows": 1,
+					},
+				}
+				data, _ := json.Marshal(respData)
+				return json.Unmarshal(data, resp)
+			}
+			// Second call: insert mutation
+			respData := map[string]interface{}{
+				"insert_transfers": map[string]interface{}{
+					"returning": []map[string]interface{}{},
+				},
+			}
+			data, _ := json.Marshal(respData)
+			return json.Unmarshal(data, resp)
+		},
+	}
+
+	client := NewClientWithGraphQL(mockClient, ClientConfig{
+		URL:         "http://localhost:8080/v1/graphql",
+		AdminSecret: "test-secret",
+	})
+
+	inputs := []*models.TransferInput{
+		{
+			ExchangeAccountID: accountID,
+			Type:              models.TypeDeposit,
+			Asset:             "USDC",
+			Amount:            "1000",
+			Timestamp:         time.Now(),
+			ExternalID:        "ext-123",
+		},
+	}
+
+	transfers, err := client.AddTransfers(ctx, inputs)
+	if err != nil {
+		t.Fatalf("AddTransfers failed: %v", err)
+	}
+
+	// The upgrade mutation upgraded the existing row, so insert returns nothing new
+	if len(transfers) != 0 {
+		t.Fatalf("Expected 0 transfers (upgraded existing), got %d", len(transfers))
+	}
+
+	// Verify both mutations were called: upgrade + insert
+	if callCount != 2 {
+		t.Errorf("Expected 2 GraphQL calls (upgrade + insert), got %d", callCount)
+	}
+
+	_ = returnedID // suppress unused
+}
+
 func TestClient_AddTransfers_Empty(t *testing.T) {
 	ctx := context.Background()
 	client := NewClientWithGraphQL(&mockGraphQLClient{}, ClientConfig{

--- a/exchange/client.go
+++ b/exchange/client.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/zif-terminal/lib/db"
 	"github.com/zif-terminal/lib/exchange/drift"
 	"github.com/zif-terminal/lib/exchange/hyperliquid"
 	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/exchange/lighter"
+	"github.com/zif-terminal/lib/exchange/variational"
 )
 
 // ErrExchangeNotFound is returned when an exchange name is not recognized
@@ -14,6 +17,7 @@ var ErrExchangeNotFound = errors.New("exchange not found")
 
 // GetClient returns an ExchangeClient for the given exchange name.
 // Returns ErrExchangeNotFound if the exchange name is not recognized.
+// For exchanges that require a DB client (e.g., variational), use GetClientWithDB instead.
 //
 // Example:
 //
@@ -28,8 +32,23 @@ func GetClient(name string) (iface.ExchangeClient, error) {
 		return drift.NewClient(), nil
 	case "hyperliquid":
 		return hyperliquid.NewClient(), nil
+	case "lighter":
+		return lighter.NewClient(), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrExchangeNotFound, name)
+	}
+}
+
+// GetClientWithDB returns an ExchangeClient for the given exchange name,
+// using the provided DB client for exchanges that read from staging tables
+// (e.g., variational reads from omni_raw_events).
+// Falls back to GetClient for exchanges that don't need a DB client.
+func GetClientWithDB(name string, dbClient db.DBClient) (iface.ExchangeClient, error) {
+	switch name {
+	case "variational":
+		return variational.NewClient(dbClient), nil
+	default:
+		return GetClient(name)
 	}
 }
 
@@ -38,5 +57,7 @@ func ListAvailableExchanges() []string {
 	return []string{
 		"drift",
 		"hyperliquid",
+		"lighter",
+		"variational",
 	}
 }

--- a/exchange/client_test.go
+++ b/exchange/client_test.go
@@ -70,11 +70,64 @@ func TestGetClientHyperliquid(t *testing.T) {
 	var _ iface.ExchangeClient = client
 }
 
+func TestGetClientLighter(t *testing.T) {
+	client, err := GetClient("lighter")
+	if err != nil {
+		t.Fatalf("GetClient failed: %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("GetClient returned nil client")
+	}
+
+	if client.Name() != "lighter" {
+		t.Errorf("Expected client name 'lighter', got '%s'", client.Name())
+	}
+
+	var _ iface.ExchangeClient = client
+}
+
+func TestGetClientWithDB_Variational(t *testing.T) {
+	// variational requires a DB client — pass nil since we're only checking construction
+	client, err := GetClientWithDB("variational", nil)
+	if err != nil {
+		t.Fatalf("GetClientWithDB failed: %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("GetClientWithDB returned nil client")
+	}
+
+	if client.Name() != "variational" {
+		t.Errorf("Expected client name 'variational', got '%s'", client.Name())
+	}
+
+	var _ iface.ExchangeClient = client
+}
+
+func TestGetClientWithDB_FallbackToDrift(t *testing.T) {
+	client, err := GetClientWithDB("drift", nil)
+	if err != nil {
+		t.Fatalf("GetClientWithDB failed for drift: %v", err)
+	}
+
+	if client.Name() != "drift" {
+		t.Errorf("Expected client name 'drift', got '%s'", client.Name())
+	}
+}
+
+func TestGetClientWithDB_NotFound(t *testing.T) {
+	_, err := GetClientWithDB("nonexistent", nil)
+	if !errors.Is(err, ErrExchangeNotFound) {
+		t.Errorf("Expected ErrExchangeNotFound, got: %v", err)
+	}
+}
+
 func TestListAvailableExchanges(t *testing.T) {
 	exchanges := ListAvailableExchanges()
 
-	if len(exchanges) != 2 {
-		t.Fatalf("Expected 2 exchanges, got %d", len(exchanges))
+	if len(exchanges) != 4 {
+		t.Fatalf("Expected 4 exchanges, got %d", len(exchanges))
 	}
 
 	found := map[string]bool{}
@@ -87,5 +140,11 @@ func TestListAvailableExchanges(t *testing.T) {
 	}
 	if !found["hyperliquid"] {
 		t.Error("Expected 'hyperliquid' in exchanges list")
+	}
+	if !found["lighter"] {
+		t.Error("Expected 'lighter' in exchanges list")
+	}
+	if !found["variational"] {
+		t.Error("Expected 'variational' in exchanges list")
 	}
 }

--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -164,6 +164,22 @@ func (c *Client) FetchTrades(
 	// Combine trades and swaps
 	allResults := append(tradeResults, swapResults...)
 
+	// Deduplicate by trade_id + base_asset + market_type before returning —
+	// the Drift API can return the same record more than once across the
+	// historical/recent boundary. The key must match the DB unique constraint
+	// (trade_id, exchange_account_id, base_asset, market_type).
+	seenTrades := make(map[string]bool, len(allResults))
+	dedupedResults := make([]tradeWithPrices, 0, len(allResults))
+	for _, r := range allResults {
+		key := fmt.Sprintf("%s_%s_%s", r.trade.TradeID, r.trade.BaseAsset, r.trade.MarketType)
+		if seenTrades[key] {
+			continue
+		}
+		seenTrades[key] = true
+		dedupedResults = append(dedupedResults, r)
+	}
+	allResults = dedupedResults
+
 	// Sort by timestamp (oldest first)
 	sort.Slice(allResults, func(i, j int) bool {
 		return allResults[i].trade.Timestamp.Before(allResults[j].trade.Timestamp)
@@ -213,6 +229,21 @@ func (c *Client) FetchFundingPayments(
 		return nil, err
 	}
 
+	// Deduplicate by external_id before returning — the Drift API can return
+	// the same funding payment more than once.
+	seenFunding := make(map[string]bool, len(payments))
+	dedupedPayments := make([]*models.TransferInput, 0, len(payments))
+	for _, p := range payments {
+		if p.ExternalID != "" && seenFunding[p.ExternalID] {
+			continue
+		}
+		if p.ExternalID != "" {
+			seenFunding[p.ExternalID] = true
+		}
+		dedupedPayments = append(dedupedPayments, p)
+	}
+	payments = dedupedPayments
+
 	// Sort by timestamp (oldest first)
 	sort.Slice(payments, func(i, j int) bool {
 		return payments[i].Timestamp.Before(payments[j].Timestamp)
@@ -260,6 +291,22 @@ func (c *Client) FetchDeposits(
 		return nil, nil, err
 	}
 
+	// Deduplicate by external_id before returning — the Drift API can return
+	// the same deposit record more than once (within a single month archive or
+	// across the historical/recent boundary).
+	seen := make(map[string]bool, len(results))
+	deduped := make([]depositWithPrice, 0, len(results))
+	for _, r := range results {
+		if r.transfer.ExternalID != "" && seen[r.transfer.ExternalID] {
+			continue
+		}
+		if r.transfer.ExternalID != "" {
+			seen[r.transfer.ExternalID] = true
+		}
+		deduped = append(deduped, r)
+	}
+	results = deduped
+
 	// Sort by timestamp (oldest first)
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].transfer.Timestamp.Before(results[j].transfer.Timestamp)
@@ -289,7 +336,7 @@ func (c *Client) createTradePageFetcher(accountUUID uuid.UUID) pageFetcher[trade
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[tradeWithPrices]{}, &HTTPStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
 		}
 
 		var response driftTradesResponse
@@ -338,7 +385,7 @@ func (c *Client) createSwapPageFetcher(accountUUID uuid.UUID) pageFetcher[tradeW
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[tradeWithPrices]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[tradeWithPrices]{}, &HTTPStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
 		}
 
 		var response driftSwapsResponse
@@ -383,7 +430,7 @@ func (c *Client) createFundingPageFetcher(accountUUID uuid.UUID) pageFetcher[*mo
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[*models.TransferInput]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[*models.TransferInput]{}, &HTTPStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
 		}
 
 		var response driftFundingResponse
@@ -428,7 +475,7 @@ func (c *Client) createDepositPageFetcher(accountUUID uuid.UUID) pageFetcher[dep
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[depositWithPrice]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[depositWithPrice]{}, &HTTPStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
 		}
 
 		var response driftDepositsResponse
@@ -491,8 +538,17 @@ func (c *Client) FetchSettlements(
 		return nil, err
 	}
 
+	// Deduplicate records by settlement_id before returning — the Drift API
+	// can return the same settlePnl record more than once.
+	seenSettlements := make(map[string]bool, len(records))
 	settlements := make([]*models.Settlement, 0, len(records))
 	for _, r := range records {
+		sid := settlementID(r)
+		if seenSettlements[sid] {
+			continue
+		}
+		seenSettlements[sid] = true
+
 		// Resolve market index to symbol
 		marketInfo, err := c.getMarketInfo(ctx, r.MarketIndex, "perp")
 		market := fmt.Sprintf("%d", r.MarketIndex)
@@ -500,7 +556,6 @@ func (c *Client) FetchSettlements(
 			market = marketInfo.Symbol
 		}
 
-		sid := settlementID(r)
 		settlements = append(settlements, &models.Settlement{
 			ExchangeAccountID: accountUUID,
 			Asset:             "USDC",
@@ -555,7 +610,7 @@ func (c *Client) createSettlePnlPageFetcher() pageFetcher[settlePnlRecord] {
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return pageResult[settlePnlRecord]{}, fmt.Errorf("API returned status %d: %s", resp.StatusCode, resp.Status)
+			return pageResult[settlePnlRecord]{}, &HTTPStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
 		}
 
 		var response driftSettlePnlResponse

--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -308,7 +308,8 @@ func (c *Client) createTradePageFetcher(accountUUID uuid.UUID) pageFetcher[trade
 		for _, record := range response.Records {
 			trade, price, err := c.transformTrade(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/trades: failed to process trade %s: %w", record.FillRecordID, err)
+				return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/trades: failed to transform trade %s (market_index=%d, market_type=%s, ts=%d): %w",
+					record.FillRecordID, record.MarketIndex, record.MarketType, record.Ts, err)
 			}
 			var prices []*models.PriceRecord
 			if price != nil {
@@ -317,9 +318,13 @@ func (c *Client) createTradePageFetcher(accountUUID uuid.UUID) pageFetcher[trade
 			results = append(results, tradeWithPrices{trade: trade, prices: prices})
 		}
 
+		nextPage, err := extractNextPage(response.Meta)
+		if err != nil {
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/trades: %w", err)
+		}
 		return pageResult[tradeWithPrices]{
 			items:    results,
-			nextPage: extractNextPage(response.Meta),
+			nextPage: nextPage,
 		}, nil
 	}
 }
@@ -352,14 +357,19 @@ func (c *Client) createSwapPageFetcher(accountUUID uuid.UUID) pageFetcher[tradeW
 		for _, record := range response.Records {
 			swap, prices, err := c.transformSwap(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/swaps: failed to process swap %s_%d: %w", record.TxSig, record.TxSigIndex, err)
+				return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/swaps: failed to transform swap %s_%d (out_market=%d, in_market=%d, ts=%d): %w",
+					record.TxSig, record.TxSigIndex, record.OutMarketIndex, record.InMarketIndex, record.Ts, err)
 			}
 			results = append(results, tradeWithPrices{trade: swap, prices: prices})
 		}
 
+		nextPage, err := extractNextPage(response.Meta)
+		if err != nil {
+			return pageResult[tradeWithPrices]{}, fmt.Errorf("drift/swaps: %w", err)
+		}
 		return pageResult[tradeWithPrices]{
 			items:    results,
-			nextPage: extractNextPage(response.Meta),
+			nextPage: nextPage,
 		}, nil
 	}
 }
@@ -392,14 +402,19 @@ func (c *Client) createFundingPageFetcher(accountUUID uuid.UUID) pageFetcher[*mo
 		for _, record := range response.Records {
 			payment, err := c.transformFundingPayment(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[*models.TransferInput]{}, fmt.Errorf("drift/funding: failed to process payment at ts=%d: %w", record.Ts, err)
+				return pageResult[*models.TransferInput]{}, fmt.Errorf("drift/funding: failed to transform payment (market_index=%d, ts=%d): %w",
+					record.MarketIndex, record.Ts, err)
 			}
 			payments = append(payments, payment)
 		}
 
+		nextPage, err := extractNextPage(response.Meta)
+		if err != nil {
+			return pageResult[*models.TransferInput]{}, fmt.Errorf("drift/funding: %w", err)
+		}
 		return pageResult[*models.TransferInput]{
 			items:    payments,
-			nextPage: extractNextPage(response.Meta),
+			nextPage: nextPage,
 		}, nil
 	}
 }
@@ -432,14 +447,19 @@ func (c *Client) createDepositPageFetcher(accountUUID uuid.UUID) pageFetcher[dep
 		for _, record := range response.Records {
 			transfer, price, err := c.transformDeposit(ctx, record, accountUUID)
 			if err != nil {
-				return pageResult[depositWithPrice]{}, fmt.Errorf("drift/deposits: failed to process deposit %s: %w", record.DepositRecordID, err)
+				return pageResult[depositWithPrice]{}, fmt.Errorf("drift/deposits: failed to transform deposit %s (market_index=%d, ts=%d): %w",
+					record.DepositRecordID, record.MarketIndex, record.Ts, err)
 			}
 			results = append(results, depositWithPrice{transfer: transfer, price: price})
 		}
 
+		nextPage, err := extractNextPage(response.Meta)
+		if err != nil {
+			return pageResult[depositWithPrice]{}, fmt.Errorf("drift/deposits: %w", err)
+		}
 		return pageResult[depositWithPrice]{
 			items:    results,
-			nextPage: extractNextPage(response.Meta),
+			nextPage: nextPage,
 		}, nil
 	}
 }
@@ -449,6 +469,8 @@ type settlePnlRecord struct {
 	Timestamp   time.Time
 	Pnl         string // Settled PnL amount (signed)
 	MarketIndex int
+	TxSig       string
+	TxSigIndex  int
 }
 
 // FetchSettlements implements iface.ExchangeClient.
@@ -478,13 +500,15 @@ func (c *Client) FetchSettlements(
 			market = marketInfo.Symbol
 		}
 
+		sid := settlementID(r)
 		settlements = append(settlements, &models.Settlement{
 			ExchangeAccountID: accountUUID,
 			Asset:             "USDC",
 			Amount:            r.Pnl,
 			Market:            market,
 			Timestamp:         r.Timestamp,
-			SettlementID:      fmt.Sprintf("settle_%d_%s", r.MarketIndex, r.Timestamp.Format("20060102150405")),
+			SettlementID:      sid,
+			ExternalID:        sid,
 		})
 	}
 
@@ -549,28 +573,37 @@ func (c *Client) createSettlePnlPageFetcher() pageFetcher[settlePnlRecord] {
 				Timestamp:   time.Unix(r.Ts, 0).UTC(),
 				Pnl:         cleanDecimalString(r.Pnl),
 				MarketIndex: r.MarketIndex,
+				TxSig:       r.TxSig,
+				TxSigIndex:  r.TxSigIndex,
 			})
 		}
 
+		nextPage, err := extractNextPage(response.Meta)
+		if err != nil {
+			return pageResult[settlePnlRecord]{}, fmt.Errorf("drift/settlePnl: %w", err)
+		}
 		return pageResult[settlePnlRecord]{
 			items:    records,
-			nextPage: extractNextPage(response.Meta),
+			nextPage: nextPage,
 		}, nil
 	}
 }
 
-// extractNextPage extracts the next page token from API response metadata
-func extractNextPage(meta driftMeta) string {
+// extractNextPage extracts the next page token from API response metadata.
+// Returns "" when meta.NextPage is nil (terminal page). Returns an error on
+// unknown token types — a silent "" would mask a real pagination bug.
+func extractNextPage(meta driftMeta) (string, error) {
 	if meta.NextPage == nil {
-		return ""
+		return "", nil
 	}
 	switch v := meta.NextPage.(type) {
 	case string:
-		return v
+		return v, nil
 	case float64:
-		return strconv.Itoa(int(v))
+		return strconv.Itoa(int(v)), nil
+	default:
+		return "", fmt.Errorf("drift: unknown next_page token type %T: %v", meta.NextPage, meta.NextPage)
 	}
-	return ""
 }
 
 // Transform functions - convert API records to model types
@@ -584,7 +617,10 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 	} else {
 		direction = record.MakerOrderDirection
 	}
-	side := normalizeSide(direction)
+	side, err := normalizeSide(direction)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to normalize side for trade %s (ts=%d): %w", record.FillRecordID, record.Ts, err)
+	}
 
 	var orderID string
 	if isTaker {
@@ -616,7 +652,10 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 	quoteAsset := marketInfo.QuoteAsset
 	baseAmount := cleanDecimalString(record.BaseAssetAmountFilled)
 	quoteAmount := cleanDecimalString(record.QuoteAssetAmountFilled)
-	price := calculatePrice(quoteAmount, baseAmount)
+	price, err := calculatePrice(quoteAmount, baseAmount)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to compute price for trade %s (base=%q, quote=%q): %w", record.FillRecordID, baseAmount, quoteAmount, err)
+	}
 	timestamp := time.Unix(record.Ts, 0).UTC()
 
 	trade := &models.TradeInput{
@@ -631,6 +670,8 @@ func (c *Client) transformTrade(ctx context.Context, record driftTradeRecord, ac
 		Timestamp:         timestamp,
 		ExchangeAccountID: accountUUID,
 		MarketType:        marketType,
+		TxSignature:       record.TxSig,
+		FeeAsset:          quoteAsset,
 	}
 
 	// Extract oracle price if available
@@ -664,6 +705,7 @@ func (c *Client) transformSwap(ctx context.Context, record driftSwapRecord, acco
 	fee := cleanDecimalString(record.Fee)
 
 	var baseAsset, quoteAsset, side, quantity, price string
+	var priceErr error
 
 	// Drift swap semantics: out = what user RECEIVES, in = what user SENDS
 	// (from the protocol's perspective: user puts tokens IN, gets tokens OUT)
@@ -673,21 +715,24 @@ func (c *Client) transformSwap(ctx context.Context, record driftSwapRecord, acco
 		quoteAsset = "USDC"
 		side = "sell"
 		quantity = amountIn
-		price = calculatePrice(amountOut, amountIn)
+		price, priceErr = calculatePrice(amountOut, amountIn)
 	} else if inMarket.BaseAsset == "USDC" {
 		// User sent USDC (in), received outMarket asset (out) → buy base with USDC
 		baseAsset = outMarket.BaseAsset
 		quoteAsset = "USDC"
 		side = "buy"
 		quantity = amountOut
-		price = calculatePrice(amountIn, amountOut)
+		price, priceErr = calculatePrice(amountIn, amountOut)
 	} else {
 		// Non-USDC swap: user sent inMarket (in), received outMarket (out)
 		baseAsset = outMarket.BaseAsset
 		quoteAsset = inMarket.BaseAsset
 		side = "buy"
 		quantity = amountOut
-		price = calculatePrice(amountIn, amountOut)
+		price, priceErr = calculatePrice(amountIn, amountOut)
+	}
+	if priceErr != nil {
+		return nil, nil, fmt.Errorf("failed to compute price for swap %s_%d (in=%q, out=%q): %w", record.TxSig, record.TxSigIndex, amountIn, amountOut, priceErr)
 	}
 
 	if baseAsset == "" || quoteAsset == "" {
@@ -710,6 +755,8 @@ func (c *Client) transformSwap(ctx context.Context, record driftSwapRecord, acco
 		Timestamp:         timestamp,
 		ExchangeAccountID: accountUUID,
 		MarketType:        "swap",
+		TxSignature:       record.TxSig,
+		FeeAsset:          quoteAsset,
 	}
 
 	// Extract oracle prices for both sides of the swap
@@ -752,8 +799,9 @@ func (c *Client) transformFundingPayment(ctx context.Context, record driftFundin
 		Asset:             marketInfo.QuoteAsset,
 		Amount:            amount,
 		Timestamp:         timestamp,
+		ExternalID:        paymentID,
 		Metadata: map[string]string{
-			"market":     marketInfo.BaseAsset,
+			"market":     marketInfo.BaseAsset + "-PERP",
 			"payment_id": paymentID,
 		},
 	}, nil
@@ -780,6 +828,10 @@ func (c *Client) transformDeposit(ctx context.Context, record driftDepositRecord
 		Type:              transferType,
 		Amount:            amount,
 		Timestamp:         timestamp,
+		ExternalID:        record.DepositRecordID,
+		Metadata: map[string]string{
+			"payment_id": record.DepositRecordID,
+		},
 	}
 
 	// Extract oracle price if available
@@ -799,15 +851,24 @@ func (c *Client) transformDeposit(ctx context.Context, record driftDepositRecord
 
 // Helper functions
 
-func normalizeSide(direction string) string {
-	direction = strings.ToLower(strings.TrimSpace(direction))
-	switch direction {
+// settlementID returns a unique ID for a settlement record.
+// Uses TxSig + TxSigIndex when available; falls back to synthetic format.
+func settlementID(r settlePnlRecord) string {
+	if r.TxSig != "" {
+		return fmt.Sprintf("%s_%d", r.TxSig, r.TxSigIndex)
+	}
+	return fmt.Sprintf("settle_%d_%s", r.MarketIndex, r.Timestamp.Format("20060102150405"))
+}
+
+func normalizeSide(direction string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(direction))
+	switch normalized {
 	case "long":
-		return "buy"
+		return "buy", nil
 	case "short":
-		return "sell"
+		return "sell", nil
 	default:
-		return "buy"
+		return "", fmt.Errorf("drift: unknown order direction %q", direction)
 	}
 }
 
@@ -834,25 +895,25 @@ func cleanDecimalString(s string) string {
 	return s
 }
 
-func convertFromBasePrecision(raw string) string {
+func convertFromBasePrecision(raw string) (string, error) {
 	if raw == "" {
-		return "0"
+		return "0", nil
 	}
 	return divideByPrecision(raw, BasePrecision)
 }
 
-func convertFromQuotePrecision(raw string) string {
+func convertFromQuotePrecision(raw string) (string, error) {
 	if raw == "" {
-		return "0"
+		return "0", nil
 	}
 	return divideByPrecision(raw, QuotePrecision)
 }
 
-func divideByPrecision(raw string, precision int64) string {
+func divideByPrecision(raw string, precision int64) (string, error) {
 	rawInt := new(big.Int)
 	rawInt, ok := rawInt.SetString(raw, 10)
 	if !ok {
-		return "0"
+		return "", fmt.Errorf("drift: failed to parse integer %q for precision division", raw)
 	}
 
 	negative := rawInt.Sign() < 0
@@ -875,26 +936,26 @@ func divideByPrecision(raw string, precision int64) string {
 		str = "-" + str
 	}
 
-	return str
+	return str, nil
 }
 
-func calculatePrice(quoteAmount, baseAmount string) string {
+func calculatePrice(quoteAmount, baseAmount string) (string, error) {
 	if baseAmount == "" || baseAmount == "0" {
-		return "0"
+		return "0", nil
 	}
 
 	quoteFloat, _, err := big.ParseFloat(quoteAmount, 10, 256, big.ToNearestEven)
 	if err != nil {
-		return "0"
+		return "", fmt.Errorf("drift: failed to parse quote amount %q: %w", quoteAmount, err)
 	}
 
 	baseFloat, _, err := big.ParseFloat(baseAmount, 10, 256, big.ToNearestEven)
 	if err != nil {
-		return "0"
+		return "", fmt.Errorf("drift: failed to parse base amount %q: %w", baseAmount, err)
 	}
 
 	if baseFloat.Sign() == 0 {
-		return "0"
+		return "0", nil
 	}
 
 	result := new(big.Float).Quo(quoteFloat, baseFloat)
@@ -905,7 +966,7 @@ func calculatePrice(quoteAmount, baseAmount string) string {
 		str = strings.TrimRight(str, ".")
 	}
 
-	return str
+	return str, nil
 }
 
 func parseRetryAfter(retryAfter string) time.Duration {

--- a/exchange/drift/client_test.go
+++ b/exchange/drift/client_test.go
@@ -505,16 +505,16 @@ func TestDriftClient_FetchFundingPayments_Success(t *testing.T) {
 	}
 
 	// Verify first payment (oldest) - market stored in metadata
-	if payments[0].Metadata["market"] != "SOL" {
-		t.Errorf("Expected market 'SOL', got '%s'", payments[0].Metadata["market"])
+	if payments[0].Metadata["market"] != "SOL-PERP" {
+		t.Errorf("Expected market 'SOL-PERP', got '%s'", payments[0].Metadata["market"])
 	}
 	if payments[0].Amount != "0.1" {
 		t.Errorf("Expected amount '0.1', got '%s'", payments[0].Amount)
 	}
 
 	// Verify second payment (negative)
-	if payments[1].Metadata["market"] != "BTC" {
-		t.Errorf("Expected market 'BTC', got '%s'", payments[1].Metadata["market"])
+	if payments[1].Metadata["market"] != "BTC-PERP" {
+		t.Errorf("Expected market 'BTC-PERP', got '%s'", payments[1].Metadata["market"])
 	}
 	if payments[1].Amount != "-0.05" {
 		t.Errorf("Expected amount '-0.05', got '%s'", payments[1].Amount)
@@ -547,21 +547,32 @@ func TestDriftClient_FetchFundingPayments_ContextCancellation(t *testing.T) {
 
 func TestNormalizeSide(t *testing.T) {
 	tests := []struct {
-		input    string
-		expected string
+		input     string
+		expected  string
+		wantError bool
 	}{
-		{"long", "buy"},
-		{"LONG", "buy"},
-		{"Long", "buy"},
-		{"short", "sell"},
-		{"SHORT", "sell"},
-		{"Short", "sell"},
-		{"unknown", "buy"}, // Default
-		{"", "buy"},        // Default
+		{"long", "buy", false},
+		{"LONG", "buy", false},
+		{"Long", "buy", false},
+		{"short", "sell", false},
+		{"SHORT", "sell", false},
+		{"Short", "sell", false},
+		{"unknown", "", true},
+		{"", "", true},
 	}
 
 	for _, tc := range tests {
-		result := normalizeSide(tc.input)
+		result, err := normalizeSide(tc.input)
+		if tc.wantError {
+			if err == nil {
+				t.Errorf("normalizeSide(%q) expected error, got nil", tc.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeSide(%q) unexpected error: %v", tc.input, err)
+			continue
+		}
 		if result != tc.expected {
 			t.Errorf("normalizeSide(%q) = %q, expected %q", tc.input, result, tc.expected)
 		}
@@ -631,7 +642,11 @@ func TestConvertFromBasePrecision(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		result := convertFromBasePrecision(tc.raw)
+		result, err := convertFromBasePrecision(tc.raw)
+		if err != nil {
+			t.Errorf("convertFromBasePrecision(%q) unexpected error: %v", tc.raw, err)
+			continue
+		}
 		if result != tc.expected {
 			t.Errorf("convertFromBasePrecision(%q) = %q, expected %q", tc.raw, result, tc.expected)
 		}
@@ -654,7 +669,11 @@ func TestConvertFromQuotePrecision(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		result := convertFromQuotePrecision(tc.raw)
+		result, err := convertFromQuotePrecision(tc.raw)
+		if err != nil {
+			t.Errorf("convertFromQuotePrecision(%q) unexpected error: %v", tc.raw, err)
+			continue
+		}
 		if result != tc.expected {
 			t.Errorf("convertFromQuotePrecision(%q) = %q, expected %q", tc.raw, result, tc.expected)
 		}
@@ -676,7 +695,11 @@ func TestCalculatePrice(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		result := calculatePrice(tc.quote, tc.base)
+		result, err := calculatePrice(tc.quote, tc.base)
+		if err != nil {
+			t.Errorf("calculatePrice(%q, %q) unexpected error: %v", tc.quote, tc.base, err)
+			continue
+		}
 		if result != tc.expected {
 			t.Errorf("calculatePrice(%q, %q) = %q, expected %q", tc.quote, tc.base, result, tc.expected)
 		}
@@ -867,8 +890,8 @@ func TestDriftClient_FetchTrades_WithSwaps(t *testing.T) {
 }
 
 // TestFetchTrades_UnresolvableSwapMarketIndex verifies that a swap with an
-// unknown market index causes FetchTrades to return an error, not silently
-// skip the record. Same bug pattern as the deposit case.
+// unknown market index causes FetchTrades to return an error. Silently
+// skipping unresolvable records caused data gaps that went unnoticed.
 func TestFetchTrades_UnresolvableSwapMarketIndex(t *testing.T) {
 	now := time.Now()
 	swapTs := now.Add(-5 * 24 * time.Hour).Unix()
@@ -930,10 +953,10 @@ func TestFetchTrades_UnresolvableSwapMarketIndex(t *testing.T) {
 	since := time.Now().AddDate(0, 0, -30)
 	_, _, err := client.FetchTrades(context.Background(), account, since)
 	if err == nil {
-		t.Fatal("Expected error when swap has unresolvable market index, but got nil — swap would be silently dropped")
+		t.Fatal("Expected error for unresolvable swap market index, got nil")
 	}
-	if !strings.Contains(err.Error(), "888") {
-		t.Errorf("Error should reference the unresolvable market index 888, got: %v", err)
+	if !strings.Contains(err.Error(), "market spot index 888 not found") {
+		t.Errorf("Expected 'market not found' error, got: %v", err)
 	}
 }
 
@@ -1279,10 +1302,9 @@ func TestDriftClient_FetchDeposits_FiltersBySince(t *testing.T) {
 }
 
 // TestFetchDeposits_UnresolvableMarketIndex verifies that a deposit with an
-// unknown market index causes FetchDeposits to return an error, not silently
-// skip the record. This was a real bug: a PUMP deposit (spot market index 56)
-// was silently dropped because the market index wasn't in the hardcoded defaults
-// and the Drift markets API returned empty data.
+// unknown market index causes FetchDeposits to return an error. Silently
+// skipping unresolvable records caused data gaps (e.g., 2.38M PUMP deposits
+// were dropped when market index 56 wasn't in hardcoded defaults).
 func TestFetchDeposits_UnresolvableMarketIndex(t *testing.T) {
 	now := time.Now()
 	knownTs := now.Add(-10 * 24 * time.Hour).Unix()
@@ -1357,10 +1379,10 @@ func TestFetchDeposits_UnresolvableMarketIndex(t *testing.T) {
 	since := time.Now().AddDate(0, 0, -30)
 	_, _, err := client.FetchDeposits(context.Background(), account, since)
 	if err == nil {
-		t.Fatal("Expected error when deposit has unresolvable market index, but got nil — deposit would be silently dropped")
+		t.Fatal("Expected error for unresolvable deposit market index, got nil")
 	}
-	if !strings.Contains(err.Error(), "999") {
-		t.Errorf("Error should reference the unresolvable market index 999, got: %v", err)
+	if !strings.Contains(err.Error(), "market spot index 999 not found") {
+		t.Errorf("Expected 'market not found' error, got: %v", err)
 	}
 }
 

--- a/exchange/drift/live.go
+++ b/exchange/drift/live.go
@@ -140,7 +140,7 @@ func (c *Client) FetchBalances(
 
 		balances = append(balances, &models.BalanceSnapshot{
 			Asset:   b.Symbol,
-			Balance: balance,
+			Balance: b.Balance,
 		})
 	}
 
@@ -213,9 +213,10 @@ func (c *Client) FetchHistoricalBalanceSnapshots(
 					continue
 				}
 
+				_ = balance
 				balances = append(balances, &models.BalanceSnapshot{
 					Asset:   symbol,
-					Balance: balance,
+					Balance: asset.Balance,
 				})
 			}
 

--- a/exchange/drift/live_test.go
+++ b/exchange/drift/live_test.go
@@ -91,18 +91,18 @@ func TestDriftClient_FetchBalances_LiveEndpoint(t *testing.T) {
 		t.Fatalf("Expected 3 balances from /user endpoint, got %d", len(balances))
 	}
 
-	assetMap := map[string]float64{}
+	assetMap := map[string]string{}
 	for _, b := range balances {
 		assetMap[b.Asset] = b.Balance
 	}
-	if assetMap["USDC"] != 5000 {
-		t.Errorf("Expected USDC=5000, got %f", assetMap["USDC"])
+	if assetMap["USDC"] != "5000" {
+		t.Errorf("Expected USDC=5000, got %s", assetMap["USDC"])
 	}
-	if assetMap["SOL"] != 100 {
-		t.Errorf("Expected SOL=100, got %f", assetMap["SOL"])
+	if assetMap["SOL"] != "100" {
+		t.Errorf("Expected SOL=100, got %s", assetMap["SOL"])
 	}
-	if assetMap["JUP"] >= 0 {
-		t.Errorf("Expected negative JUP balance (borrow), got %f", assetMap["JUP"])
+	if len(assetMap["JUP"]) == 0 || assetMap["JUP"][0] != '-' {
+		t.Errorf("Expected negative JUP balance (borrow), got %s", assetMap["JUP"])
 	}
 }
 

--- a/exchange/drift/markets.go
+++ b/exchange/drift/markets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -160,8 +161,12 @@ func (c *Client) fetchMarkets(ctx context.Context) error {
 		return fmt.Errorf("markets API returned success=false")
 	}
 
-	// If API returned no markets, don't overwrite hardcoded defaults
+	// If API returned no markets, don't overwrite hardcoded defaults.
+	// The hardcoded defaults are a legitimate fallback (keeps us running),
+	// but an empty response from the markets API is a real upstream regression
+	// that degrades our ability to resolve newly-added markets — log loudly.
 	if len(response.Markets) == 0 {
+		log.Printf("ERROR drift/markets: API returned 0 markets — relying on hardcoded defaults (newly-added markets will fail to resolve) | url=%s", c.baseURL+"/stats/markets")
 		// Still mark as fetched so we don't retry immediately
 		c.marketCache.mu.Lock()
 		c.marketCache.lastFetch = time.Now()

--- a/exchange/drift/pagination.go
+++ b/exchange/drift/pagination.go
@@ -2,10 +2,23 @@ package drift
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 )
+
+// HTTPStatusError is returned when the Drift API returns a non-200 status code.
+// It carries the status code so callers can distinguish e.g. 400 from 500.
+type HTTPStatusError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("API returned status %d: %s", e.StatusCode, e.Status)
+}
 
 // pageResult holds items from a single page plus the next page token
 type pageResult[T any] struct {
@@ -68,6 +81,11 @@ func fetchHistorical[T any](
 	current := time.Date(since.Year(), since.Month(), 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(recentWindowStart.Year(), recentWindowStart.Month(), 1, 0, 0, 0, 0, time.UTC)
 
+	// Track whether we've received any data from historical months.
+	// Sequential 400s before any data means the account didn't exist yet.
+	// Once data arrives, a 400 is a real data gap.
+	hasReceivedData := false
+
 	for !current.After(end) {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -78,8 +96,15 @@ func fetchHistorical[T any](
 
 		monthItems, err := fetchAllPages(ctx, monthURL, fetcher)
 		if err != nil {
-			// A failed month is a real data gap — fail loud rather than silently
-			// losing a slice of the historical record.
+			var httpErr *HTTPStatusError
+			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusBadRequest && !hasReceivedData {
+				// Account likely didn't exist yet — skip this month
+				log.Printf("drift/%s: skipping %d/%d (400, account likely didn't exist yet) | account=%s",
+					endpoint, current.Year(), int(current.Month()), accountID)
+				current = current.AddDate(0, 1, 0)
+				continue
+			}
+			// Real error — either non-400, or 400 after we've already gotten data
 			return nil, fmt.Errorf("drift/%s: historical fetch failed for %d/%d (account=%s): %w",
 				endpoint, current.Year(), int(current.Month()), accountID, err)
 		}
@@ -94,6 +119,10 @@ func fetchHistorical[T any](
 				}
 			}
 			monthItems = filtered
+		}
+
+		if len(monthItems) > 0 {
+			hasReceivedData = true
 		}
 
 		all = append(all, monthItems...)

--- a/exchange/drift/pagination.go
+++ b/exchange/drift/pagination.go
@@ -78,9 +78,10 @@ func fetchHistorical[T any](
 
 		monthItems, err := fetchAllPages(ctx, monthURL, fetcher)
 		if err != nil {
-			// Continue on error - some months may not have data
-			current = current.AddDate(0, 1, 0)
-			continue
+			// A failed month is a real data gap — fail loud rather than silently
+			// losing a slice of the historical record.
+			return nil, fmt.Errorf("drift/%s: historical fetch failed for %d/%d (account=%s): %w",
+				endpoint, current.Year(), int(current.Month()), accountID, err)
 		}
 
 		// For the month that overlaps with the recent window, filter out records

--- a/exchange/hyperliquid/client.go
+++ b/exchange/hyperliquid/client.go
@@ -579,6 +579,30 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		// Skip until we understand the full vault withdrawal flow
 		return nil, nil, nil
 
+	case "vaultleadercommission":
+		transferType = models.TypeReward
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+
+	case "rewardsclaim":
+		transferType = models.TypeReward
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+
+	case "send":
+		amount := cleanDecimal(entry.Delta.Usdc)
+		if strings.HasPrefix(amount, "-") {
+			transferType = models.TypeWithdraw
+		} else {
+			transferType = models.TypeDeposit
+		}
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+
+	case "liquidation":
+		// Informational only — no cash flow. Intentionally skipped.
+		return nil, nil, nil
+
 	default:
 		return nil, nil, fmt.Errorf("hyperliquid: unknown ledger delta type %q for entry at timestamp=%d hash=%s", deltaType, entry.Time, entry.Hash)
 	}

--- a/exchange/hyperliquid/client.go
+++ b/exchange/hyperliquid/client.go
@@ -3,6 +3,7 @@ package hyperliquid
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -87,6 +88,11 @@ func (c *Client) doPost(ctx context.Context, body interface{}, result interface{
 				}
 			}
 
+			// Respect Retry-After header if present
+			if retryAfter := parseRetryAfter(resp.Header.Get("Retry-After")); retryAfter > 0 {
+				backoff = retryAfter
+			}
+
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -145,10 +151,34 @@ func (c *Client) FetchTrades(
 		return nil, nil, fmt.Errorf("failed to fetch fills: %w", err)
 	}
 
+	// Synthesize opening fills for pre-launch perp positions.
+	// Pre-launch perps (e.g., @107) may only have closing fills in the API —
+	// the position was opened via pre-launch auction/airdrop and never appears as a fill.
+	// We detect this by looking at startPosition on the earliest fill per coin:
+	// if startPosition > 0 and there's no earlier buy fill, we synthesize an opening
+	// fill at ~$0 cost basis (derived from closedPnl) to give the processor a complete
+	// position lifecycle.
+	fills = synthesizePrelaunchOpenings(fills, accountUUID)
+
 	trades := make([]*models.TradeInput, 0, len(fills))
+	prices := make([]*models.PriceRecord, 0, len(fills))
 	for _, fill := range fills {
 		trade := transformFill(fill, accountUUID)
+		if err := c.resolveSpotTradeNames(ctx, trade); err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve spot coin name for %q: %w", fill.Coin, err)
+		}
 		trades = append(trades, trade)
+
+		// Build price record from execution price (must be done before sorting trades)
+		if fill.Px != "" && fill.Px != "0" {
+			prices = append(prices, &models.PriceRecord{
+				Asset:        trade.BaseAsset,
+				Denomination: trade.QuoteAsset,
+				Timestamp:    trade.Timestamp,
+				Price:        cleanDecimal(fill.Px),
+				Source:       "execution",
+			})
+		}
 	}
 
 	// Sort by timestamp ascending
@@ -156,8 +186,7 @@ func (c *Client) FetchTrades(
 		return trades[i].Timestamp.Before(trades[j].Timestamp)
 	})
 
-	// Hyperliquid doesn't provide oracle prices in fills
-	return trades, nil, nil
+	return trades, prices, nil
 }
 
 // FetchFundingPayments fetches funding payments from the Hyperliquid userFunding API.
@@ -225,10 +254,17 @@ func (c *Client) FetchDeposits(
 	}
 
 	transfers := make([]*models.TransferInput, 0)
+	var prices []*models.PriceRecord
 	for _, entry := range entries {
-		transfer := transformLedgerEntry(entry, accountUUID)
+		transfer, price, err := transformLedgerEntry(entry, accountUUID, user)
+		if err != nil {
+			return nil, nil, err
+		}
 		if transfer != nil {
 			transfers = append(transfers, transfer)
+		}
+		if price != nil {
+			prices = append(prices, price)
 		}
 	}
 
@@ -237,8 +273,7 @@ func (c *Client) FetchDeposits(
 		return transfers[i].Timestamp.Before(transfers[j].Timestamp)
 	})
 
-	// Hyperliquid doesn't provide oracle prices in ledger updates
-	return transfers, nil, nil
+	return transfers, prices, nil
 }
 
 // FetchBalances fetches current spot and perp balances from Hyperliquid.
@@ -279,10 +314,14 @@ func (c *Client) FetchBalances(
 	var balances []*models.BalanceSnapshot
 
 	// Add USDC balance from perp account value
-	if accountValue, err := strconv.ParseFloat(perpState.MarginSummary.AccountValue, 64); err == nil && math.Abs(accountValue) > 0.000001 {
+	accountValue, err := strconv.ParseFloat(perpState.MarginSummary.AccountValue, 64)
+	if err != nil {
+		return nil, fmt.Errorf("hyperliquid: failed to parse perp account value %q: %w", perpState.MarginSummary.AccountValue, err)
+	}
+	if math.Abs(accountValue) > 0.000001 {
 		balances = append(balances, &models.BalanceSnapshot{
 			Asset:       "USDC",
-			Balance:     accountValue,
+			Balance:     perpState.MarginSummary.AccountValue,
 			TimestampMs: nowMs,
 		})
 	}
@@ -290,12 +329,24 @@ func (c *Client) FetchBalances(
 	// Add spot balances
 	for _, b := range spotState.Balances {
 		total, err := strconv.ParseFloat(b.Total, 64)
-		if err != nil || math.Abs(total) < 0.000001 {
+		if err != nil {
+			return nil, fmt.Errorf("hyperliquid: failed to parse spot balance %q for coin %s: %w", b.Total, b.Coin, err)
+		}
+		if math.Abs(total) < 0.000001 {
 			continue
 		}
+		asset := b.Coin
+		// Resolve @N coin names to real token names
+		if len(asset) > 0 && asset[0] == '@' {
+			base, _, resolveErr := c.resolveSpotCoin(ctx, asset)
+			if resolveErr != nil {
+				return nil, fmt.Errorf("hyperliquid: failed to resolve spot coin %q to asset symbol: %w", asset, resolveErr)
+			}
+			asset = base
+		}
 		balances = append(balances, &models.BalanceSnapshot{
-			Asset:       b.Coin,
-			Balance:     total,
+			Asset:       asset,
+			Balance:     b.Total,
 			TimestampMs: nowMs,
 		})
 	}
@@ -324,16 +375,50 @@ func (c *Client) FetchSettlements(
 
 // Transform functions
 
+// resolveSpotTradeNames resolves @N base asset names in spot trades to real token names
+// using the spot metadata cache. No-op for perp trades or trades that already have resolved names.
+func (c *Client) resolveSpotTradeNames(ctx context.Context, trade *models.TradeInput) error {
+	if trade.MarketType != "spot" {
+		return nil
+	}
+	if len(trade.BaseAsset) == 0 || trade.BaseAsset[0] != '@' {
+		return nil
+	}
+	base, quote, err := c.resolveSpotCoin(ctx, trade.BaseAsset)
+	if err != nil {
+		return err
+	}
+	trade.BaseAsset = base
+	trade.QuoteAsset = quote
+	return nil
+}
+
 // transformFill converts a Hyperliquid fill to a TradeInput.
+// Note: spot fills with @N coin names will have BaseAsset="@N" after this call.
+// Call resolveSpotTradeNames to resolve them to real token names.
 func transformFill(fill hlFill, accountUUID uuid.UUID) *models.TradeInput {
 	coin := fill.Coin
 	marketType := "perp"
 	baseAsset := coin
 
+	// Spot Dust Conversions are spot sells of tiny balances, not perp trades.
+	// Hyperliquid auto-converts dust token balances to USDC with dir="Spot Dust Conversion".
+	// These fills use @N coin names without -SPOT suffix, so they'd be misclassified as perp.
+	// The matching opening position comes from spotGenesis ledger entries (deposit transfers).
+	if fill.Dir == "Spot Dust Conversion" {
+		marketType = "spot"
+	}
+
 	// Spot coins have a "-SPOT" suffix in Hyperliquid
 	if strings.HasSuffix(coin, "-SPOT") {
 		marketType = "spot"
 		baseAsset = strings.TrimSuffix(coin, "-SPOT")
+	}
+
+	// Bare @N coins are spot tokens per the HL API spec (e.g., @107 for HYPE).
+	// Perps use plain symbol names from the meta response (e.g., "ETH", "BTC").
+	if strings.HasPrefix(coin, "@") {
+		marketType = "spot"
 	}
 
 	// Canonical spot pairs use "BASE/QUOTE" format (e.g., "PURR/USDC")
@@ -351,8 +436,14 @@ func transformFill(fill hlFill, accountUUID uuid.UUID) *models.TradeInput {
 
 	fee := cleanDecimal(fill.Fee)
 
+	tradeID := strconv.FormatInt(fill.Tid, 10)
+	if fill.Tid == 0 {
+		h := fmt.Sprintf("%d|%s|%s|%s|%s|%d", fill.Time, fill.Coin, fill.Side, fill.Px, fill.Sz, fill.Oid)
+		tradeID = fmt.Sprintf("hl_%x", sha256.Sum256([]byte(h)))
+	}
+
 	return &models.TradeInput{
-		TradeID:           strconv.FormatInt(fill.Tid, 10),
+		TradeID:           tradeID,
 		OrderID:           strconv.FormatInt(fill.Oid, 10),
 		BaseAsset:         baseAsset,
 		QuoteAsset:        quoteAsset,
@@ -363,48 +454,133 @@ func transformFill(fill hlFill, accountUUID uuid.UUID) *models.TradeInput {
 		Timestamp:         time.UnixMilli(fill.Time).UTC(),
 		ExchangeAccountID: accountUUID,
 		MarketType:        marketType,
+		FeeAsset:          "USDC",
 	}
 }
 
 // transformFunding converts a Hyperliquid funding entry to a TransferInput.
 func transformFunding(entry hlFundingEntry, accountUUID uuid.UUID) *models.TransferInput {
+	externalID := fmt.Sprintf("%d_%s", entry.Time, entry.Delta.Coin)
 	return &models.TransferInput{
 		ExchangeAccountID: accountUUID,
 		Type:              models.TypeFunding,
 		Asset:             "USDC",
-		Amount:            entry.Delta.Usdc, // Keep signed — Drift also stores signed funding amounts
+		Amount:            cleanDecimal(entry.Delta.Usdc), // Keep signed — Drift also stores signed funding amounts
 		Timestamp:         time.UnixMilli(entry.Time).UTC(),
+		ExternalID:        externalID,
 		Metadata: map[string]string{
-			"market":    entry.Delta.Coin + "-PERP",
-			"n_samples": strconv.Itoa(entry.Delta.NSamples),
+			"market":      entry.Delta.Coin + "-PERP",
+			"funding_rate": entry.Delta.FundingRate,
+			"n_samples":   strconv.Itoa(entry.Delta.NSamples),
+			"payment_id":  externalID,
 		},
 	}
 }
 
-// transformLedgerEntry converts a Hyperliquid ledger entry to a TransferInput.
-// Returns nil for unsupported entry types.
-func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID) *models.TransferInput {
+// transformLedgerEntry converts a Hyperliquid ledger entry to a TransferInput and optional PriceRecord.
+// Returns (nil, nil, nil) for intentionally-skipped entry types (e.g. accountClassTransfer).
+// Returns an error for unknown delta types — we must not silently drop cashflows.
+// walletAddress is needed to determine direction for spotTransfer and internalTransfer.
+func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddress string) (*models.TransferInput, *models.PriceRecord, error) {
 	deltaType := strings.ToLower(entry.Delta.Type)
 
 	var transferType string
+	var asset string
+	var amountStr string
+	var priceRecord *models.PriceRecord
+
 	switch deltaType {
 	case "deposit":
 		transferType = models.TypeDeposit
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+		if amountStr == "" {
+			amountStr = entry.Delta.Amount
+		}
+		if entry.Delta.Token != "" {
+			asset = entry.Delta.Token
+		}
+
 	case "withdraw":
 		transferType = models.TypeWithdraw
-	default:
-		// Skip unsupported types (internalTransfer, liquidation, etc.)
-		return nil
-	}
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+		if amountStr == "" {
+			amountStr = entry.Delta.Amount
+		}
+		if entry.Delta.Token != "" {
+			asset = entry.Delta.Token
+		}
 
-	// Use usdc field; fall back to amount field
-	amountStr := entry.Delta.Usdc
-	asset := "USDC"
-	if amountStr == "" {
-		amountStr = entry.Delta.Amount
-	}
-	if entry.Delta.Token != "" {
+	case "spotgenesis":
+		transferType = models.TypeDeposit
 		asset = entry.Delta.Token
+		amountStr = entry.Delta.Amount
+		// spotGenesis entries are free airdrops — price is 0
+		priceRecord = &models.PriceRecord{
+			Asset:        entry.Delta.Token,
+			Denomination: "USDC",
+			Timestamp:    time.UnixMilli(entry.Time).UTC(),
+			Price:        "0",
+			Source:       "ledger",
+		}
+
+	case "spottransfer":
+		if strings.EqualFold(entry.Delta.Destination, walletAddress) {
+			transferType = models.TypeDeposit
+		} else {
+			transferType = models.TypeWithdraw
+		}
+		asset = entry.Delta.Token
+		amountStr = entry.Delta.Amount
+		// Derive price from usdcValue / amount when available
+		if entry.Delta.UsdcValue != "" {
+			usdcVal, uErr := strconv.ParseFloat(entry.Delta.UsdcValue, 64)
+			amt, aErr := strconv.ParseFloat(entry.Delta.Amount, 64)
+			if uErr == nil && aErr == nil && amt != 0 {
+				price := math.Abs(usdcVal / amt)
+				priceRecord = &models.PriceRecord{
+					Asset:        entry.Delta.Token,
+					Denomination: "USDC",
+					Timestamp:    time.UnixMilli(entry.Time).UTC(),
+					Price:        cleanDecimal(strconv.FormatFloat(price, 'f', -1, 64)),
+					Source:       "ledger",
+				}
+			}
+		}
+
+	case "internaltransfer":
+		amount := cleanDecimal(entry.Delta.Usdc)
+		if strings.HasPrefix(amount, "-") {
+			transferType = models.TypeWithdraw
+		} else {
+			transferType = models.TypeDeposit
+		}
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+
+	case "vaultcreate", "vaultdeposit":
+		transferType = models.TypeWithdraw
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+
+	case "vaultdistribution":
+		transferType = models.TypeDeposit
+		asset = "USDC"
+		amountStr = entry.Delta.Usdc
+
+	case "accountclasstransfer":
+		// Internal rebalance between the user's own spot and perp sub-accounts.
+		// This is NOT a cashflow — the wallet's total USDC position is unchanged,
+		// just moved between trading classes. Intentionally skipped.
+		return nil, nil, nil
+
+	case "vaultwithdraw":
+		// Skip until we understand the full vault withdrawal flow
+		return nil, nil, nil
+
+	default:
+		return nil, nil, fmt.Errorf("hyperliquid: unknown ledger delta type %q for entry at timestamp=%d hash=%s", deltaType, entry.Time, entry.Hash)
 	}
 
 	amount := cleanDecimal(amountStr)
@@ -419,7 +595,12 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID) *models.Tr
 		Asset:             asset,
 		Amount:            amount,
 		Timestamp:         time.UnixMilli(entry.Time).UTC(),
-	}
+		ExternalID:        entry.Hash,
+		Metadata: map[string]string{
+			"payment_id":  entry.Hash,
+			"source_type": deltaType,
+		},
+	}, priceRecord, nil
 }
 
 // cleanDecimal cleans a decimal string: trims trailing zeros and dots.
@@ -435,6 +616,105 @@ func cleanDecimal(s string) string {
 		return "0"
 	}
 	return s
+}
+
+// synthesizePrelaunchOpenings detects fills where the API only returns closing/sell
+// fills but no corresponding opening/buy fills. This happens in two cases:
+//
+//  1. Pre-launch perp positions (e.g., @107): opened via pre-launch auction, only
+//     close fills appear in the API.
+//  2. Spot dust conversions (e.g., @2 with dir="Spot Dust Conversion"): airdrop tokens
+//     auto-converted to USDC. The tokens were received via airdrop, not a trade.
+//
+// For each such coin, this function inserts a synthetic opening buy fill 1ms before
+// the earliest real fill, with qty = startPosition and price = $0 (airdrop cost basis).
+// This gives the processor a complete position lifecycle (open → close).
+func synthesizePrelaunchOpenings(fills []hlFill, accountUUID uuid.UUID) []hlFill {
+	// Group fills by coin, track earliest fill per coin
+	type coinInfo struct {
+		earliestIdx int
+		earliestMs  int64
+		hasBuy      bool
+	}
+	coins := make(map[string]*coinInfo)
+
+	for i, fill := range fills {
+		coin := fill.Coin
+		// Skip spot fills — their opening positions come from deposit transfers, not pre-launch auctions.
+		// Spot fills use -SPOT suffix, BASE/QUOTE format, or bare @N coin names.
+		if strings.HasSuffix(coin, "-SPOT") || strings.Contains(coin, "/") || strings.HasPrefix(coin, "@") {
+			continue
+		}
+
+		info, ok := coins[coin]
+		if !ok {
+			info = &coinInfo{earliestIdx: i, earliestMs: fill.Time}
+			coins[coin] = info
+		}
+		if fill.Time < info.earliestMs {
+			info.earliestIdx = i
+			info.earliestMs = fill.Time
+		}
+		if fill.Side == "B" {
+			info.hasBuy = true
+		}
+	}
+
+	var synthetic []hlFill
+	for coin, info := range coins {
+		if info.hasBuy {
+			continue // Has a real buy — no synthesis needed
+		}
+		earliest := fills[info.earliestIdx]
+		startPos := cleanDecimal(earliest.StartPosition)
+		if startPos == "0" || startPos == "" {
+			continue // No pre-existing position
+		}
+
+		// Skip dust conversions — their opening positions come from spotGenesis
+		// ledger entries (captured as deposit transfers in FetchDeposits).
+		// Synthesizing a fill here would double-count the inflow.
+		if earliest.Dir == "Spot Dust Conversion" {
+			continue
+		}
+
+		// Synthesize an opening buy fill 1ms before the earliest real fill.
+		// Price = $0 (pre-launch airdrop/auction cost basis is effectively zero).
+		// TradeID uses a deterministic negative TID so it's unique and reproducible.
+		synthetic = append(synthetic, hlFill{
+			Time:          earliest.Time - 1,
+			Coin:          coin,
+			Side:          "B", // buy to open long
+			Px:            "0",
+			Sz:            startPos,
+			Fee:           "0",
+			Tid:           -earliest.Time, // deterministic unique ID
+			ClosedPnl:     "0",
+			Hash:          "synthetic_prelaunch_open_" + coin,
+			StartPosition: "0",
+			Dir:           "Synthetic Open Long",
+			Oid:           0,
+		})
+	}
+
+	if len(synthetic) == 0 {
+		return fills
+	}
+
+	return append(synthetic, fills...)
+}
+
+// parseRetryAfter parses the Retry-After header value (in seconds) into a duration.
+// Returns 0 if the header is empty or unparseable.
+func parseRetryAfter(retryAfter string) time.Duration {
+	if retryAfter == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // Compile-time interface check

--- a/exchange/hyperliquid/client_test.go
+++ b/exchange/hyperliquid/client_test.go
@@ -559,12 +559,141 @@ func TestTransformLedgerEntry(t *testing.T) {
 		}
 	})
 
+	t.Run("vaultLeaderCommission", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xvlc",
+			Delta: hlLedgerDelta{
+				Type: "vaultLeaderCommission",
+				Usdc: "88.403549",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeReward {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeReward)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "88.403549" {
+			t.Errorf("Amount = %q, want 88.403549", transfer.Amount)
+		}
+	})
+
+	t.Run("rewardsClaim", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xrc",
+			Delta: hlLedgerDelta{
+				Type: "rewardsClaim",
+				Usdc: "50.0",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeReward {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeReward)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "50" {
+			t.Errorf("Amount = %q, want 50", transfer.Amount)
+		}
+	})
+
+	t.Run("send outgoing", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xsendout",
+			Delta: hlLedgerDelta{
+				Type: "send",
+				Usdc: "-100.0",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeWithdraw {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeWithdraw)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "100" {
+			t.Errorf("Amount = %q, want 100", transfer.Amount)
+		}
+	})
+
+	t.Run("send incoming", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xsendin",
+			Delta: hlLedgerDelta{
+				Type: "send",
+				Usdc: "200.0",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeDeposit {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeDeposit)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "200" {
+			t.Errorf("Amount = %q, want 200", transfer.Amount)
+		}
+	})
+
+	t.Run("liquidation skipped", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xliq",
+			Delta: hlLedgerDelta{
+				Type: "liquidation",
+				Usdc: "100.00",
+			},
+		}
+		transfer, price, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer != nil {
+			t.Error("expected nil transfer for liquidation")
+		}
+		if price != nil {
+			t.Error("expected nil price for liquidation")
+		}
+	})
+
 	t.Run("unknown type returns error", func(t *testing.T) {
 		entry := hlLedgerEntry{
 			Time: 1700000000000,
 			Hash: "0xunknown",
 			Delta: hlLedgerDelta{
-				Type: "liquidation",
+				Type: "futureUnknownType",
 				Usdc: "100.00",
 			},
 		}
@@ -1056,7 +1185,7 @@ func spotMetaHandler() http.HandlerFunc {
 					{"name": "@1", "tokens": []int{2, 0}, "index": 1, "isCanonical": false},
 				},
 			})
-		case "userFills":
+		case "userFillsByTime":
 			json.NewEncoder(w).Encode([]hlFill{
 				{
 					Time: 1700000000000,

--- a/exchange/hyperliquid/client_test.go
+++ b/exchange/hyperliquid/client_test.go
@@ -3,8 +3,11 @@ package hyperliquid
 import (
 	"context"
 	"encoding/json"
+
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -167,6 +170,15 @@ func TestTransformFunding(t *testing.T) {
 	if payment.Metadata["n_samples"] != "1" {
 		t.Errorf("n_samples metadata = %q, want 1", payment.Metadata["n_samples"])
 	}
+	if payment.Metadata["payment_id"] != "1700000000000_ETH" {
+		t.Errorf("payment_id metadata = %q, want 1700000000000_ETH", payment.Metadata["payment_id"])
+	}
+	if payment.Metadata["funding_rate"] != "0.0001" {
+		t.Errorf("funding_rate metadata = %q, want 0.0001", payment.Metadata["funding_rate"])
+	}
+	if payment.Amount != "-0.5" {
+		t.Errorf("Amount = %q, want -0.5 (cleanDecimal applied)", payment.Amount)
+	}
 }
 
 func TestTransformFillSlashCoin(t *testing.T) {
@@ -195,6 +207,7 @@ func TestTransformFillSlashCoin(t *testing.T) {
 
 func TestTransformLedgerEntry(t *testing.T) {
 	accountUUID := uuid.New()
+	wallet := "0x4C5feD7BDDA8023f3133e3A8F7C615395AD673c8"
 
 	t.Run("deposit", func(t *testing.T) {
 		entry := hlLedgerEntry{
@@ -205,7 +218,10 @@ func TestTransformLedgerEntry(t *testing.T) {
 				Usdc: "1000.00",
 			},
 		}
-		transfer := transformLedgerEntry(entry, accountUUID)
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if transfer == nil {
 			t.Fatal("expected non-nil transfer")
 		}
@@ -214,6 +230,12 @@ func TestTransformLedgerEntry(t *testing.T) {
 		}
 		if transfer.Amount != "1000" {
 			t.Errorf("Amount = %q, want 1000", transfer.Amount)
+		}
+		if transfer.Metadata["payment_id"] != "0xabc" {
+			t.Errorf("payment_id metadata = %q, want 0xabc", transfer.Metadata["payment_id"])
+		}
+		if transfer.Metadata["source_type"] != "deposit" {
+			t.Errorf("source_type metadata = %q, want deposit", transfer.Metadata["source_type"])
 		}
 	})
 
@@ -226,7 +248,10 @@ func TestTransformLedgerEntry(t *testing.T) {
 				Usdc: "-500.00",
 			},
 		}
-		transfer := transformLedgerEntry(entry, accountUUID)
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if transfer == nil {
 			t.Fatal("expected non-nil transfer")
 		}
@@ -236,20 +261,319 @@ func TestTransformLedgerEntry(t *testing.T) {
 		if transfer.Amount != "500" {
 			t.Errorf("Amount = %q, want 500", transfer.Amount)
 		}
+		if transfer.Metadata["payment_id"] != "0xdef" {
+			t.Errorf("payment_id metadata = %q, want 0xdef", transfer.Metadata["payment_id"])
+		}
 	})
 
-	t.Run("unsupported type returns nil", func(t *testing.T) {
+	t.Run("spotGenesis", func(t *testing.T) {
 		entry := hlLedgerEntry{
 			Time: 1700000000000,
-			Hash: "0xghi",
+			Hash: "0xgenesis",
+			Delta: hlLedgerDelta{
+				Type:   "spotGenesis",
+				Token:  "PURR",
+				Amount: "1000.50",
+			},
+		}
+		transfer, price, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeDeposit {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeDeposit)
+		}
+		if transfer.Asset != "PURR" {
+			t.Errorf("Asset = %q, want PURR", transfer.Asset)
+		}
+		if transfer.Amount != "1000.5" {
+			t.Errorf("Amount = %q, want 1000.5", transfer.Amount)
+		}
+		if transfer.Metadata["source_type"] != "spotgenesis" {
+			t.Errorf("source_type = %q, want spotgenesis", transfer.Metadata["source_type"])
+		}
+		// spotGenesis is a free airdrop — price must be 0
+		if price == nil {
+			t.Fatal("expected price record for spotGenesis")
+		}
+		if price.Price != "0" {
+			t.Errorf("price = %q, want 0 (free airdrop)", price.Price)
+		}
+		if price.Asset != "PURR" {
+			t.Errorf("price asset = %q, want PURR", price.Asset)
+		}
+		if price.Denomination != "USDC" {
+			t.Errorf("price denomination = %q, want USDC", price.Denomination)
+		}
+		if price.Source != "ledger" {
+			t.Errorf("price source = %q, want ledger", price.Source)
+		}
+	})
+
+	t.Run("spotTransfer inbound", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xspotin",
+			Delta: hlLedgerDelta{
+				Type:        "spotTransfer",
+				Token:       "HYPE",
+				Amount:      "50.0",
+				Destination: wallet,
+				User:        "0xSenderAddress",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeDeposit {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeDeposit)
+		}
+		if transfer.Asset != "HYPE" {
+			t.Errorf("Asset = %q, want HYPE", transfer.Asset)
+		}
+		if transfer.Amount != "50" {
+			t.Errorf("Amount = %q, want 50", transfer.Amount)
+		}
+	})
+
+	t.Run("spotTransfer outbound", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xspotout",
+			Delta: hlLedgerDelta{
+				Type:        "spotTransfer",
+				Token:       "HYPE",
+				Amount:      "25.0",
+				Destination: "0xReceiverAddress",
+				User:        wallet,
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeWithdraw {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeWithdraw)
+		}
+		if transfer.Asset != "HYPE" {
+			t.Errorf("Asset = %q, want HYPE", transfer.Asset)
+		}
+	})
+
+	t.Run("spotTransfer case insensitive match", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xspotcase",
+			Delta: hlLedgerDelta{
+				Type:        "spotTransfer",
+				Token:       "HYPE",
+				Amount:      "10.0",
+				Destination: "0x4c5fed7bdda8023f3133e3a8f7c615395ad673c8", // lowercase
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeDeposit {
+			t.Errorf("Type = %q, want deposit (case-insensitive match)", transfer.Type)
+		}
+	})
+
+	t.Run("internalTransfer outgoing", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xinternalout",
 			Delta: hlLedgerDelta{
 				Type: "internalTransfer",
+				Usdc: "-100.00",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeWithdraw {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeWithdraw)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "100" {
+			t.Errorf("Amount = %q, want 100", transfer.Amount)
+		}
+	})
+
+	t.Run("internalTransfer incoming", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xinternalin",
+			Delta: hlLedgerDelta{
+				Type: "internalTransfer",
+				Usdc: "200.00",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeDeposit {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeDeposit)
+		}
+		if transfer.Amount != "200" {
+			t.Errorf("Amount = %q, want 200", transfer.Amount)
+		}
+	})
+
+	t.Run("vaultCreate", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xvaultcreate",
+			Delta: hlLedgerDelta{
+				Type: "vaultCreate",
+				Usdc: "-5000.00",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeWithdraw {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeWithdraw)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "5000" {
+			t.Errorf("Amount = %q, want 5000", transfer.Amount)
+		}
+	})
+
+	t.Run("vaultDeposit", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xvaultdeposit",
+			Delta: hlLedgerDelta{
+				Type: "vaultDeposit",
+				Usdc: "-1000.00",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeWithdraw {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeWithdraw)
+		}
+		if transfer.Amount != "1000" {
+			t.Errorf("Amount = %q, want 1000", transfer.Amount)
+		}
+	})
+
+	t.Run("vaultDistribution", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xvaultdist",
+			Delta: hlLedgerDelta{
+				Type: "vaultDistribution",
+				Usdc: "250.00",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeDeposit {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeDeposit)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "250" {
+			t.Errorf("Amount = %q, want 250", transfer.Amount)
+		}
+	})
+
+	t.Run("accountClassTransfer skipped", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xacctclass",
+			Delta: hlLedgerDelta{
+				Type:   "accountClassTransfer",
+				Usdc:   "100.00",
+				ToPerp: true,
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer != nil {
+			t.Error("expected nil transfer for accountClassTransfer")
+		}
+	})
+
+	t.Run("vaultWithdraw skipped", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xvaultwithdraw",
+			Delta: hlLedgerDelta{
+				Type: "vaultWithdraw",
+				Usdc: "500.00",
+			},
+		}
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if transfer != nil {
+			t.Error("expected nil transfer for vaultWithdraw")
+		}
+	})
+
+	t.Run("unknown type returns error", func(t *testing.T) {
+		entry := hlLedgerEntry{
+			Time: 1700000000000,
+			Hash: "0xunknown",
+			Delta: hlLedgerDelta{
+				Type: "liquidation",
 				Usdc: "100.00",
 			},
 		}
-		transfer := transformLedgerEntry(entry, accountUUID)
+		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
+		if err == nil {
+			t.Fatal("expected error for unknown ledger delta type, got nil")
+		}
 		if transfer != nil {
-			t.Error("expected nil transfer for unsupported type")
+			t.Errorf("expected nil transfer for unknown type, got %+v", transfer)
 		}
 	})
 }
@@ -322,8 +646,19 @@ func TestFetchTradesWithMockServer(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if prices != nil {
-		t.Error("expected nil prices for Hyperliquid")
+	if len(prices) != 2 {
+		t.Errorf("expected 2 price records from execution prices, got %d", len(prices))
+	}
+	if len(prices) > 0 {
+		if prices[0].Source != "execution" {
+			t.Errorf("price source = %s, want execution", prices[0].Source)
+		}
+		if prices[0].Asset != "ETH" {
+			t.Errorf("price asset = %s, want ETH", prices[0].Asset)
+		}
+		if prices[0].Price != "2000" {
+			t.Errorf("price = %s, want 2000", prices[0].Price)
+		}
 	}
 
 	if len(trades) != 2 {
@@ -408,14 +743,17 @@ func TestFetchFundingPaymentsWithMockServer(t *testing.T) {
 	if p.Asset != "USDC" {
 		t.Errorf("Asset = %q, want USDC", p.Asset)
 	}
-	if p.Amount != "-0.50" {
-		t.Errorf("Amount = %q, want -0.50", p.Amount)
+	if p.Amount != "-0.5" {
+		t.Errorf("Amount = %q, want -0.5", p.Amount)
 	}
 	if p.Metadata["market"] != "ETH-PERP" {
 		t.Errorf("market metadata = %q, want ETH-PERP", p.Metadata["market"])
 	}
 	if p.Metadata["n_samples"] != "4" {
 		t.Errorf("n_samples metadata = %q, want 4", p.Metadata["n_samples"])
+	}
+	if p.Metadata["payment_id"] != "1700000000000_ETH" {
+		t.Errorf("payment_id metadata = %q, want 1700000000000_ETH", p.Metadata["payment_id"])
 	}
 	if p.ExchangeAccountID != accountID {
 		t.Errorf("ExchangeAccountID = %v, want %v", p.ExchangeAccountID, accountID)
@@ -472,13 +810,14 @@ func TestFetchDepositsWithMockServer(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if prices != nil {
-		t.Error("expected nil prices for Hyperliquid")
+	// These entries (deposit, withdraw, internalTransfer) have no spot price records
+	if len(prices) != 0 {
+		t.Errorf("expected 0 prices for non-spot ledger entries, got %d", len(prices))
 	}
 
-	// internalTransfer should be filtered out
-	if len(transfers) != 2 {
-		t.Fatalf("expected 2 transfers (deposit + withdraw, skipping internalTransfer), got %d", len(transfers))
+	// internalTransfer with positive USDC is now handled as a deposit
+	if len(transfers) != 3 {
+		t.Fatalf("expected 3 transfers (deposit + withdraw + internalTransfer), got %d", len(transfers))
 	}
 
 	// Verify sorted ascending
@@ -662,14 +1001,827 @@ func TestFetchBalancesWithMockServer(t *testing.T) {
 	if usdcBalance == nil {
 		t.Fatal("expected USDC balance")
 	}
-	if usdcBalance.Balance != 5000.50 {
-		t.Errorf("USDC balance = %f, want 5000.50", usdcBalance.Balance)
+	if usdcBalance.Balance != "5000.50" {
+		t.Errorf("USDC balance = %s, want 5000.50", usdcBalance.Balance)
 	}
 
 	if ethBalance == nil {
 		t.Fatal("expected ETH balance")
 	}
-	if ethBalance.Balance != 1.5 {
-		t.Errorf("ETH balance = %f, want 1.5", ethBalance.Balance)
+	if ethBalance.Balance != "1.5" {
+		t.Errorf("ETH balance = %s, want 1.5", ethBalance.Balance)
+	}
+}
+
+func TestTransformFillAtIndexedSpotCoin(t *testing.T) {
+	accountUUID := uuid.New()
+	fill := hlFill{
+		Time: 1700000000000,
+		Coin: "@13-SPOT",
+		Side: "B",
+		Px:   "25.00",
+		Sz:   "10",
+		Fee:  "0.01",
+		Tid:  200,
+		Oid:  300,
+	}
+	trade := transformFill(fill, accountUUID)
+
+	// Before resolution, base asset should be @13
+	if trade.BaseAsset != "@13" {
+		t.Errorf("BaseAsset = %q, want @13 (before resolution)", trade.BaseAsset)
+	}
+	if trade.MarketType != "spot" {
+		t.Errorf("MarketType = %q, want spot", trade.MarketType)
+	}
+}
+
+func spotMetaHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+
+		reqType, _ := body["type"].(string)
+		switch reqType {
+		case "spotMeta":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"tokens": []map[string]interface{}{
+					{"name": "USDC", "index": 0, "szDecimals": 2, "weiDecimals": 6, "tokenId": "0x0", "isCanonical": true},
+					{"name": "PURR", "index": 1, "szDecimals": 0, "weiDecimals": 18, "tokenId": "0x1", "isCanonical": true},
+					{"name": "HYPE", "index": 2, "szDecimals": 2, "weiDecimals": 18, "tokenId": "0x2", "isCanonical": false},
+				},
+				"universe": []map[string]interface{}{
+					{"name": "PURR/USDC", "tokens": []int{1, 0}, "index": 0, "isCanonical": true},
+					{"name": "@1", "tokens": []int{2, 0}, "index": 1, "isCanonical": false},
+				},
+			})
+		case "userFills":
+			json.NewEncoder(w).Encode([]hlFill{
+				{
+					Time: 1700000000000,
+					Coin: "@1-SPOT",
+					Side: "B",
+					Px:   "25.00",
+					Sz:   "10",
+					Fee:  "0.01",
+					Tid:  200,
+					Oid:  300,
+				},
+				{
+					Time: 1700000001000,
+					Coin: "PURR/USDC",
+					Side: "A",
+					Px:   "0.001",
+					Sz:   "1000",
+					Fee:  "0.005",
+					Tid:  201,
+					Oid:  301,
+				},
+				{
+					Time: 1700000002000,
+					Coin: "ETH",
+					Side: "B",
+					Px:   "2000.00",
+					Sz:   "1",
+					Fee:  "0.20",
+					Tid:  202,
+					Oid:  302,
+				},
+			})
+		}
+	}
+}
+
+func TestFetchTradesResolvesAtIndexedSpotCoins(t *testing.T) {
+	resetSpotMetaCache()
+
+	server := httptest.NewServer(spotMetaHandler())
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	accountID := uuid.New()
+	account := &models.ExchangeAccount{
+		ID:                accountID.String(),
+		AccountIdentifier: "0x1234567890abcdef1234567890abcdef12345678",
+	}
+
+	trades, prices, err := c.FetchTrades(context.Background(), account, time.UnixMilli(1700000000000))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(trades) != 3 {
+		t.Fatalf("expected 3 trades, got %d", len(trades))
+	}
+
+	// First trade: @1-SPOT should resolve to HYPE/USDC
+	if trades[0].BaseAsset != "HYPE" {
+		t.Errorf("trade[0] BaseAsset = %q, want HYPE (@1 resolved)", trades[0].BaseAsset)
+	}
+	if trades[0].QuoteAsset != "USDC" {
+		t.Errorf("trade[0] QuoteAsset = %q, want USDC", trades[0].QuoteAsset)
+	}
+	if trades[0].MarketType != "spot" {
+		t.Errorf("trade[0] MarketType = %q, want spot", trades[0].MarketType)
+	}
+
+	// Second trade: PURR/USDC canonical pair
+	if trades[1].BaseAsset != "PURR" {
+		t.Errorf("trade[1] BaseAsset = %q, want PURR", trades[1].BaseAsset)
+	}
+	if trades[1].MarketType != "spot" {
+		t.Errorf("trade[1] MarketType = %q, want spot", trades[1].MarketType)
+	}
+
+	// Third trade: ETH perp — should be unchanged
+	if trades[2].BaseAsset != "ETH" {
+		t.Errorf("trade[2] BaseAsset = %q, want ETH", trades[2].BaseAsset)
+	}
+	if trades[2].MarketType != "perp" {
+		t.Errorf("trade[2] MarketType = %q, want perp", trades[2].MarketType)
+	}
+
+	// Price records should also use resolved names
+	if len(prices) != 3 {
+		t.Fatalf("expected 3 price records, got %d", len(prices))
+	}
+	if prices[0].Asset != "HYPE" {
+		t.Errorf("prices[0] Asset = %q, want HYPE", prices[0].Asset)
+	}
+}
+
+func TestSpotMetaCacheLazyLoad(t *testing.T) {
+	resetSpotMetaCache()
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+
+		if body["type"] == "spotMeta" {
+			callCount++
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"tokens": []map[string]interface{}{
+					{"name": "USDC", "index": 0},
+					{"name": "SOL", "index": 1},
+				},
+				"universe": []map[string]interface{}{
+					{"name": "@0", "tokens": []int{1, 0}, "index": 0},
+				},
+			})
+			return
+		}
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx := context.Background()
+
+	// First call should trigger API fetch
+	base, quote, err := c.resolveSpotCoin(ctx, "@0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if base != "SOL" {
+		t.Errorf("base = %q, want SOL", base)
+	}
+	if quote != "USDC" {
+		t.Errorf("quote = %q, want USDC", quote)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 API call, got %d", callCount)
+	}
+
+	// Second call should use cache — no additional API call
+	base2, _, err := c.resolveSpotCoin(ctx, "@0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if base2 != "SOL" {
+		t.Errorf("base = %q, want SOL (cached)", base2)
+	}
+	if callCount != 1 {
+		t.Errorf("expected still 1 API call (cached), got %d", callCount)
+	}
+
+	// Non-indexed coin should pass through without API call
+	base3, quote3, err := c.resolveSpotCoin(ctx, "ETH")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if base3 != "ETH" {
+		t.Errorf("base = %q, want ETH (passthrough)", base3)
+	}
+	if quote3 != "USDC" {
+		t.Errorf("quote = %q, want USDC (passthrough)", quote3)
+	}
+	if callCount != 1 {
+		t.Errorf("expected still 1 API call, got %d", callCount)
+	}
+}
+
+func TestTransformFillSpotDustConversion(t *testing.T) {
+	accountUUID := uuid.New()
+
+	// A spot dust conversion fill — should be classified as spot, not perp
+	fill := hlFill{
+		Time:          1728345600098,
+		Coin:          "@74",
+		Side:          "A",
+		Px:            "0.0014717",
+		Sz:            "639.282608",
+		Fee:           "0",
+		Tid:           0,
+		ClosedPnl:     "0.0",
+		StartPosition: "639.282608",
+		Dir:           "Spot Dust Conversion",
+		Oid:           40950466295,
+	}
+
+	trade := transformFill(fill, accountUUID)
+
+	if trade.MarketType != "spot" {
+		t.Errorf("MarketType = %q, want spot (dust conversion should be spot)", trade.MarketType)
+	}
+	if trade.Side != "sell" {
+		t.Errorf("Side = %q, want sell", trade.Side)
+	}
+	// BaseAsset is still @74 before resolution
+	if trade.BaseAsset != "@74" {
+		t.Errorf("BaseAsset = %q, want @74 (before resolution)", trade.BaseAsset)
+	}
+	// Tid=0 fills must get a deterministic hash-based trade ID, not "0"
+	if trade.TradeID == "0" {
+		t.Error("TradeID should not be \"0\" for dust conversion fills with Tid=0")
+	}
+	if !strings.HasPrefix(trade.TradeID, "hl_") {
+		t.Errorf("TradeID = %q, want prefix \"hl_\" for Tid=0 fills", trade.TradeID)
+	}
+}
+
+func TestTransformFillTidZeroDeterministicUnique(t *testing.T) {
+	accountUUID := uuid.New()
+
+	fill1 := hlFill{
+		Time:          1728345600098,
+		Coin:          "@74",
+		Side:          "A",
+		Px:            "0.0014717",
+		Sz:            "639.282608",
+		Fee:           "0",
+		Tid:           0,
+		ClosedPnl:     "0.0",
+		StartPosition: "639.282608",
+		Dir:           "Spot Dust Conversion",
+		Oid:           40950466295,
+	}
+
+	fill2 := hlFill{
+		Time:          1728345700000,
+		Coin:          "@75",
+		Side:          "A",
+		Px:            "0.002",
+		Sz:            "100.0",
+		Fee:           "0",
+		Tid:           0,
+		ClosedPnl:     "0.0",
+		StartPosition: "100.0",
+		Dir:           "Spot Dust Conversion",
+		Oid:           40950466300,
+	}
+
+	trade1 := transformFill(fill1, accountUUID)
+	trade2 := transformFill(fill2, accountUUID)
+
+	if trade1.TradeID == "0" || trade2.TradeID == "0" {
+		t.Fatal("TradeID should not be \"0\" for Tid=0 fills")
+	}
+	if !strings.HasPrefix(trade1.TradeID, "hl_") {
+		t.Errorf("trade1 TradeID = %q, want prefix \"hl_\"", trade1.TradeID)
+	}
+	if !strings.HasPrefix(trade2.TradeID, "hl_") {
+		t.Errorf("trade2 TradeID = %q, want prefix \"hl_\"", trade2.TradeID)
+	}
+	if trade1.TradeID == trade2.TradeID {
+		t.Errorf("two different fills with Tid=0 produced the same TradeID: %s", trade1.TradeID)
+	}
+}
+
+func TestSynthesizePrelaunchOpenings(t *testing.T) {
+	accountUUID := uuid.New()
+
+	t.Run("pre-launch perp with no buy fills", func(t *testing.T) {
+		// Use a plain perp coin (e.g., HYPE) — not @N which is now classified as spot.
+		// Pre-launch perps use plain symbol names from the meta response.
+		fills := []hlFill{
+			{
+				Time:          1733265316756,
+				Coin:          "HYPE",
+				Side:          "A",
+				Px:            "11.2",
+				Sz:            "530.49",
+				Fee:           "0.594148",
+				Tid:           544611872761152,
+				ClosedPnl:     "5941.482696",
+				StartPosition: "1567.77",
+				Dir:           "Sell",
+			},
+			{
+				Time:          1733265324007,
+				Coin:          "HYPE",
+				Side:          "A",
+				Px:            "11.2",
+				Sz:            "863.1",
+				Fee:           "0.966672",
+				Tid:           884529762032827,
+				ClosedPnl:     "9666.711369",
+				StartPosition: "1037.28",
+				Dir:           "Sell",
+			},
+		}
+
+		result := synthesizePrelaunchOpenings(fills, accountUUID)
+
+		// Should have 3 fills: 1 synthetic + 2 original
+		if len(result) != 3 {
+			t.Fatalf("expected 3 fills, got %d", len(result))
+		}
+
+		// Find the synthetic fill
+		var synth *hlFill
+		for i := range result {
+			if result[i].Dir == "Synthetic Open Long" {
+				synth = &result[i]
+				break
+			}
+		}
+		if synth == nil {
+			t.Fatal("expected a synthetic opening fill")
+		}
+
+		if synth.Sz != "1567.77" {
+			t.Errorf("synthetic Sz = %q, want 1567.77 (startPosition of earliest fill)", synth.Sz)
+		}
+		if synth.Px != "0" {
+			t.Errorf("synthetic Px = %q, want 0", synth.Px)
+		}
+		if synth.Side != "B" {
+			t.Errorf("synthetic Side = %q, want B (buy)", synth.Side)
+		}
+		if synth.Time >= 1733265316756 {
+			t.Errorf("synthetic Time = %d, should be before earliest fill", synth.Time)
+		}
+	})
+
+	t.Run("spot dust conversion skipped — opening comes from spotGenesis transfer", func(t *testing.T) {
+		fills := []hlFill{
+			{
+				Time:          1728345600098,
+				Coin:          "@74",
+				Side:          "A",
+				Px:            "0.0014717",
+				Sz:            "639.282608",
+				Fee:           "0",
+				Tid:           0,
+				ClosedPnl:     "0.0",
+				StartPosition: "639.282608",
+				Dir:           "Spot Dust Conversion",
+			},
+		}
+
+		result := synthesizePrelaunchOpenings(fills, accountUUID)
+
+		// Dust conversions should NOT get synthetic fills — the opening
+		// position is captured via spotGenesis ledger entries (deposit transfers).
+		if len(result) != 1 {
+			t.Fatalf("expected 1 fill (no synthesis for dust conversion), got %d", len(result))
+		}
+	})
+
+	t.Run("coin with buy fills is not synthesized", func(t *testing.T) {
+		fills := []hlFill{
+			{
+				Time: 1700000000000,
+				Coin: "ETH",
+				Side: "B",
+				Px:   "2000",
+				Sz:   "1",
+				Dir:  "Open Long",
+			},
+			{
+				Time: 1700000001000,
+				Coin: "ETH",
+				Side: "A",
+				Px:   "2100",
+				Sz:   "1",
+				Dir:  "Close Long",
+				StartPosition: "1",
+			},
+		}
+
+		result := synthesizePrelaunchOpenings(fills, accountUUID)
+		if len(result) != 2 {
+			t.Errorf("expected 2 fills (no synthesis for coin with buys), got %d", len(result))
+		}
+	})
+
+	t.Run("no synthesis for zero startPosition", func(t *testing.T) {
+		fills := []hlFill{
+			{
+				Time:          1700000000000,
+				Coin:          "@50",
+				Side:          "A",
+				Px:            "1.0",
+				Sz:            "10",
+				Dir:           "Spot Dust Conversion",
+				StartPosition: "0",
+			},
+		}
+
+		result := synthesizePrelaunchOpenings(fills, accountUUID)
+		if len(result) != 1 {
+			t.Errorf("expected 1 fill (no synthesis for zero startPosition), got %d", len(result))
+		}
+	})
+}
+
+func TestDoPostRateLimitRetry(t *testing.T) {
+	var retryCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := retryCount.Add(1)
+		if attempt <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// Succeed on 3rd attempt
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]hlFill{})
+	}))
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var result []hlFill
+	err := c.doPost(ctx, map[string]string{"type": "userFills", "user": "0x0"}, &result)
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+
+	count := retryCount.Load()
+	if count != 3 {
+		t.Errorf("expected 3 attempts (2 retries + 1 success), got %d", count)
+	}
+}
+
+func TestDoPostRateLimitExhausted(t *testing.T) {
+	var retryCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		retryCount.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	// Use a generous timeout — we want to test that maxRetries is hit, not context timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	var result []hlFill
+	err := c.doPost(ctx, map[string]string{"type": "userFills", "user": "0x0"}, &result)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+
+	if !iface.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got %T: %v", err, err)
+	}
+
+	// Should have made maxRetries+1 attempts
+	count := retryCount.Load()
+	if count != int32(maxRetries+1) {
+		t.Errorf("expected %d attempts, got %d", maxRetries+1, count)
+	}
+}
+
+func TestDoPostRespectsRetryAfterHeader(t *testing.T) {
+	var timestamps []time.Time
+	var retryCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timestamps = append(timestamps, time.Now())
+		attempt := retryCount.Add(1)
+		if attempt == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// Succeed on 2nd attempt
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]hlFill{})
+	}))
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var result []hlFill
+	err := c.doPost(ctx, map[string]string{"type": "userFills", "user": "0x0"}, &result)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	if len(timestamps) < 2 {
+		t.Fatal("expected at least 2 requests")
+	}
+
+	// The gap between requests should be at least ~1 second (the Retry-After value)
+	gap := timestamps[1].Sub(timestamps[0])
+	if gap < 900*time.Millisecond {
+		t.Errorf("expected at least ~1s gap due to Retry-After header, got %v", gap)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		{"", 0},
+		{"1", 1 * time.Second},
+		{"5", 5 * time.Second},
+		{"60", 60 * time.Second},
+		{"abc", 0},
+		{"1.5", 0}, // Only integer seconds supported
+	}
+
+	for _, tt := range tests {
+		got := parseRetryAfter(tt.input)
+		if got != tt.want {
+			t.Errorf("parseRetryAfter(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestTransformFillBareAtCoinIsSpot(t *testing.T) {
+	accountUUID := uuid.New()
+
+	tests := []struct {
+		name     string
+		coin     string
+		wantBase string
+		wantType string
+	}{
+		{
+			name:     "bare @107 is spot",
+			coin:     "@107",
+			wantBase: "@107",
+			wantType: "spot",
+		},
+		{
+			name:     "bare @2 is spot",
+			coin:     "@2",
+			wantBase: "@2",
+			wantType: "spot",
+		},
+		{
+			name:     "ETH is perp",
+			coin:     "ETH",
+			wantBase: "ETH",
+			wantType: "perp",
+		},
+		{
+			name:     "BTC is perp",
+			coin:     "BTC",
+			wantBase: "BTC",
+			wantType: "perp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fill := hlFill{
+				Time: 1700000000000,
+				Coin: tt.coin,
+				Side: "B",
+				Px:   "10",
+				Sz:   "1",
+				Fee:  "0",
+				Tid:  1,
+			}
+			trade := transformFill(fill, accountUUID)
+			if trade.BaseAsset != tt.wantBase {
+				t.Errorf("BaseAsset = %q, want %q", trade.BaseAsset, tt.wantBase)
+			}
+			if trade.MarketType != tt.wantType {
+				t.Errorf("MarketType = %q, want %q", trade.MarketType, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestSynthesizePrelaunchOpeningsSkipsBareAtCoins(t *testing.T) {
+	accountUUID := uuid.New()
+
+	// Bare @N coin with sell-only fills and startPosition > 0 — should NOT be synthesized
+	// because @N coins are spot, and their opening comes from spotGenesis deposits.
+	fills := []hlFill{
+		{
+			Time:          1733265316756,
+			Coin:          "@107",
+			Side:          "A",
+			Px:            "25.5",
+			Sz:            "100",
+			Fee:           "0.1",
+			Tid:           123,
+			ClosedPnl:     "500",
+			StartPosition: "200",
+			Dir:           "Sell",
+		},
+	}
+
+	result := synthesizePrelaunchOpenings(fills, accountUUID)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 fill (no synthesis for bare @N spot coin), got %d", len(result))
+	}
+}
+
+func TestTransformLedgerEntrySpotTransferWithUsdcValue(t *testing.T) {
+	accountUUID := uuid.New()
+	wallet := "0x4C5feD7BDDA8023f3133e3A8F7C615395AD673c8"
+
+	entry := hlLedgerEntry{
+		Time: 1700000000000,
+		Hash: "0xspotval",
+		Delta: hlLedgerDelta{
+			Type:        "spotTransfer",
+			Token:       "HYPE",
+			Amount:      "100.0",
+			Destination: wallet,
+			UsdcValue:   "2500.0",
+		},
+	}
+
+	transfer, price, err := transformLedgerEntry(entry, accountUUID, wallet)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if transfer == nil {
+		t.Fatal("expected non-nil transfer")
+	}
+	if transfer.Asset != "HYPE" {
+		t.Errorf("Asset = %q, want HYPE", transfer.Asset)
+	}
+	if transfer.Amount != "100" {
+		t.Errorf("Amount = %q, want 100", transfer.Amount)
+	}
+
+	// Price should be derived: 2500 / 100 = 25
+	if price == nil {
+		t.Fatal("expected price record for spotTransfer with usdcValue")
+	}
+	if price.Price != "25" {
+		t.Errorf("price = %q, want 25 (2500/100)", price.Price)
+	}
+	if price.Asset != "HYPE" {
+		t.Errorf("price asset = %q, want HYPE", price.Asset)
+	}
+	if price.Denomination != "USDC" {
+		t.Errorf("price denomination = %q, want USDC", price.Denomination)
+	}
+	if price.Source != "ledger" {
+		t.Errorf("price source = %q, want ledger", price.Source)
+	}
+}
+
+func TestTransformLedgerEntrySpotTransferWithoutUsdcValue(t *testing.T) {
+	accountUUID := uuid.New()
+	wallet := "0x4C5feD7BDDA8023f3133e3A8F7C615395AD673c8"
+
+	entry := hlLedgerEntry{
+		Time: 1700000000000,
+		Hash: "0xspotnoval",
+		Delta: hlLedgerDelta{
+			Type:        "spotTransfer",
+			Token:       "HYPE",
+			Amount:      "50.0",
+			Destination: wallet,
+		},
+	}
+
+	transfer, price, err := transformLedgerEntry(entry, accountUUID, wallet)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if transfer == nil {
+		t.Fatal("expected non-nil transfer")
+	}
+	if price != nil {
+		t.Errorf("expected nil price for spotTransfer without usdcValue, got %+v", price)
+	}
+}
+
+func TestFetchDepositsReturnsPriceRecords(t *testing.T) {
+	entries := []hlLedgerEntry{
+		{
+			Time: 1700000000000,
+			Hash: "0xgenesis1",
+			Delta: hlLedgerDelta{
+				Type:   "spotGenesis",
+				Token:  "PURR",
+				Amount: "1000.0",
+			},
+		},
+		{
+			Time: 1700000001000,
+			Hash: "0xspottx1",
+			Delta: hlLedgerDelta{
+				Type:        "spotTransfer",
+				Token:       "HYPE",
+				Amount:      "50.0",
+				Destination: "0x1234567890abcdef1234567890abcdef12345678",
+				UsdcValue:   "1250.0",
+			},
+		},
+		{
+			Time: 1700000002000,
+			Hash: "0xdeposit1",
+			Delta: hlLedgerDelta{
+				Type: "deposit",
+				Usdc: "5000.0",
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(entries)
+	}))
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	accountID := uuid.New()
+	account := &models.ExchangeAccount{
+		ID:                accountID.String(),
+		AccountIdentifier: "0x1234567890abcdef1234567890abcdef12345678",
+	}
+
+	transfers, prices, err := c.FetchDeposits(context.Background(), account, time.UnixMilli(1700000000000))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(transfers) != 3 {
+		t.Fatalf("expected 3 transfers, got %d", len(transfers))
+	}
+
+	// Should have 2 price records: spotGenesis (price=0) and spotTransfer (price=25)
+	if len(prices) != 2 {
+		t.Fatalf("expected 2 price records, got %d", len(prices))
+	}
+
+	// First price: spotGenesis PURR at price 0
+	if prices[0].Asset != "PURR" {
+		t.Errorf("prices[0].Asset = %q, want PURR", prices[0].Asset)
+	}
+	if prices[0].Price != "0" {
+		t.Errorf("prices[0].Price = %q, want 0", prices[0].Price)
+	}
+
+	// Second price: spotTransfer HYPE at price 25 (1250/50)
+	if prices[1].Asset != "HYPE" {
+		t.Errorf("prices[1].Asset = %q, want HYPE", prices[1].Asset)
+	}
+	if prices[1].Price != "25" {
+		t.Errorf("prices[1].Price = %q, want 25", prices[1].Price)
 	}
 }

--- a/exchange/hyperliquid/pagination.go
+++ b/exchange/hyperliquid/pagination.go
@@ -11,11 +11,22 @@ const maxFillsPerPage = 2000
 // maxLedgerEntriesPerPage is the number of ledger entries we expect before paginating.
 const maxLedgerEntriesPerPage = 500
 
+// clampUnixMilli returns the unix milliseconds of t, clamped to 0 (Unix epoch)
+// if t is before that. Go's zero time.Time is year 1 which gives a negative ms value
+// that the Hyperliquid API rejects.
+func clampUnixMilli(t time.Time) int64 {
+	ms := t.UnixMilli()
+	if ms < 0 {
+		return 0
+	}
+	return ms
+}
+
 // fetchAllFills fetches all fills for a user, paginating by startTime.
 // since is the earliest timestamp to fetch from (unix milliseconds).
 // Returns fills sorted by timestamp ascending (oldest first).
 func (c *Client) fetchAllFills(ctx context.Context, user string, since time.Time) ([]hlFill, error) {
-	startTime := since.UnixMilli()
+	startTime := clampUnixMilli(since)
 	var all []hlFill
 
 	for {
@@ -59,7 +70,7 @@ func (c *Client) fetchAllFunding(ctx context.Context, user string, since time.Ti
 	req := map[string]interface{}{
 		"type":      "userFunding",
 		"user":      user,
-		"startTime": since.UnixMilli(),
+		"startTime": clampUnixMilli(since),
 	}
 
 	var entries []hlFundingEntry
@@ -72,7 +83,7 @@ func (c *Client) fetchAllFunding(ctx context.Context, user string, since time.Ti
 
 // fetchAllLedgerUpdates fetches all non-funding ledger updates for a user since the given time.
 func (c *Client) fetchAllLedgerUpdates(ctx context.Context, user string, since time.Time) ([]hlLedgerEntry, error) {
-	startTime := since.UnixMilli()
+	startTime := clampUnixMilli(since)
 	var all []hlLedgerEntry
 
 	for {

--- a/exchange/hyperliquid/pagination.go
+++ b/exchange/hyperliquid/pagination.go
@@ -35,7 +35,7 @@ func (c *Client) fetchAllFills(ctx context.Context, user string, since time.Time
 		}
 
 		req := map[string]interface{}{
-			"type":      "userFills",
+			"type":      "userFillsByTime",
 			"user":      user,
 			"startTime": startTime,
 		}

--- a/exchange/hyperliquid/spot_meta.go
+++ b/exchange/hyperliquid/spot_meta.go
@@ -1,0 +1,133 @@
+package hyperliquid
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// hlSpotMetaResponse is the response from the spotMeta endpoint.
+// Request: {"type": "spotMeta"}
+type hlSpotMetaResponse struct {
+	Tokens []hlSpotToken    `json:"tokens"`
+	Universe []hlSpotMarket `json:"universe"`
+}
+
+// hlSpotToken represents a token in the spotMeta response.
+type hlSpotToken struct {
+	Name        string `json:"name"`
+	Index       int    `json:"index"`
+	SzDecimals  int    `json:"szDecimals"`
+	WeiDecimals int    `json:"weiDecimals"`
+	TokenID     string `json:"tokenId"`
+	IsCanonical bool   `json:"isCanonical"`
+}
+
+// hlSpotMarket represents a spot trading pair in the spotMeta universe.
+type hlSpotMarket struct {
+	Name        string `json:"name"`
+	Tokens      []int  `json:"tokens"` // [baseTokenIndex, quoteTokenIndex]
+	Index       int    `json:"index"`
+	IsCanonical bool   `json:"isCanonical"`
+}
+
+// spotMetaCache caches the mapping from @N universe index to token names.
+// Populated lazily on first use and shared across all Client instances.
+type spotMetaCache struct {
+	mu     sync.RWMutex
+	// universeIndexToBase maps universe index N (from @N) to the base token name
+	universeIndexToBase map[int]string
+	// universeIndexToQuote maps universe index N to the quote token name
+	universeIndexToQuote map[int]string
+	loaded bool
+}
+
+var globalSpotMetaCache = &spotMetaCache{
+	universeIndexToBase:  make(map[int]string),
+	universeIndexToQuote: make(map[int]string),
+}
+
+// resolveSpotCoin resolves a @N spot coin index to the actual token name.
+// If the coin doesn't start with @, it is returned as-is.
+func (mc *spotMetaCache) resolveSpotCoin(ctx context.Context, c *Client, coin string) (base, quote string, err error) {
+	if len(coin) < 2 || coin[0] != '@' {
+		// Not an indexed coin — return as-is with USDC quote
+		return coin, "USDC", nil
+	}
+
+	var idx int
+	if _, err := fmt.Sscanf(coin, "@%d", &idx); err != nil {
+		return coin, "USDC", nil
+	}
+
+	mc.mu.RLock()
+	if mc.loaded {
+		base, baseOK := mc.universeIndexToBase[idx]
+		quote, quoteOK := mc.universeIndexToQuote[idx]
+		mc.mu.RUnlock()
+		if baseOK && quoteOK {
+			return base, quote, nil
+		}
+		// Index not found — try reloading in case new markets were added
+		return mc.reload(ctx, c, idx)
+	}
+	mc.mu.RUnlock()
+
+	return mc.reload(ctx, c, idx)
+}
+
+// reload fetches spot metadata from the API and rebuilds the cache.
+func (mc *spotMetaCache) reload(ctx context.Context, c *Client, idx int) (string, string, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if mc.loaded {
+		if base, ok := mc.universeIndexToBase[idx]; ok {
+			return base, mc.universeIndexToQuote[idx], nil
+		}
+	}
+
+	var resp hlSpotMetaResponse
+	if err := c.doPost(ctx, map[string]string{"type": "spotMeta"}, &resp); err != nil {
+		return "", "", fmt.Errorf("failed to fetch spot metadata: %w", err)
+	}
+
+	// Build token index -> name lookup
+	tokenNames := make(map[int]string, len(resp.Tokens))
+	for _, token := range resp.Tokens {
+		tokenNames[token.Index] = token.Name
+	}
+
+	// Build universe index -> base/quote token names
+	for _, market := range resp.Universe {
+		if len(market.Tokens) >= 2 {
+			baseName := tokenNames[market.Tokens[0]]
+			quoteName := tokenNames[market.Tokens[1]]
+			mc.universeIndexToBase[market.Index] = baseName
+			mc.universeIndexToQuote[market.Index] = quoteName
+		}
+	}
+	mc.loaded = true
+
+	base, baseOK := mc.universeIndexToBase[idx]
+	quote, quoteOK := mc.universeIndexToQuote[idx]
+	if !baseOK || !quoteOK {
+		return "", "", fmt.Errorf("unknown spot market index @%d", idx)
+	}
+	return base, quote, nil
+}
+
+// resolveSpotCoin resolves a @N spot coin to the actual token name using the global cache.
+func (c *Client) resolveSpotCoin(ctx context.Context, coin string) (base, quote string, err error) {
+	return globalSpotMetaCache.resolveSpotCoin(ctx, c, coin)
+}
+
+// resetSpotMetaCache resets the global spot metadata cache. Used in tests.
+func resetSpotMetaCache() {
+	globalSpotMetaCache.mu.Lock()
+	defer globalSpotMetaCache.mu.Unlock()
+	globalSpotMetaCache.universeIndexToBase = make(map[int]string)
+	globalSpotMetaCache.universeIndexToQuote = make(map[int]string)
+	globalSpotMetaCache.loaded = false
+}

--- a/exchange/hyperliquid/types.go
+++ b/exchange/hyperliquid/types.go
@@ -4,8 +4,8 @@ package hyperliquid
 // Base URL: https://api.hyperliquid.xyz/info (POST with JSON body)
 
 // hlFill represents a single trade fill from Hyperliquid API
-// Request: {"type": "userFills", "user": "0x..."}
-// or with pagination: {"type": "userFills", "user": "0x...", "startTime": 1234567890000}
+// Request: {"type": "userFillsByTime", "user": "0x...", "startTime": 1234567890000}
+// Returns fills sorted by timestamp ascending (oldest first).
 type hlFill struct {
 	Time      int64  `json:"time"`      // Unix milliseconds
 	Coin      string `json:"coin"`      // e.g., "ETH" for perp, "ETH-SPOT" for spot

--- a/exchange/hyperliquid/types.go
+++ b/exchange/hyperliquid/types.go
@@ -17,8 +17,9 @@ type hlFill struct {
 	ClosedPnl string `json:"closedPnl"` // Realized PnL on this fill
 	Hash      string `json:"hash"`      // Transaction hash
 	StartPosition string `json:"startPosition"` // Position before fill
-	Dir       string `json:"dir"`       // Direction description
+	Dir       string `json:"dir"`       // Direction description (e.g., "Open Long", "Close Short", "Sell", "Spot Dust Conversion")
 	Oid       int64  `json:"oid"`       // Order ID
+	FeeToken  string `json:"feeToken"`  // Fee denomination token
 }
 
 // hlFundingEntry represents a single funding payment from Hyperliquid API
@@ -50,13 +51,16 @@ type hlLedgerEntry struct {
 
 // hlLedgerDelta holds the details of a ledger update
 type hlLedgerDelta struct {
-	Type    string `json:"type"`    // "deposit", "withdraw", "internalTransfer", etc.
-	Usdc    string `json:"usdc"`    // USDC amount (string)
-	Amount  string `json:"amount"`  // Amount (sometimes used instead of usdc)
-	Token   string `json:"token"`   // Token name (for non-USDC)
-	Fee     string `json:"fee"`     // Fee (if applicable)
-	Nonce   int64  `json:"nonce"`   // Nonce
-	Destination string `json:"destination"` // Destination address (for withdrawals)
+	Type        string `json:"type"`        // "deposit", "withdraw", "internalTransfer", "spotTransfer", etc.
+	Usdc        string `json:"usdc"`        // USDC amount (string)
+	Amount      string `json:"amount"`      // Amount (sometimes used instead of usdc)
+	Token       string `json:"token"`       // Token name (for non-USDC)
+	Fee         string `json:"fee"`         // Fee (if applicable)
+	Nonce       int64  `json:"nonce"`       // Nonce
+	Destination string `json:"destination"` // Destination address (for withdrawals/spotTransfer)
+	User        string `json:"user"`        // Source user address (for spotTransfer outbound)
+	ToPerp      bool   `json:"toPerp"`      // Direction for accountClassTransfer (true = spot→perp)
+	UsdcValue   string `json:"usdcValue"`   // USDC value of spot transfer (for price derivation)
 }
 
 // hlClearinghouseState represents the clearinghouse state for a user

--- a/exchange/iface/contract.go
+++ b/exchange/iface/contract.go
@@ -297,6 +297,9 @@ func validateFundingTransferInput(t *testing.T, payment *models.TransferInput) {
 	if payment.Timestamp.IsZero() {
 		t.Error("TransferInput.Timestamp must be non-zero")
 	}
+	if payment.ExternalID == "" {
+		t.Error("TransferInput.ExternalID must be non-empty for funding payments")
+	}
 	if payment.Metadata == nil {
 		t.Error("TransferInput.Metadata must be non-nil for funding payments")
 	} else {

--- a/exchange/lighter/auth.go
+++ b/exchange/lighter/auth.go
@@ -1,0 +1,43 @@
+package lighter
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// defaultTokenDuration is how long a read-only token is valid for.
+const defaultTokenDuration = 24 * time.Hour
+
+// generateReadOnlyToken creates a read-only API token for Lighter.
+// Format: ro:{account_index}:{scope}:{expiry_unix}:{random_hex}
+// scope is "single" for one account or "all" for all accounts.
+func generateReadOnlyToken(accountIndex int, scope string, expiry time.Time) (string, error) {
+	randomBytes := make([]byte, 16)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+
+	token := fmt.Sprintf("ro:%d:%s:%d:%s",
+		accountIndex,
+		scope,
+		expiry.Unix(),
+		hex.EncodeToString(randomBytes),
+	)
+
+	return token, nil
+}
+
+// buildAuthToken returns the auth token to use for API requests.
+// If an API key is provided (from account metadata), it is used directly.
+// Otherwise, a read-only token is generated.
+func buildAuthToken(apiKey string, accountIndex int) (string, error) {
+	if apiKey != "" {
+		return apiKey, nil
+	}
+
+	// Generate a read-only token
+	expiry := time.Now().Add(defaultTokenDuration)
+	return generateReadOnlyToken(accountIndex, "single", expiry)
+}

--- a/exchange/lighter/client.go
+++ b/exchange/lighter/client.go
@@ -1,0 +1,475 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+const (
+	defaultBaseURL = "https://mainnet.zklighter.elliot.ai/api/v1"
+	httpTimeout    = 15 * time.Second
+	maxRetries     = 5
+	initialBackoff = 2 * time.Second
+	maxBackoff     = 60 * time.Second
+	backoffMult    = 2.0
+)
+
+// Client implements iface.ExchangeClient for Lighter DEX.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	limiter    *rateLimiter // nil means use globalLimiter
+}
+
+// NewClient creates a new Lighter client.
+func NewClient() *Client {
+	return &Client{
+		baseURL:    defaultBaseURL,
+		httpClient: &http.Client{Timeout: httpTimeout},
+	}
+}
+
+// Name returns the exchange identifier.
+func (c *Client) Name() string {
+	return "lighter"
+}
+
+// doGet performs an authenticated GET request with rate limiting and retry on 429.
+func (c *Client) doGet(ctx context.Context, url string) (json.RawMessage, error) {
+	backoff := initialBackoff
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		lim := c.limiter
+		if lim == nil {
+			lim = globalLimiter
+		}
+		if err := lim.Wait(ctx); err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("request failed: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			resp.Body.Close()
+
+			if attempt == maxRetries {
+				return nil, &iface.RateLimitError{
+					Exchange:   "lighter",
+					Message:    fmt.Sprintf("rate limit exceeded after %d retries", maxRetries),
+					RetryAfter: backoff,
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+
+			backoff = time.Duration(float64(backoff) * backoffMult)
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		// 404 is a legitimate "no data" for Lighter history endpoints.
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+		// 400 is a client-side error — always a bug in the request we built.
+		if resp.StatusCode == http.StatusBadRequest {
+			return nil, fmt.Errorf("lighter: 400 bad request | url=%s | body=%s", url, string(body))
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		}
+
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("max retries exceeded")
+}
+
+// FetchTrades fetches trades from the Lighter trades API.
+func (c *Client) FetchTrades(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TradeInput, []*models.PriceRecord, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	accountIndex, err := strconv.Atoi(account.AccountIdentifier)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid account_index %q: %w", account.AccountIdentifier, err)
+	}
+
+	rawTrades, err := fetchAllPages[lighterTrade](ctx, c, func(cursor string) string {
+		url := fmt.Sprintf("%s/trades?account_index=%d&sort_by=timestamp&limit=%d",
+			c.baseURL, accountIndex, defaultPageLimit)
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		return url
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch trades: %w", err)
+	}
+
+	sinceMs := since.UnixMilli()
+	trades := make([]*models.TradeInput, 0, len(rawTrades))
+	prices := make([]*models.PriceRecord, 0, len(rawTrades))
+
+	for _, rt := range rawTrades {
+		if !since.IsZero() && rt.Timestamp < sinceMs {
+			continue
+		}
+
+		market, err := c.resolveMarket(ctx, rt.MarketID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve market %d: %w", rt.MarketID, err)
+		}
+
+		// Determine side: if account is the bid account, they're buying; if ask, selling
+		side := "buy"
+		orderID := rt.BidOrderID
+		if rt.AskAccountID == accountIndex {
+			side = "sell"
+			orderID = rt.AskOrderID
+		}
+
+		// Determine fee: taker vs maker
+		fee := rt.MakerFee
+		if (side == "buy" && rt.IsBuyerTaker) || (side == "sell" && !rt.IsBuyerTaker) {
+			fee = rt.TakerFee
+		}
+
+		ts := time.UnixMilli(rt.Timestamp).UTC()
+
+		trades = append(trades, &models.TradeInput{
+			TradeID:           rt.TradeID,
+			OrderID:           orderID,
+			BaseAsset:         market.BaseAsset,
+			QuoteAsset:        market.QuoteAsset,
+			Side:              side,
+			Price:             cleanDecimal(rt.Price),
+			Quantity:          cleanDecimal(rt.Quantity),
+			Fee:               cleanDecimal(fee),
+			Timestamp:         ts,
+			ExchangeAccountID: accountUUID,
+			MarketType:        market.MarketType,
+			FeeAsset:          "USDC",
+		})
+
+		if rt.Price != "" && rt.Price != "0" {
+			prices = append(prices, &models.PriceRecord{
+				Asset:        market.BaseAsset,
+				Denomination: market.QuoteAsset,
+				Timestamp:    ts,
+				Price:        cleanDecimal(rt.Price),
+				Source:       "execution",
+			})
+		}
+	}
+
+	// Sort ascending by timestamp
+	sort.Slice(trades, func(i, j int) bool {
+		return trades[i].Timestamp.Before(trades[j].Timestamp)
+	})
+	sort.Slice(prices, func(i, j int) bool {
+		return prices[i].Timestamp.Before(prices[j].Timestamp)
+	})
+
+	return trades, prices, nil
+}
+
+// FetchFundingPayments fetches funding payments from the Lighter positionFunding API.
+func (c *Client) FetchFundingPayments(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TransferInput, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	accountIndex, err := strconv.Atoi(account.AccountIdentifier)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account_index %q: %w", account.AccountIdentifier, err)
+	}
+
+	rawFunding, err := fetchAllPages[lighterFunding](ctx, c, func(cursor string) string {
+		url := fmt.Sprintf("%s/positionFunding?account_index=%d&limit=%d",
+			c.baseURL, accountIndex, defaultPageLimit)
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		return url
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch funding: %w", err)
+	}
+
+	sinceMs := since.UnixMilli()
+	payments := make([]*models.TransferInput, 0, len(rawFunding))
+
+	for _, rf := range rawFunding {
+		if !since.IsZero() && rf.Timestamp < sinceMs {
+			continue
+		}
+
+		market, err := c.resolveMarket(ctx, rf.MarketID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve market %d: %w", rf.MarketID, err)
+		}
+
+		payments = append(payments, &models.TransferInput{
+			ExchangeAccountID: accountUUID,
+			Type:              models.TypeFunding,
+			Asset:             market.QuoteAsset,
+			Amount:            rf.Amount,
+			Timestamp:         time.UnixMilli(rf.Timestamp).UTC(),
+			ExternalID:        rf.FundingID,
+			Metadata: map[string]string{
+				"market":     market.Symbol + "-PERP",
+				"payment_id": rf.FundingID,
+			},
+		})
+	}
+
+	// Sort ascending by timestamp
+	sort.Slice(payments, func(i, j int) bool {
+		return payments[i].Timestamp.Before(payments[j].Timestamp)
+	})
+
+	return payments, nil
+}
+
+// FetchDeposits fetches deposits and withdrawals from the Lighter deposit history API.
+func (c *Client) FetchDeposits(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TransferInput, []*models.PriceRecord, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
+	accountUUID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid account ID: %w", err)
+	}
+
+	accountIndex, err := strconv.Atoi(account.AccountIdentifier)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid account_index %q: %w", account.AccountIdentifier, err)
+	}
+
+	// Extract l1_address from account metadata or use wallet address
+	l1Address := extractL1Address(account)
+
+	rawDeposits, err := fetchAllPages[lighterDeposit](ctx, c, func(cursor string) string {
+		url := fmt.Sprintf("%s/deposit/history?account_index=%d&l1_address=%s&filter=all&limit=%d",
+			c.baseURL, accountIndex, l1Address, defaultPageLimit)
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		return url
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch deposits: %w", err)
+	}
+
+	sinceMs := since.UnixMilli()
+	transfers := make([]*models.TransferInput, 0, len(rawDeposits))
+
+	for _, rd := range rawDeposits {
+		if !since.IsZero() && rd.Timestamp < sinceMs {
+			continue
+		}
+
+		// Determine deposit vs withdrawal from amount sign
+		amount := rd.Amount
+		transferType := models.TypeDeposit
+		if strings.HasPrefix(amount, "-") {
+			transferType = models.TypeWithdraw
+			amount = amount[1:] // Make positive
+		}
+
+		// Resolve asset from asset_id (0 = USDC on Lighter)
+		asset := "USDC"
+
+		transfers = append(transfers, &models.TransferInput{
+			ExchangeAccountID: accountUUID,
+			Type:              transferType,
+			Asset:             asset,
+			Amount:            cleanDecimal(amount),
+			Timestamp:         time.UnixMilli(rd.Timestamp).UTC(),
+			Metadata: map[string]string{
+				"deposit_id": rd.DepositID,
+				"tx_hash":    rd.TxHash,
+			},
+		})
+	}
+
+	// Sort ascending by timestamp
+	sort.Slice(transfers, func(i, j int) bool {
+		return transfers[i].Timestamp.Before(transfers[j].Timestamp)
+	})
+
+	return transfers, nil, nil
+}
+
+// FetchBalances fetches current balances for a Lighter account.
+func (c *Client) FetchBalances(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+) ([]*models.BalanceSnapshot, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	l1Address := extractL1Address(account)
+	if l1Address == "" {
+		return nil, fmt.Errorf("l1_address is required for balance fetching")
+	}
+
+	accountIndex, err := strconv.Atoi(account.AccountIdentifier)
+	if err != nil {
+		return nil, fmt.Errorf("invalid account_index %q: %w", account.AccountIdentifier, err)
+	}
+
+	url := fmt.Sprintf("%s/account?by=l1_address&value=%s", c.baseURL, l1Address)
+	body, err := c.doGet(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch account: %w", err)
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	var resp lighterAccountResp
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode account response: %w", err)
+	}
+
+	nowMs := time.Now().UnixMilli()
+	var balances []*models.BalanceSnapshot
+
+	for _, acct := range resp.Accounts {
+		if acct.AccountIndex != accountIndex {
+			continue
+		}
+
+		for _, a := range acct.Assets {
+			bal, err := strconv.ParseFloat(a.Balance, 64)
+			if err != nil {
+				return nil, fmt.Errorf("lighter: failed to parse balance %q for asset %s (account_index=%d): %w", a.Balance, a.Symbol, accountIndex, err)
+			}
+			if math.Abs(bal) < 0.000001 {
+				continue
+			}
+			_ = bal
+			balances = append(balances, &models.BalanceSnapshot{
+				Asset:       a.Symbol,
+				Balance:     a.Balance,
+				TimestampMs: nowMs,
+			})
+		}
+	}
+
+	return balances, nil
+}
+
+// FetchHistoricalBalanceSnapshots returns nil for Lighter (not supported).
+func (c *Client) FetchHistoricalBalanceSnapshots(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+) ([]*models.HistoricalBalanceSnapshots, error) {
+	return nil, nil
+}
+
+// FetchSettlements returns nil for Lighter.
+// Lighter settles on close (PnL is credited to balance immediately on position close).
+func (c *Client) FetchSettlements(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.Settlement, error) {
+	return nil, nil
+}
+
+// extractL1Address extracts the L1 (Ethereum) address from account metadata.
+func extractL1Address(account *models.ExchangeAccount) string {
+	if account.AccountTypeMetadata != nil {
+		var meta map[string]interface{}
+		if err := json.Unmarshal(account.AccountTypeMetadata, &meta); err == nil {
+			if addr, ok := meta["l1_address"].(string); ok && addr != "" {
+				return addr
+			}
+		}
+	}
+	return ""
+}
+
+// cleanDecimal cleans a decimal string: trims trailing zeros and dots.
+func cleanDecimal(s string) string {
+	if s == "" {
+		return "0"
+	}
+	if strings.Contains(s, ".") {
+		s = strings.TrimRight(s, "0")
+		s = strings.TrimRight(s, ".")
+	}
+	if s == "" || s == "-" {
+		return "0"
+	}
+	return s
+}
+
+// Compile-time interface check
+var _ iface.ExchangeClient = (*Client)(nil)

--- a/exchange/lighter/client_test.go
+++ b/exchange/lighter/client_test.go
@@ -1,0 +1,798 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+func TestClientImplementsInterface(t *testing.T) {
+	var _ iface.ExchangeClient = (*Client)(nil)
+}
+
+func TestName(t *testing.T) {
+	c := NewClient()
+	if c.Name() != "lighter" {
+		t.Errorf("expected 'lighter', got %q", c.Name())
+	}
+}
+
+func TestFetchSettlementsReturnsNil(t *testing.T) {
+	c := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0",
+	}
+	settlements, err := c.FetchSettlements(context.Background(), account, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if settlements != nil {
+		t.Errorf("expected nil settlements, got %v", settlements)
+	}
+}
+
+func TestFetchHistoricalBalanceSnapshotsReturnsNil(t *testing.T) {
+	c := NewClient()
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0",
+	}
+	snapshots, err := c.FetchHistoricalBalanceSnapshots(context.Background(), account)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snapshots != nil {
+		t.Errorf("expected nil snapshots, got %v", snapshots)
+	}
+}
+
+// testLimiter returns a fast rate limiter for tests (no waiting).
+func testLimiter() *rateLimiter {
+	return newRateLimiter(1000, 1000)
+}
+
+// newTestClient creates a Client pointing at a test server URL with a fast rate limiter.
+func newTestClient(url string) *Client {
+	return &Client{
+		baseURL:    url,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		limiter:    testLimiter(),
+	}
+}
+
+func TestFetchTradesWithMock(t *testing.T) {
+	resetMarketCache()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
+			OrderBooks: []lighterOrderBookDetail{
+				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
+				{MarketID: 2, Symbol: "BTC", BaseAsset: "BTC", QuoteAsset: "USDC", MarketType: "perp"},
+			},
+		})
+	})
+
+	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
+			Code:    0,
+			Message: "ok",
+			Data: []lighterTrade{
+				{
+					TradeID:      "t1",
+					MarketID:     1,
+					AskAccountID: 5,
+					BidAccountID: 10,
+					Price:        "2000.50",
+					Quantity:     "1.5",
+					TakerFee:     "0.30",
+					MakerFee:     "0.10",
+					IsBuyerTaker: true,
+					Timestamp:    1700000001000,
+					AskOrderID:   "o-ask-1",
+					BidOrderID:   "o-bid-1",
+				},
+				{
+					TradeID:      "t2",
+					MarketID:     2,
+					AskAccountID: 10,
+					BidAccountID: 99,
+					Price:        "35000.00",
+					Quantity:     "0.1",
+					TakerFee:     "0.50",
+					MakerFee:     "0.15",
+					IsBuyerTaker: false,
+					Timestamp:    1700000000000,
+					AskOrderID:   "o-ask-2",
+					BidOrderID:   "o-bid-2",
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accountID := uuid.New()
+	account := &models.ExchangeAccount{
+		ID:                accountID.String(),
+		AccountIdentifier: "10", // account_index = 10
+	}
+
+	trades, prices, err := c.FetchTrades(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(trades) != 2 {
+		t.Fatalf("expected 2 trades, got %d", len(trades))
+	}
+
+	if len(prices) != 2 {
+		t.Errorf("expected 2 price records, got %d", len(prices))
+	}
+
+	// Verify sorted ascending by timestamp
+	if !trades[0].Timestamp.Before(trades[1].Timestamp) {
+		t.Error("trades should be sorted ascending by timestamp")
+	}
+
+	// First trade (t2 - earlier timestamp): account 10 is ask, so sell
+	sell := trades[0]
+	if sell.TradeID != "t2" {
+		t.Errorf("expected trade t2 first (earlier), got %s", sell.TradeID)
+	}
+	if sell.Side != "sell" {
+		t.Errorf("expected sell side for ask account, got %s", sell.Side)
+	}
+	if sell.BaseAsset != "BTC" {
+		t.Errorf("expected BTC, got %s", sell.BaseAsset)
+	}
+	if sell.MarketType != "perp" {
+		t.Errorf("expected perp, got %s", sell.MarketType)
+	}
+	if sell.Fee != "0.5" {
+		t.Errorf("expected fee 0.5 (taker, sell side, buyer is not taker), got %s", sell.Fee)
+	}
+	if sell.OrderID != "o-ask-2" {
+		t.Errorf("expected ask order ID for sell side, got %s", sell.OrderID)
+	}
+	if sell.FeeAsset != "USDC" {
+		t.Errorf("expected USDC fee asset, got %s", sell.FeeAsset)
+	}
+
+	// Second trade (t1 - later timestamp): account 10 is bid, so buy
+	buy := trades[1]
+	if buy.Side != "buy" {
+		t.Errorf("expected buy side for bid account, got %s", buy.Side)
+	}
+	if buy.BaseAsset != "ETH" {
+		t.Errorf("expected ETH, got %s", buy.BaseAsset)
+	}
+	if buy.Fee != "0.3" {
+		t.Errorf("expected fee 0.3 (taker, buy side, buyer is taker), got %s", buy.Fee)
+	}
+	if buy.ExchangeAccountID != accountID {
+		t.Errorf("expected account ID %v, got %v", accountID, buy.ExchangeAccountID)
+	}
+
+	// Verify price records
+	if len(prices) >= 2 {
+		if prices[0].Source != "execution" {
+			t.Errorf("price source = %s, want execution", prices[0].Source)
+		}
+	}
+}
+
+func TestFetchTradesSideDetermination(t *testing.T) {
+	resetMarketCache()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
+			OrderBooks: []lighterOrderBookDetail{
+				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
+			},
+		})
+	})
+
+	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
+			Code: 0,
+			Data: []lighterTrade{
+				{
+					TradeID:      "t-maker-buy",
+					MarketID:     1,
+					AskAccountID: 99,
+					BidAccountID: 5, // Our account is bid (buyer) and maker
+					Price:        "2000",
+					Quantity:     "1",
+					TakerFee:     "0.30",
+					MakerFee:     "0.10",
+					IsBuyerTaker: false, // Buyer is maker
+					Timestamp:    1700000000000,
+					AskOrderID:   "o1",
+					BidOrderID:   "o2",
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "5",
+	}
+
+	trades, _, err := c.FetchTrades(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(trades))
+	}
+
+	// Account 5 is bid (buyer), buyer is NOT taker, so fee should be maker fee
+	if trades[0].Fee != "0.1" {
+		t.Errorf("expected maker fee 0.1, got %s", trades[0].Fee)
+	}
+}
+
+func TestFetchFundingPaymentsWithMock(t *testing.T) {
+	resetMarketCache()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
+			OrderBooks: []lighterOrderBookDetail{
+				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
+			},
+		})
+	})
+
+	mux.HandleFunc("/positionFunding", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(apiResponse[lighterFunding]{
+			Code: 0,
+			Data: []lighterFunding{
+				{
+					FundingID: "f1",
+					AccountID: 10,
+					MarketID:  1,
+					Amount:    "-0.50",
+					Timestamp: 1700000000000,
+				},
+				{
+					FundingID: "f2",
+					AccountID: 10,
+					MarketID:  1,
+					Amount:    "1.25",
+					Timestamp: 1700000001000,
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accountID := uuid.New()
+	account := &models.ExchangeAccount{
+		ID:                accountID.String(),
+		AccountIdentifier: "10",
+	}
+
+	payments, err := c.FetchFundingPayments(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(payments) != 2 {
+		t.Fatalf("expected 2 payments, got %d", len(payments))
+	}
+
+	// Verify sorted ascending
+	if !payments[0].Timestamp.Before(payments[1].Timestamp) {
+		t.Error("payments should be sorted ascending by timestamp")
+	}
+
+	p := payments[0]
+	if p.Type != models.TypeFunding {
+		t.Errorf("Type = %q, want %q", p.Type, models.TypeFunding)
+	}
+	if p.Asset != "USDC" {
+		t.Errorf("Asset = %q, want USDC", p.Asset)
+	}
+	if p.Amount != "-0.50" {
+		t.Errorf("Amount = %q, want -0.50", p.Amount)
+	}
+	if p.Metadata["market"] != "ETH-PERP" {
+		t.Errorf("market metadata = %q, want ETH-PERP", p.Metadata["market"])
+	}
+	if p.Metadata["payment_id"] != "f1" {
+		t.Errorf("payment_id metadata = %q, want f1", p.Metadata["payment_id"])
+	}
+	if p.ExchangeAccountID != accountID {
+		t.Errorf("ExchangeAccountID = %v, want %v", p.ExchangeAccountID, accountID)
+	}
+}
+
+func TestFetchDepositsWithMock(t *testing.T) {
+	resetMarketCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(apiResponse[lighterDeposit]{
+			Code: 0,
+			Data: []lighterDeposit{
+				{
+					DepositID: "d1",
+					AccountID: 10,
+					AssetID:   0,
+					Amount:    "1000.00",
+					Status:    "completed",
+					Timestamp: 1700000000000,
+					TxHash:    "0xaaa",
+				},
+				{
+					DepositID: "d2",
+					AccountID: 10,
+					AssetID:   0,
+					Amount:    "-500.00",
+					Status:    "completed",
+					Timestamp: 1700000001000,
+					TxHash:    "0xbbb",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accountID := uuid.New()
+	meta, _ := json.Marshal(map[string]interface{}{"l1_address": "0x1234"})
+	account := &models.ExchangeAccount{
+		ID:                  accountID.String(),
+		AccountIdentifier:   "10",
+		AccountTypeMetadata: meta,
+	}
+
+	transfers, prices, err := c.FetchDeposits(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if prices != nil {
+		t.Error("expected nil prices for Lighter deposits")
+	}
+
+	if len(transfers) != 2 {
+		t.Fatalf("expected 2 transfers, got %d", len(transfers))
+	}
+
+	// Verify sorted ascending
+	if !transfers[0].Timestamp.Before(transfers[1].Timestamp) {
+		t.Error("transfers should be sorted ascending by timestamp")
+	}
+
+	dep := transfers[0]
+	if dep.Type != models.TypeDeposit {
+		t.Errorf("deposit Type = %q, want %q", dep.Type, models.TypeDeposit)
+	}
+	if dep.Amount != "1000" {
+		t.Errorf("deposit Amount = %q, want 1000", dep.Amount)
+	}
+	if dep.Asset != "USDC" {
+		t.Errorf("deposit Asset = %q, want USDC", dep.Asset)
+	}
+	if dep.Metadata["deposit_id"] != "d1" {
+		t.Errorf("deposit_id metadata = %q, want d1", dep.Metadata["deposit_id"])
+	}
+
+	wd := transfers[1]
+	if wd.Type != models.TypeWithdraw {
+		t.Errorf("withdraw Type = %q, want %q", wd.Type, models.TypeWithdraw)
+	}
+	if wd.Amount != "500" {
+		t.Errorf("withdraw Amount = %q, want 500 (should be positive)", wd.Amount)
+	}
+}
+
+func TestFetchBalancesWithMock(t *testing.T) {
+	resetMarketCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterAccountResp{
+			Accounts: []lighterAccount{
+				{
+					AccountIndex: 10,
+					L1Address:    "0x1234",
+					Assets: []lighterAsset{
+						{Symbol: "USDC", AssetID: 0, Balance: "5000.50", LockedBalance: "0"},
+						{Symbol: "ETH", AssetID: 1, Balance: "1.5", LockedBalance: "0.5"},
+					},
+				},
+				{
+					AccountIndex: 20,
+					L1Address:    "0x1234",
+					Assets: []lighterAsset{
+						{Symbol: "USDC", AssetID: 0, Balance: "100", LockedBalance: "0"},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	meta, _ := json.Marshal(map[string]interface{}{"l1_address": "0x1234"})
+	account := &models.ExchangeAccount{
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "10",
+		AccountTypeMetadata: meta,
+	}
+
+	balances, err := c.FetchBalances(context.Background(), account)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should only return balances for account_index=10
+	if len(balances) != 2 {
+		t.Fatalf("expected 2 balances (USDC + ETH), got %d", len(balances))
+	}
+
+	var usdcBalance, ethBalance *models.BalanceSnapshot
+	for _, b := range balances {
+		switch b.Asset {
+		case "USDC":
+			usdcBalance = b
+		case "ETH":
+			ethBalance = b
+		}
+	}
+
+	if usdcBalance == nil {
+		t.Fatal("expected USDC balance")
+	}
+	if usdcBalance.Balance != "5000.50" {
+		t.Errorf("USDC balance = %s, want 5000.50", usdcBalance.Balance)
+	}
+
+	if ethBalance == nil {
+		t.Fatal("expected ETH balance")
+	}
+	if ethBalance.Balance != "1.5" {
+		t.Errorf("ETH balance = %s, want 1.5", ethBalance.Balance)
+	}
+}
+
+func TestDiscoverAccountsWithMock(t *testing.T) {
+	resetMarketCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterAccountResp{
+			Code: 200,
+			Accounts: []lighterAccount{
+				{
+					AccountIndex: 0,
+					L1Address:    "0xabcdef",
+					Status:       "active",
+					Assets: []lighterAsset{
+						{Symbol: "USDC", Balance: "1000"},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accounts, err := c.DiscoverAccounts(context.Background(), "0xabcdef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+
+	acc := accounts[0]
+	if acc.AccountIdentifier != "0" {
+		t.Errorf("AccountIdentifier = %q, want '0'", acc.AccountIdentifier)
+	}
+	if acc.AccountType != "main" {
+		t.Errorf("AccountType = %q, want 'main'", acc.AccountType)
+	}
+	if acc.Name != "Main Account" {
+		t.Errorf("Name = %q, want 'Main Account'", acc.Name)
+	}
+	if acc.Metadata["l1_address"] != "0xabcdef" {
+		t.Errorf("metadata l1_address = %v, want '0xabcdef'", acc.Metadata["l1_address"])
+	}
+}
+
+func TestDiscoverAccountsMultipleSubaccounts(t *testing.T) {
+	resetMarketCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterAccountResp{
+			Code: 200,
+			Accounts: []lighterAccount{
+				{AccountIndex: 0, L1Address: "0xabcdef"},
+				{AccountIndex: 1, L1Address: "0xabcdef"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accounts, err := c.DiscoverAccounts(context.Background(), "0xabcdef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(accounts) != 2 {
+		t.Fatalf("expected 2 accounts, got %d", len(accounts))
+	}
+
+	if accounts[0].AccountType != "main" {
+		t.Errorf("first account type = %q, want 'main'", accounts[0].AccountType)
+	}
+	if accounts[1].AccountType != "sub_account" {
+		t.Errorf("second account type = %q, want 'sub_account'", accounts[1].AccountType)
+	}
+}
+
+func TestDiscoverAccountsNoAccounts(t *testing.T) {
+	resetMarketCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterAccountResp{
+			Code:     200,
+			Accounts: []lighterAccount{},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accounts, err := c.DiscoverAccounts(context.Background(), "0x0000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if accounts != nil {
+		t.Errorf("expected nil accounts, got %d", len(accounts))
+	}
+}
+
+func TestDiscoverAccountsNotFound(t *testing.T) {
+	resetMarketCache()
+
+	// Simulate the actual Lighter API response for unknown addresses:
+	// HTTP 200 with {"code":21100,"message":"account not found"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"code":21100,"message":"account not found"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accounts, err := c.DiscoverAccounts(context.Background(), "0xdeadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if accounts != nil {
+		t.Errorf("expected nil accounts for unknown address, got %d", len(accounts))
+	}
+}
+
+func TestPagination(t *testing.T) {
+	resetMarketCache()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
+			OrderBooks: []lighterOrderBookDetail{
+				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
+			},
+		})
+	})
+
+	callCount := 0
+	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		cursor := r.URL.Query().Get("cursor")
+		switch cursor {
+		case "":
+			// First page
+			json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
+				Code:       0,
+				NextCursor: "page2",
+				Data: []lighterTrade{
+					{TradeID: "t1", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2000", Quantity: "1", TakerFee: "0.1", MakerFee: "0.05", IsBuyerTaker: true, Timestamp: 1700000000000, BidOrderID: "o1", AskOrderID: "o2"},
+				},
+			})
+		case "page2":
+			// Second page (last)
+			json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
+				Code: 0,
+				Data: []lighterTrade{
+					{TradeID: "t2", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2001", Quantity: "2", TakerFee: "0.2", MakerFee: "0.1", IsBuyerTaker: true, Timestamp: 1700000001000, BidOrderID: "o3", AskOrderID: "o4"},
+				},
+			})
+		default:
+			t.Errorf("unexpected cursor: %s", cursor)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "5",
+	}
+
+	trades, _, err := c.FetchTrades(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(trades) != 2 {
+		t.Fatalf("expected 2 trades across 2 pages, got %d", len(trades))
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls (2 pages), got %d", callCount)
+	}
+
+	if trades[0].TradeID != "t1" || trades[1].TradeID != "t2" {
+		t.Errorf("trades not in expected order: %s, %s", trades[0].TradeID, trades[1].TradeID)
+	}
+}
+
+func TestFetchTradesSinceFilter(t *testing.T) {
+	resetMarketCache()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
+			OrderBooks: []lighterOrderBookDetail{
+				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
+			},
+		})
+	})
+
+	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
+			Code: 0,
+			Data: []lighterTrade{
+				{TradeID: "old", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2000", Quantity: "1", TakerFee: "0.1", MakerFee: "0.05", IsBuyerTaker: true, Timestamp: 1700000000000, BidOrderID: "o1", AskOrderID: "o2"},
+				{TradeID: "new", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2001", Quantity: "1", TakerFee: "0.1", MakerFee: "0.05", IsBuyerTaker: true, Timestamp: 1700000002000, BidOrderID: "o3", AskOrderID: "o4"},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "5",
+	}
+
+	since := time.UnixMilli(1700000001000)
+	trades, _, err := c.FetchTrades(context.Background(), account, since)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(trades) != 1 {
+		t.Fatalf("expected 1 trade after filtering, got %d", len(trades))
+	}
+
+	if trades[0].TradeID != "new" {
+		t.Errorf("expected trade 'new', got %s", trades[0].TradeID)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	c := NewClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	account := &models.ExchangeAccount{
+		ID:                uuid.New().String(),
+		AccountIdentifier: "0",
+	}
+
+	_, _, err := c.FetchTrades(ctx, account, time.Time{})
+	if err == nil {
+		t.Error("FetchTrades should respect context cancellation")
+	}
+
+	_, err = c.FetchFundingPayments(ctx, account, time.Time{})
+	if err == nil {
+		t.Error("FetchFundingPayments should respect context cancellation")
+	}
+
+	_, _, err = c.FetchDeposits(ctx, account, time.Time{})
+	if err == nil {
+		t.Error("FetchDeposits should respect context cancellation")
+	}
+
+	_, err = c.FetchBalances(ctx, account)
+	if err == nil {
+		t.Error("FetchBalances should respect context cancellation")
+	}
+
+	_, err = c.DiscoverAccounts(ctx, "0x1234")
+	if err == nil {
+		t.Error("DiscoverAccounts should respect context cancellation")
+	}
+}
+
+func TestCleanDecimal(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "0"},
+		{"0", "0"},
+		{"1.0000", "1"},
+		{"1.2300", "1.23"},
+		{"-", "0"},
+		{"100", "100"},
+		{"-0.50", "-0.5"},
+	}
+
+	for _, tt := range tests {
+		got := cleanDecimal(tt.input)
+		if got != tt.want {
+			t.Errorf("cleanDecimal(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/exchange/lighter/discovery.go
+++ b/exchange/lighter/discovery.go
@@ -1,0 +1,68 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/zif-terminal/lib/models"
+)
+
+// DiscoverAccounts discovers Lighter accounts for a given Ethereum L1 address.
+// Uses the public GET /api/v1/account endpoint (no auth needed).
+// Returns accounts with status "needs_token" since API key is required for data access.
+func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([]*models.DiscoverableAccount, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	if userIdentifier == "" {
+		return nil, fmt.Errorf("user identifier (Ethereum L1 address) is required")
+	}
+
+	url := fmt.Sprintf("%s/account?by=l1_address&value=%s", c.baseURL, userIdentifier)
+	body, err := c.doGet(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch account: %w", err)
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	var resp lighterAccountResp
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode account response: %w", err)
+	}
+
+	// The Lighter API returns HTTP 200 for all responses but uses an internal code field.
+	// Code 21100 means "account not found". Any non-200 code means no valid account.
+	if resp.Code != 200 || len(resp.Accounts) == 0 {
+		return nil, nil
+	}
+
+	accounts := make([]*models.DiscoverableAccount, 0, len(resp.Accounts))
+	for _, acct := range resp.Accounts {
+		name := "Main Account"
+		accountType := "main"
+		if len(resp.Accounts) > 1 {
+			name = fmt.Sprintf("Account %d", acct.AccountIndex)
+			if acct.AccountIndex > 0 {
+				accountType = "sub_account"
+			}
+		}
+
+		accounts = append(accounts, &models.DiscoverableAccount{
+			AccountIdentifier: strconv.Itoa(acct.AccountIndex),
+			AccountType:       accountType,
+			Name:              name,
+			Metadata: map[string]interface{}{
+				"l1_address":    userIdentifier,
+				"account_index": acct.AccountIndex,
+			},
+		})
+	}
+
+	return accounts, nil
+}

--- a/exchange/lighter/markets.go
+++ b/exchange/lighter/markets.go
@@ -1,0 +1,102 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// marketInfo holds resolved market metadata for a given market_id.
+type marketInfo struct {
+	Symbol     string
+	BaseAsset  string
+	QuoteAsset string
+	MarketType string // "perp" or "spot"
+}
+
+// marketCache caches market_id -> marketInfo mappings.
+// It is populated lazily on first use and shared across all Client instances.
+type marketCache struct {
+	mu      sync.RWMutex
+	markets map[int]*marketInfo
+	loaded  bool
+}
+
+var globalMarketCache = &marketCache{
+	markets: make(map[int]*marketInfo),
+}
+
+// get returns the market info for a given market_id, loading the cache if needed.
+func (mc *marketCache) get(ctx context.Context, c *Client, marketID int) (*marketInfo, error) {
+	mc.mu.RLock()
+	if mc.loaded {
+		info, ok := mc.markets[marketID]
+		mc.mu.RUnlock()
+		if ok {
+			return info, nil
+		}
+		// Market not in cache — force reload in case new markets were added
+		return mc.reload(ctx, c, marketID)
+	}
+	mc.mu.RUnlock()
+
+	return mc.reload(ctx, c, marketID)
+}
+
+// reload fetches the full market list from the API and updates the cache.
+func (mc *marketCache) reload(ctx context.Context, c *Client, marketID int) (*marketInfo, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if mc.loaded {
+		if info, ok := mc.markets[marketID]; ok {
+			return info, nil
+		}
+	}
+
+	url := c.baseURL + "/orderBookDetails"
+	body, err := c.doGet(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch order book details: %w", err)
+	}
+
+	if body == nil {
+		return nil, fmt.Errorf("no order book details returned")
+	}
+
+	var resp lighterOrderBookDetailsResp
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode order book details: %w", err)
+	}
+
+	for _, ob := range resp.OrderBooks {
+		mc.markets[ob.MarketID] = &marketInfo{
+			Symbol:     ob.Symbol,
+			BaseAsset:  ob.BaseAsset,
+			QuoteAsset: ob.QuoteAsset,
+			MarketType: ob.MarketType,
+		}
+	}
+	mc.loaded = true
+
+	info, ok := mc.markets[marketID]
+	if !ok {
+		return nil, fmt.Errorf("unknown market_id %d", marketID)
+	}
+	return info, nil
+}
+
+// resolveMarket resolves a market_id to its metadata using the global cache.
+func (c *Client) resolveMarket(ctx context.Context, marketID int) (*marketInfo, error) {
+	return globalMarketCache.get(ctx, c, marketID)
+}
+
+// resetMarketCache resets the global market cache. Used in tests.
+func resetMarketCache() {
+	globalMarketCache.mu.Lock()
+	defer globalMarketCache.mu.Unlock()
+	globalMarketCache.markets = make(map[int]*marketInfo)
+	globalMarketCache.loaded = false
+}

--- a/exchange/lighter/pagination.go
+++ b/exchange/lighter/pagination.go
@@ -1,0 +1,54 @@
+package lighter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// defaultPageLimit is the number of records per page for Lighter API requests.
+const defaultPageLimit = 100
+
+// fetchAllPages fetches all pages of a paginated Lighter API endpoint using cursor-based pagination.
+// The urlFn is called with each cursor value (empty string for the first page) and returns the full URL.
+// Returns all data items across all pages.
+func fetchAllPages[T any](ctx context.Context, c *Client, urlFn func(cursor string) string) ([]T, error) {
+	var all []T
+	cursor := ""
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		url := urlFn(cursor)
+		body, err := c.doGet(ctx, url)
+		if err != nil {
+			return nil, err
+		}
+
+		if body == nil {
+			break
+		}
+
+		var resp apiResponse[T]
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		if resp.Code != 0 {
+			return nil, fmt.Errorf("API error code %d: %s", resp.Code, resp.Message)
+		}
+
+		all = append(all, resp.Data...)
+
+		// Stop if no next cursor or no data returned
+		if resp.NextCursor == "" || len(resp.Data) == 0 {
+			break
+		}
+
+		cursor = resp.NextCursor
+	}
+
+	return all, nil
+}

--- a/exchange/lighter/ratelimit.go
+++ b/exchange/lighter/ratelimit.go
@@ -1,4 +1,4 @@
-package hyperliquid
+package lighter
 
 import (
 	"context"
@@ -6,11 +6,9 @@ import (
 	"time"
 )
 
-// Global rate limiter shared across all hyperliquid.Client instances.
-// Hyperliquid allows 1200 req/min (20 req/s). We target 5 req/s to leave ample
-// headroom — practical limits are lower than the theoretical max, especially
-// when multiple services share the same IP.
-var globalLimiter = newRateLimiter(5, 5)
+// Global rate limiter shared across all lighter.Client instances.
+// Lighter allows ~60 req/min (1 req/s). We target 1 req/s to match the limit.
+var globalLimiter = newRateLimiter(1, 2)
 
 // rateLimiter implements a token bucket rate limiter.
 type rateLimiter struct {

--- a/exchange/lighter/types.go
+++ b/exchange/lighter/types.go
@@ -1,0 +1,105 @@
+package lighter
+
+// Lighter API response types
+// Base URL: https://mainnet.zklighter.elliot.ai/api/v1
+
+// apiResponse is the generic envelope for paginated Lighter API responses.
+type apiResponse[T any] struct {
+	Code       int    `json:"code"`
+	Message    string `json:"message"`
+	NextCursor string `json:"next_cursor"`
+	Data       []T    `json:"data"`
+}
+
+// lighterTrade represents a single trade from GET /api/v1/trades
+type lighterTrade struct {
+	TradeID         string `json:"trade_id"`
+	MarketID        int    `json:"market_id"`
+	AskAccountID    int    `json:"ask_account_id"`
+	BidAccountID    int    `json:"bid_account_id"`
+	Price           string `json:"price"`
+	Quantity        string `json:"quantity"`
+	TakerFee        string `json:"taker_fee"`
+	MakerFee        string `json:"maker_fee"`
+	IsBuyerTaker    bool   `json:"is_buyer_taker"`
+	Timestamp       int64  `json:"timestamp"` // Unix milliseconds
+	AskOrderID      string `json:"ask_order_id"`
+	BidOrderID      string `json:"bid_order_id"`
+}
+
+// lighterFunding represents a funding payment from GET /api/v1/positionFunding
+type lighterFunding struct {
+	FundingID   string `json:"funding_id"`
+	AccountID   int    `json:"account_id"`
+	MarketID    int    `json:"market_id"`
+	Amount      string `json:"amount"` // Signed: negative = paid, positive = received
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// lighterDeposit represents a deposit/withdrawal from GET /api/v1/deposit/history
+type lighterDeposit struct {
+	DepositID   string `json:"deposit_id"`
+	AccountID   int    `json:"account_id"`
+	L1Address   string `json:"l1_address"`
+	AssetID     int    `json:"asset_id"`
+	Amount      string `json:"amount"` // Positive = deposit, negative = withdrawal
+	Status      string `json:"status"` // "completed", "pending", etc.
+	Timestamp   int64  `json:"timestamp"`
+	TxHash      string `json:"tx_hash"`
+}
+
+// lighterAccountResp is the response from GET /api/v1/account
+// Reuses the structure observed in portfolio_monitor/fetcher_lighter.go
+// Note: the API returns {"code":21100,"message":"account not found"} for unknown addresses
+// (HTTP 200 but non-200 code field), so callers must check the Code field.
+type lighterAccountResp struct {
+	Code     int              `json:"code"`
+	Accounts []lighterAccount `json:"accounts"`
+}
+
+// lighterAccount represents a single account within the response
+type lighterAccount struct {
+	AccountIndex    int                 `json:"account_index"`
+	L1Address       string              `json:"l1_address"`
+	Status          string              `json:"status"`
+	TotalAssetValue string              `json:"total_asset_value"`
+	Collateral      string              `json:"collateral"`
+	AvailableBalance string             `json:"available_balance"`
+	Positions       []lighterPosition   `json:"positions"`
+	Assets          []lighterAsset      `json:"assets"`
+}
+
+// lighterPosition represents an open position on the account
+type lighterPosition struct {
+	Symbol          string  `json:"symbol"`
+	MarketID        int     `json:"market_id"`
+	Position        string  `json:"position"`
+	AvgEntryPrice   string  `json:"avg_entry_price"`
+	UnrealizedPnl   string  `json:"unrealized_pnl"`
+	RealizedPnl     string  `json:"realized_pnl"`
+	LiquidationPrice *string `json:"liquidation_price"`
+	MarginMode      int     `json:"margin_mode"`
+	AllocatedMargin string  `json:"allocated_margin"`
+}
+
+// lighterAsset represents an asset balance on the account
+type lighterAsset struct {
+	Symbol        string `json:"symbol"`
+	AssetID       int    `json:"asset_id"`
+	Balance       string `json:"balance"`
+	LockedBalance string `json:"locked_balance"`
+}
+
+// lighterOrderBookDetail represents market metadata from the API
+type lighterOrderBookDetail struct {
+	MarketID   int    `json:"market_id"`
+	Symbol     string `json:"symbol"`
+	BaseAsset  string `json:"base_asset"`
+	QuoteAsset string `json:"quote_asset"`
+	MarketType string `json:"market_type"` // "perp" or "spot"
+}
+
+// lighterOrderBookDetailsResp is the response from GET /api/v1/orderBookDetails
+type lighterOrderBookDetailsResp struct {
+	OrderBooks []lighterOrderBookDetail `json:"order_books"`
+}

--- a/exchange/variational/client.go
+++ b/exchange/variational/client.go
@@ -1,0 +1,282 @@
+package variational
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/db"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+// Client implements iface.ExchangeClient for Variational (OMNI).
+// It reads from the omni_raw_events staging table rather than calling a live API.
+type Client struct {
+	dbClient db.DBClient
+}
+
+// NewClient creates a new Variational exchange client.
+func NewClient(dbClient db.DBClient) *Client {
+	return &Client{dbClient: dbClient}
+}
+
+// Name returns the exchange identifier.
+func (c *Client) Name() string {
+	return "variational"
+}
+
+// FetchTrades reads trade events from omni_raw_events and converts them to TradeInput.
+func (c *Client) FetchTrades(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TradeInput, []*models.PriceRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	accountID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var sinceMs int64
+	if !since.IsZero() {
+		sinceMs = since.UnixMilli()
+	}
+
+	events, err := c.dbClient.ListOmniRawEvents(ctx, accountID, "trade", sinceMs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	trades := make([]*models.TradeInput, 0, len(events))
+	for _, ev := range events {
+		underlying := derefString(ev.Underlying)
+		side := derefString(ev.Side)
+		price := derefString(ev.Price)
+		qty := derefString(ev.Qty)
+
+		if underlying == "" {
+			return nil, nil, fmt.Errorf("variational: trade %s missing required field underlying", ev.OmniID)
+		}
+		if side == "" {
+			return nil, nil, fmt.Errorf("variational: trade %s missing required field side", ev.OmniID)
+		}
+		if price == "" {
+			return nil, nil, fmt.Errorf("variational: trade %s missing required field price", ev.OmniID)
+		}
+		if qty == "" {
+			return nil, nil, fmt.Errorf("variational: trade %s missing required field qty", ev.OmniID)
+		}
+
+		trade := &models.TradeInput{
+			TradeID:           ev.OmniID,
+			OrderID:           ev.OmniID, // OMNI doesn't have separate order IDs
+			BaseAsset:         underlying,
+			QuoteAsset:        "USDC",
+			Side:              side,
+			Price:             price,
+			Quantity:          qty,
+			Fee:               "0",
+			FeeAsset:          "USDC",
+			MarketType:        "perp",
+			ExchangeAccountID: accountID,
+			Timestamp:         time.Unix(0, ev.TimestampMs*int64(time.Millisecond)).UTC(),
+		}
+		trades = append(trades, trade)
+	}
+
+	return trades, nil, nil
+}
+
+// FetchDeposits reads deposit, withdrawal, and fee events from omni_raw_events.
+func (c *Client) FetchDeposits(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TransferInput, []*models.PriceRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	accountID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var sinceMs int64
+	if !since.IsZero() {
+		sinceMs = since.UnixMilli()
+	}
+
+	events, err := c.dbClient.ListOmniRawEventsByTypes(ctx, accountID, []string{"deposit", "withdrawal", "fee"}, sinceMs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	transfers := make([]*models.TransferInput, 0, len(events))
+	for _, ev := range events {
+		var transferType string
+		var amount string
+		asset := "USDC"
+		if ev.Asset != nil {
+			asset = *ev.Asset
+		}
+
+		qtyStr := derefString(ev.Qty)
+
+		switch ev.EventType {
+		case "deposit":
+			transferType = models.TypeDeposit
+			amount = qtyStr
+		case "withdrawal":
+			transferType = models.TypeWithdraw
+			amount = absNumericString(qtyStr)
+		case "fee":
+			transferType = models.TypeFee
+			amount = absNumericString(qtyStr)
+		default:
+			return nil, nil, fmt.Errorf("variational: unknown event type %q for event %s", ev.EventType, ev.OmniID)
+		}
+
+		transfer := &models.TransferInput{
+			ExchangeAccountID: accountID,
+			Type:              transferType,
+			Asset:             asset,
+			Amount:            amount,
+			Timestamp:         time.Unix(0, ev.TimestampMs*int64(time.Millisecond)).UTC(),
+			ExternalID:        ev.OmniID,
+		}
+
+		// Add metadata for fee rows
+		if ev.EventType == "fee" && ev.FeeType != nil {
+			transfer.Metadata = map[string]string{
+				"fee_type":   *ev.FeeType,
+				"payment_id": ev.OmniID,
+			}
+		} else {
+			transfer.Metadata = map[string]string{
+				"payment_id": ev.OmniID,
+			}
+		}
+
+		transfers = append(transfers, transfer)
+	}
+
+	return transfers, nil, nil
+}
+
+// FetchFundingPayments reads funding events from omni_raw_events.
+func (c *Client) FetchFundingPayments(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.TransferInput, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	accountID, err := uuid.Parse(account.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var sinceMs int64
+	if !since.IsZero() {
+		sinceMs = since.UnixMilli()
+	}
+
+	events, err := c.dbClient.ListOmniRawEvents(ctx, accountID, "funding", sinceMs)
+	if err != nil {
+		return nil, err
+	}
+
+	transfers := make([]*models.TransferInput, 0, len(events))
+	for _, ev := range events {
+		underlying := derefString(ev.Underlying)
+		market := underlying + "-PERP"
+
+		metadata := map[string]string{
+			"market":     market,
+			"payment_id": ev.OmniID,
+		}
+		if ev.FundingRate != nil {
+			metadata["funding_rate"] = *ev.FundingRate
+		}
+
+		transfer := &models.TransferInput{
+			ExchangeAccountID: accountID,
+			Type:              models.TypeFunding,
+			Asset:             "USDC",
+			Amount:            derefString(ev.Qty),
+			Timestamp:         time.Unix(0, ev.TimestampMs*int64(time.Millisecond)).UTC(),
+			ExternalID:        ev.OmniID,
+			Metadata:          metadata,
+		}
+
+		transfers = append(transfers, transfer)
+	}
+
+	return transfers, nil
+}
+
+// FetchSettlements returns nil — Variational settles on close.
+func (c *Client) FetchSettlements(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+	since time.Time,
+) ([]*models.Settlement, error) {
+	return nil, nil
+}
+
+// FetchBalances returns nil — no live API for Variational.
+func (c *Client) FetchBalances(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+) ([]*models.BalanceSnapshot, error) {
+	return nil, nil
+}
+
+// FetchHistoricalBalanceSnapshots returns nil — no historical snapshots for Variational.
+func (c *Client) FetchHistoricalBalanceSnapshots(
+	ctx context.Context,
+	account *models.ExchangeAccount,
+) ([]*models.HistoricalBalanceSnapshots, error) {
+	return nil, nil
+}
+
+// DiscoverAccounts is not supported for Variational — accounts are created manually.
+func (c *Client) DiscoverAccounts(
+	ctx context.Context,
+	userIdentifier string,
+) ([]*models.DiscoverableAccount, error) {
+	return nil, iface.ErrNotImplemented
+}
+
+// derefString safely dereferences a *string, returning "" if nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// absNumericString returns the absolute value of a numeric string.
+// If the string starts with '-', the prefix is stripped.
+func absNumericString(s string) string {
+	if strings.HasPrefix(s, "-") {
+		// Parse and return absolute value to handle edge cases
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return strings.TrimPrefix(s, "-")
+		}
+		return strconv.FormatFloat(math.Abs(f), 'f', -1, 64)
+	}
+	return s
+}

--- a/exchange/variational/client_test.go
+++ b/exchange/variational/client_test.go
@@ -1,0 +1,720 @@
+package variational
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/db"
+	"github.com/zif-terminal/lib/exchange/iface"
+	"github.com/zif-terminal/lib/models"
+)
+
+// mockDBClient implements the subset of db.DBClient needed by variational.Client.
+type mockDBClient struct {
+	db.DBClient // embed to satisfy the interface; unused methods will panic
+
+	listOmniRawEventsFunc        func(ctx context.Context, accountID uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error)
+	listOmniRawEventsByTypesFunc func(ctx context.Context, accountID uuid.UUID, eventTypes []string, sinceMs int64) ([]*db.OmniRawEvent, error)
+}
+
+func (m *mockDBClient) ListOmniRawEvents(ctx context.Context, accountID uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+	if m.listOmniRawEventsFunc != nil {
+		return m.listOmniRawEventsFunc(ctx, accountID, eventType, sinceMs)
+	}
+	return nil, nil
+}
+
+func (m *mockDBClient) ListOmniRawEventsByTypes(ctx context.Context, accountID uuid.UUID, eventTypes []string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+	if m.listOmniRawEventsByTypesFunc != nil {
+		return m.listOmniRawEventsByTypesFunc(ctx, accountID, eventTypes, sinceMs)
+	}
+	return nil, nil
+}
+
+func strPtr(s string) *string { return &s }
+
+func makeTradeEvent(omniID, underlying, side, price, qty string, tsMs int64) *db.OmniRawEvent {
+	return &db.OmniRawEvent{
+		ID:                uuid.New(),
+		ExchangeAccountID: uuid.Nil,
+		OmniID:            omniID,
+		TimestampMs:       tsMs,
+		EventType:         "trade",
+		Side:              strPtr(side),
+		InstrumentType:    strPtr("perpetual_future"),
+		Underlying:        strPtr(underlying),
+		Price:             strPtr(price),
+		Qty:               strPtr(qty),
+		TradeType:         strPtr("trade"),
+		RawData:           json.RawMessage(`{}`),
+	}
+}
+
+func makeTransferEvent(omniID, eventType, qty, asset string, tsMs int64) *db.OmniRawEvent {
+	ev := &db.OmniRawEvent{
+		ID:                uuid.New(),
+		ExchangeAccountID: uuid.Nil,
+		OmniID:            omniID,
+		TimestampMs:       tsMs,
+		EventType:         eventType,
+		Asset:             strPtr(asset),
+		Qty:               strPtr(qty),
+		Status:            strPtr("confirmed"),
+		RawData:           json.RawMessage(`{}`),
+	}
+	if eventType == "fee" {
+		ev.FeeType = strPtr("deposit")
+	}
+	return ev
+}
+
+func makeFundingEvent(omniID, underlying, qty, fundingRate string, tsMs int64) *db.OmniRawEvent {
+	return &db.OmniRawEvent{
+		ID:                uuid.New(),
+		ExchangeAccountID: uuid.Nil,
+		OmniID:            omniID,
+		TimestampMs:       tsMs,
+		EventType:         "funding",
+		Asset:             strPtr("USDC"),
+		Underlying:        strPtr(underlying),
+		Qty:               strPtr(qty),
+		FundingRate:       strPtr(fundingRate),
+		RawData:           json.RawMessage(`{}`),
+	}
+}
+
+func testAccount() *models.ExchangeAccount {
+	return &models.ExchangeAccount{
+		ID: uuid.New().String(),
+		Exchange: &models.Exchange{
+			Name:           "variational",
+			DisplayName:    "Variational",
+			SettlesOnClose: true,
+		},
+	}
+}
+
+func TestName(t *testing.T) {
+	c := NewClient(&mockDBClient{})
+	if c.Name() != "variational" {
+		t.Errorf("expected 'variational', got %q", c.Name())
+	}
+}
+
+func TestFetchTrades(t *testing.T) {
+	account := testAccount()
+	accountID, _ := uuid.Parse(account.ID)
+
+	mock := &mockDBClient{
+		listOmniRawEventsFunc: func(ctx context.Context, aid uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			if aid != accountID {
+				t.Errorf("unexpected account ID: %s", aid)
+			}
+			if eventType != "trade" {
+				t.Errorf("expected event_type 'trade', got %q", eventType)
+			}
+			return []*db.OmniRawEvent{
+				makeTradeEvent("trade-1", "SUPER", "buy", "0.2053", "50000", 1735674516753),
+				makeTradeEvent("trade-2", "ANIME", "sell", "0.05", "100000", 1735674600000),
+			}, nil
+		},
+	}
+
+	c := NewClient(mock)
+	trades, prices, err := c.FetchTrades(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prices != nil {
+		t.Error("expected nil prices")
+	}
+	if len(trades) != 2 {
+		t.Fatalf("expected 2 trades, got %d", len(trades))
+	}
+
+	// Verify first trade
+	tr := trades[0]
+	if tr.TradeID != "trade-1" {
+		t.Errorf("expected TradeID 'trade-1', got %q", tr.TradeID)
+	}
+	if tr.BaseAsset != "SUPER" {
+		t.Errorf("expected BaseAsset 'SUPER', got %q", tr.BaseAsset)
+	}
+	if tr.QuoteAsset != "USDC" {
+		t.Errorf("expected QuoteAsset 'USDC', got %q", tr.QuoteAsset)
+	}
+	if tr.Side != "buy" {
+		t.Errorf("expected Side 'buy', got %q", tr.Side)
+	}
+	if tr.Price != "0.2053" {
+		t.Errorf("expected Price '0.2053', got %q", tr.Price)
+	}
+	if tr.Quantity != "50000" {
+		t.Errorf("expected Quantity '50000', got %q", tr.Quantity)
+	}
+	if tr.Fee != "0" {
+		t.Errorf("expected Fee '0', got %q", tr.Fee)
+	}
+	if tr.FeeAsset != "USDC" {
+		t.Errorf("expected FeeAsset 'USDC', got %q", tr.FeeAsset)
+	}
+	if tr.MarketType != "perp" {
+		t.Errorf("expected MarketType 'perp', got %q", tr.MarketType)
+	}
+	if tr.ExchangeAccountID != accountID {
+		t.Errorf("expected ExchangeAccountID %s, got %s", accountID, tr.ExchangeAccountID)
+	}
+}
+
+func TestFetchTrades_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := NewClient(&mockDBClient{})
+	_, _, err := c.FetchTrades(ctx, testAccount(), time.Time{})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestFetchTrades_SinceFilter(t *testing.T) {
+	account := testAccount()
+	since := time.Date(2025, 12, 31, 12, 0, 0, 0, time.UTC)
+
+	mock := &mockDBClient{
+		listOmniRawEventsFunc: func(ctx context.Context, aid uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			if sinceMs != since.UnixMilli() {
+				t.Errorf("expected sinceMs %d, got %d", since.UnixMilli(), sinceMs)
+			}
+			return nil, nil
+		},
+	}
+
+	c := NewClient(mock)
+	_, _, err := c.FetchTrades(context.Background(), account, since)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchDeposits(t *testing.T) {
+	account := testAccount()
+
+	mock := &mockDBClient{
+		listOmniRawEventsByTypesFunc: func(ctx context.Context, aid uuid.UUID, eventTypes []string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			// Verify we're querying the right event types
+			if len(eventTypes) != 3 {
+				t.Errorf("expected 3 event types, got %d", len(eventTypes))
+			}
+			return []*db.OmniRawEvent{
+				makeTransferEvent("dep-1", "deposit", "40000.00002", "USDC", 1731376912604),
+				makeTransferEvent("fee-1", "fee", "-0.1", "USDC", 1731376912604),
+				makeTransferEvent("wd-1", "withdrawal", "-5000", "USDC", 1731380000000),
+			}, nil
+		},
+	}
+
+	c := NewClient(mock)
+	transfers, prices, err := c.FetchDeposits(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prices != nil {
+		t.Error("expected nil prices")
+	}
+	if len(transfers) != 3 {
+		t.Fatalf("expected 3 transfers, got %d", len(transfers))
+	}
+
+	// Deposit
+	dep := transfers[0]
+	if dep.Type != models.TypeDeposit {
+		t.Errorf("expected type %q, got %q", models.TypeDeposit, dep.Type)
+	}
+	if dep.Amount != "40000.00002" {
+		t.Errorf("expected amount '40000.00002', got %q", dep.Amount)
+	}
+	if dep.Asset != "USDC" {
+		t.Errorf("expected asset 'USDC', got %q", dep.Asset)
+	}
+
+	// Fee (negative qty should become positive)
+	fee := transfers[1]
+	if fee.Type != models.TypeFee {
+		t.Errorf("expected type %q, got %q", models.TypeFee, fee.Type)
+	}
+	if fee.Amount != "0.1" {
+		t.Errorf("expected amount '0.1', got %q", fee.Amount)
+	}
+	if fee.Metadata["fee_type"] != "deposit" {
+		t.Errorf("expected fee_type metadata 'deposit', got %q", fee.Metadata["fee_type"])
+	}
+
+	// Withdrawal (negative qty should become positive)
+	wd := transfers[2]
+	if wd.Type != models.TypeWithdraw {
+		t.Errorf("expected type %q, got %q", models.TypeWithdraw, wd.Type)
+	}
+	if wd.Amount != "5000" {
+		t.Errorf("expected amount '5000', got %q", wd.Amount)
+	}
+}
+
+func TestFetchFundingPayments(t *testing.T) {
+	account := testAccount()
+
+	mock := &mockDBClient{
+		listOmniRawEventsFunc: func(ctx context.Context, aid uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			if eventType != "funding" {
+				t.Errorf("expected event_type 'funding', got %q", eventType)
+			}
+			return []*db.OmniRawEvent{
+				makeFundingEvent("fund-1", "SUPER", "0.87675", "0.0000125", 1735704000000),
+			}, nil
+		},
+	}
+
+	c := NewClient(mock)
+	payments, err := c.FetchFundingPayments(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(payments) != 1 {
+		t.Fatalf("expected 1 payment, got %d", len(payments))
+	}
+
+	p := payments[0]
+	if p.Type != models.TypeFunding {
+		t.Errorf("expected type %q, got %q", models.TypeFunding, p.Type)
+	}
+	if p.Asset != "USDC" {
+		t.Errorf("expected asset 'USDC', got %q", p.Asset)
+	}
+	if p.Amount != "0.87675" {
+		t.Errorf("expected amount '0.87675', got %q", p.Amount)
+	}
+	if p.Metadata["market"] != "SUPER-PERP" {
+		t.Errorf("expected market 'SUPER-PERP', got %q", p.Metadata["market"])
+	}
+	if p.Metadata["payment_id"] != "fund-1" {
+		t.Errorf("expected payment_id 'fund-1', got %q", p.Metadata["payment_id"])
+	}
+	if p.Metadata["funding_rate"] != "0.0000125" {
+		t.Errorf("expected funding_rate '0.0000125', got %q", p.Metadata["funding_rate"])
+	}
+}
+
+func TestFetchSettlements_ReturnsNil(t *testing.T) {
+	c := NewClient(&mockDBClient{})
+	settlements, err := c.FetchSettlements(context.Background(), testAccount(), time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if settlements != nil {
+		t.Error("expected nil settlements")
+	}
+}
+
+func TestFetchBalances_ReturnsNil(t *testing.T) {
+	c := NewClient(&mockDBClient{})
+	balances, err := c.FetchBalances(context.Background(), testAccount())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if balances != nil {
+		t.Error("expected nil balances")
+	}
+}
+
+func TestDiscoverAccounts_ReturnsNotImplemented(t *testing.T) {
+	c := NewClient(&mockDBClient{})
+	_, err := c.DiscoverAccounts(context.Background(), "test")
+	if !errors.Is(err, iface.ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+func TestAbsNumericString(t *testing.T) {
+	tests := []struct {
+		input, expected string
+	}{
+		{"100", "100"},
+		{"-100", "100"},
+		{"-0.1", "0.1"},
+		{"0", "0"},
+		{"-0", "0"},
+		{"123.456", "123.456"},
+		{"-123.456", "123.456"},
+	}
+
+	for _, tt := range tests {
+		result := absNumericString(tt.input)
+		if result != tt.expected {
+			t.Errorf("absNumericString(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests using real OMNI CSV data
+// ---------------------------------------------------------------------------
+
+// TestFetchTradesWithRealData uses OmniRawEvent rows that mirror the real OMNI
+// trades CSV export to verify full end-to-end mapping.
+func TestFetchTradesWithRealData(t *testing.T) {
+	account := testAccount()
+	accountID, _ := uuid.Parse(account.ID)
+
+	// Real OMNI trades data (timestamps derived from created_at):
+	// d0672381 2025-12-31T19:48:36.753006Z buy  SUPER 0.205300000000 50000
+	// 996f4f51 2025-12-30T22:53:33.682535Z buy  SUPER 0.208700000000 50000
+	// d516d4b6 2025-12-30T07:11:03.502226Z sell ANIME 0.007594000000 2000000
+	// dae6c563 2025-12-28T21:30:14.250804Z buy  TNSR  0.079390000000 50000
+	//
+	// The DB returns events ordered by timestamp_ms ASC, so:
+	// 1. dae6c563 (Dec 28)
+	// 2. d516d4b6 (Dec 30 07:11)
+	// 3. 996f4f51 (Dec 30 22:53)
+	// 4. d0672381 (Dec 31 19:48)
+
+	ts1 := time.Date(2025, 12, 28, 21, 30, 14, 250804000, time.UTC).UnixMilli()
+	ts2 := time.Date(2025, 12, 30, 7, 11, 3, 502226000, time.UTC).UnixMilli()
+	ts3 := time.Date(2025, 12, 30, 22, 53, 33, 682535000, time.UTC).UnixMilli()
+	ts4 := time.Date(2025, 12, 31, 19, 48, 36, 753006000, time.UTC).UnixMilli()
+
+	mock := &mockDBClient{
+		listOmniRawEventsFunc: func(ctx context.Context, aid uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			if aid != accountID {
+				t.Errorf("unexpected account ID: %s", aid)
+			}
+			if eventType != "trade" {
+				t.Errorf("expected event_type 'trade', got %q", eventType)
+			}
+			// Return in ascending timestamp order (as the real DB query does)
+			return []*db.OmniRawEvent{
+				makeTradeEvent("dae6c563-f008-4c98-970e-949b06d28bc5", "TNSR", "buy", "0.079390000000", "50000.000000000000", ts1),
+				makeTradeEvent("d516d4b6-58a2-4f0a-a6eb-517cfe592ee6", "ANIME", "sell", "0.007594000000", "2000000.000000000000", ts2),
+				makeTradeEvent("996f4f51-c572-4088-b9d8-358348fe9987", "SUPER", "buy", "0.208700000000", "50000.000000000000", ts3),
+				makeTradeEvent("d0672381-d7f6-453c-b887-b055b1ce0419", "SUPER", "buy", "0.205300000000", "50000.000000000000", ts4),
+			}, nil
+		},
+	}
+
+	c := NewClient(mock)
+	trades, prices, err := c.FetchTrades(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prices != nil {
+		t.Error("expected nil prices")
+	}
+	if len(trades) != 4 {
+		t.Fatalf("expected 4 trades, got %d", len(trades))
+	}
+
+	// All trades should be sorted ascending by timestamp (DB guarantees this)
+	for i := 1; i < len(trades); i++ {
+		if trades[i].Timestamp.Before(trades[i-1].Timestamp) {
+			t.Errorf("trades not sorted ascending: trade[%d] %v < trade[%d] %v",
+				i, trades[i].Timestamp, i-1, trades[i-1].Timestamp)
+		}
+	}
+
+	// Trade 0: TNSR buy (earliest)
+	tr0 := trades[0]
+	if tr0.TradeID != "dae6c563-f008-4c98-970e-949b06d28bc5" {
+		t.Errorf("trade[0] TradeID = %q, want dae6c563-...", tr0.TradeID)
+	}
+	if tr0.BaseAsset != "TNSR" {
+		t.Errorf("trade[0] BaseAsset = %q, want TNSR", tr0.BaseAsset)
+	}
+	if tr0.Side != "buy" {
+		t.Errorf("trade[0] Side = %q, want buy", tr0.Side)
+	}
+
+	// Trade 1: ANIME sell
+	tr1 := trades[1]
+	if tr1.TradeID != "d516d4b6-58a2-4f0a-a6eb-517cfe592ee6" {
+		t.Errorf("trade[1] TradeID = %q, want d516d4b6-...", tr1.TradeID)
+	}
+	if tr1.BaseAsset != "ANIME" {
+		t.Errorf("trade[1] BaseAsset = %q, want ANIME", tr1.BaseAsset)
+	}
+	if tr1.Side != "sell" {
+		t.Errorf("trade[1] Side = %q, want sell", tr1.Side)
+	}
+	if tr1.Quantity != "2000000.000000000000" {
+		t.Errorf("trade[1] Quantity = %q, want 2000000.000000000000", tr1.Quantity)
+	}
+
+	// Trade 3: SUPER buy (latest)
+	tr3 := trades[3]
+	if tr3.TradeID != "d0672381-d7f6-453c-b887-b055b1ce0419" {
+		t.Errorf("trade[3] TradeID = %q, want d0672381-...", tr3.TradeID)
+	}
+	if tr3.BaseAsset != "SUPER" {
+		t.Errorf("trade[3] BaseAsset = %q, want SUPER", tr3.BaseAsset)
+	}
+	if tr3.QuoteAsset != "USDC" {
+		t.Errorf("trade[3] QuoteAsset = %q, want USDC", tr3.QuoteAsset)
+	}
+	if tr3.Side != "buy" {
+		t.Errorf("trade[3] Side = %q, want buy", tr3.Side)
+	}
+	if tr3.Price != "0.205300000000" {
+		t.Errorf("trade[3] Price = %q, want 0.205300000000", tr3.Price)
+	}
+	if tr3.Quantity != "50000.000000000000" {
+		t.Errorf("trade[3] Quantity = %q, want 50000.000000000000", tr3.Quantity)
+	}
+	if tr3.Fee != "0" {
+		t.Errorf("trade[3] Fee = %q, want 0", tr3.Fee)
+	}
+	if tr3.MarketType != "perp" {
+		t.Errorf("trade[3] MarketType = %q, want perp", tr3.MarketType)
+	}
+}
+
+// TestFetchDepositsWithRealData uses real OMNI transfer CSV rows covering
+// deposit, withdrawal, and fee event types.
+func TestFetchDepositsWithRealData(t *testing.T) {
+	account := testAccount()
+	accountID, _ := uuid.Parse(account.ID)
+
+	// Real OMNI transfers:
+	// c2ae13c7 2025-12-01T07:42:27.968760Z  12184.850000000000 USDC deposit
+	// d106db26 2025-12-01T07:42:27.968760Z  -0.100000000000    USDC fee (deposit)
+	// 1f467f3d 2025-12-03T17:32:49.117549Z  -25000.000000000000 USDC withdrawal
+	// 5133f294 2025-12-03T17:32:49.117549Z  -0.100000000000    USDC fee (withdrawal)
+	// acbe27fc 2025-12-03T21:14:31.146533Z  -0.100000000000    USDC fee (deposit)
+
+	ts1 := time.Date(2025, 12, 1, 7, 42, 27, 968760000, time.UTC).UnixMilli()
+	ts2 := time.Date(2025, 12, 3, 17, 32, 49, 117549000, time.UTC).UnixMilli()
+	ts3 := time.Date(2025, 12, 3, 21, 14, 31, 146533000, time.UTC).UnixMilli()
+
+	depositFee := makeTransferEvent("d106db26-89e4-4376-8626-1a6d0d161ae2", "fee", "-0.100000000000", "USDC", ts1)
+	depositFee.FeeType = strPtr("deposit")
+
+	withdrawalFee := makeTransferEvent("5133f294-5243-419f-b3c8-320992e76fd8", "fee", "-0.100000000000", "USDC", ts2)
+	withdrawalFee.FeeType = strPtr("withdrawal")
+
+	depositFee2 := makeTransferEvent("acbe27fc-887f-40a1-8930-dd5171ab1413", "fee", "-0.100000000000", "USDC", ts3)
+	depositFee2.FeeType = strPtr("deposit")
+
+	mock := &mockDBClient{
+		listOmniRawEventsByTypesFunc: func(ctx context.Context, aid uuid.UUID, eventTypes []string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			if aid != accountID {
+				t.Errorf("unexpected account ID: %s", aid)
+			}
+			return []*db.OmniRawEvent{
+				makeTransferEvent("c2ae13c7-3dd9-49f2-8b48-3bc2336fb59f", "deposit", "12184.850000000000", "USDC", ts1),
+				depositFee,
+				makeTransferEvent("1f467f3d-6b3b-4181-a10d-5636bc662e24", "withdrawal", "-25000.000000000000", "USDC", ts2),
+				withdrawalFee,
+				depositFee2,
+			}, nil
+		},
+	}
+
+	c := NewClient(mock)
+	transfers, prices, err := c.FetchDeposits(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prices != nil {
+		t.Error("expected nil prices")
+	}
+	if len(transfers) != 5 {
+		t.Fatalf("expected 5 transfers, got %d", len(transfers))
+	}
+
+	// Transfer 0: Deposit — amount should be positive as-is
+	dep := transfers[0]
+	if dep.Type != models.TypeDeposit {
+		t.Errorf("transfer[0] Type = %q, want %q", dep.Type, models.TypeDeposit)
+	}
+	if dep.Asset != "USDC" {
+		t.Errorf("transfer[0] Asset = %q, want USDC", dep.Asset)
+	}
+	if dep.Amount != "12184.850000000000" {
+		t.Errorf("transfer[0] Amount = %q, want 12184.850000000000", dep.Amount)
+	}
+	if dep.Metadata["payment_id"] != "c2ae13c7-3dd9-49f2-8b48-3bc2336fb59f" {
+		t.Errorf("transfer[0] payment_id = %q, want c2ae13c7-...", dep.Metadata["payment_id"])
+	}
+
+	// Transfer 1: Fee on deposit — negative qty becomes positive
+	fee1 := transfers[1]
+	if fee1.Type != models.TypeFee {
+		t.Errorf("transfer[1] Type = %q, want %q", fee1.Type, models.TypeFee)
+	}
+	if fee1.Amount != "0.1" {
+		t.Errorf("transfer[1] Amount = %q, want 0.1", fee1.Amount)
+	}
+	if fee1.Metadata["fee_type"] != "deposit" {
+		t.Errorf("transfer[1] fee_type = %q, want deposit", fee1.Metadata["fee_type"])
+	}
+
+	// Transfer 2: Withdrawal — negative qty becomes positive
+	wd := transfers[2]
+	if wd.Type != models.TypeWithdraw {
+		t.Errorf("transfer[2] Type = %q, want %q", wd.Type, models.TypeWithdraw)
+	}
+	if wd.Amount != "25000" {
+		t.Errorf("transfer[2] Amount = %q, want 25000", wd.Amount)
+	}
+
+	// Transfer 3: Fee on withdrawal — negative qty becomes positive
+	fee2 := transfers[3]
+	if fee2.Type != models.TypeFee {
+		t.Errorf("transfer[3] Type = %q, want %q", fee2.Type, models.TypeFee)
+	}
+	if fee2.Amount != "0.1" {
+		t.Errorf("transfer[3] Amount = %q, want 0.1", fee2.Amount)
+	}
+	if fee2.Metadata["fee_type"] != "withdrawal" {
+		t.Errorf("transfer[3] fee_type = %q, want withdrawal", fee2.Metadata["fee_type"])
+	}
+}
+
+// TestFetchFundingWithRealData uses real OMNI funding CSV rows.
+func TestFetchFundingWithRealData(t *testing.T) {
+	account := testAccount()
+	accountID, _ := uuid.Parse(account.ID)
+
+	// Real OMNI funding data:
+	// 31a7c969 2026-01-01T05:00:00Z 0.876750000000 USDC funding SUPER 0.0000125
+	// 7d6df261 2026-01-01T05:00:00Z 0.195125000000 USDC funding TNSR  0.0000125
+	// dcc69971 2026-01-01T05:00:00Z 0.179573000000 USDC funding ANIME 0.00001249988584474886
+	// 893c3f91 2026-01-01T06:00:00Z 0.880250000000 USDC funding SUPER 0.0000125
+
+	ts5am := time.Date(2026, 1, 1, 5, 0, 0, 0, time.UTC).UnixMilli()
+	ts6am := time.Date(2026, 1, 1, 6, 0, 0, 0, time.UTC).UnixMilli()
+
+	mock := &mockDBClient{
+		listOmniRawEventsFunc: func(ctx context.Context, aid uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			if aid != accountID {
+				t.Errorf("unexpected account ID: %s", aid)
+			}
+			if eventType != "funding" {
+				t.Errorf("expected event_type 'funding', got %q", eventType)
+			}
+			return []*db.OmniRawEvent{
+				makeFundingEvent("31a7c969-1a96-4df2-85ba-eb85d2cfb85b", "SUPER", "0.876750000000", "0.0000125", ts5am),
+				makeFundingEvent("7d6df261-6ef5-4152-8413-a679e3b66f9b", "TNSR", "0.195125000000", "0.0000125", ts5am),
+				makeFundingEvent("dcc69971-c8e5-45cd-94eb-cf3be23a8e54", "ANIME", "0.179573000000", "0.00001249988584474886", ts5am),
+				makeFundingEvent("893c3f91-0c71-457e-97da-c4f0bcde5ddd", "SUPER", "0.880250000000", "0.0000125", ts6am),
+			}, nil
+		},
+	}
+
+	c := NewClient(mock)
+	payments, err := c.FetchFundingPayments(context.Background(), account, time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(payments) != 4 {
+		t.Fatalf("expected 4 funding payments, got %d", len(payments))
+	}
+
+	// Payment 0: SUPER funding at 05:00
+	p0 := payments[0]
+	if p0.Type != models.TypeFunding {
+		t.Errorf("payment[0] Type = %q, want %q", p0.Type, models.TypeFunding)
+	}
+	if p0.Asset != "USDC" {
+		t.Errorf("payment[0] Asset = %q, want USDC", p0.Asset)
+	}
+	if p0.Amount != "0.876750000000" {
+		t.Errorf("payment[0] Amount = %q, want 0.876750000000", p0.Amount)
+	}
+	if p0.Metadata["market"] != "SUPER-PERP" {
+		t.Errorf("payment[0] market = %q, want SUPER-PERP", p0.Metadata["market"])
+	}
+	if p0.Metadata["funding_rate"] != "0.0000125" {
+		t.Errorf("payment[0] funding_rate = %q, want 0.0000125", p0.Metadata["funding_rate"])
+	}
+	if p0.Metadata["payment_id"] != "31a7c969-1a96-4df2-85ba-eb85d2cfb85b" {
+		t.Errorf("payment[0] payment_id = %q, want 31a7c969-...", p0.Metadata["payment_id"])
+	}
+
+	// Payment 1: TNSR funding
+	p1 := payments[1]
+	if p1.Amount != "0.195125000000" {
+		t.Errorf("payment[1] Amount = %q, want 0.195125000000", p1.Amount)
+	}
+	if p1.Metadata["market"] != "TNSR-PERP" {
+		t.Errorf("payment[1] market = %q, want TNSR-PERP", p1.Metadata["market"])
+	}
+
+	// Payment 2: ANIME funding with long-precision funding rate
+	p2 := payments[2]
+	if p2.Amount != "0.179573000000" {
+		t.Errorf("payment[2] Amount = %q, want 0.179573000000", p2.Amount)
+	}
+	if p2.Metadata["market"] != "ANIME-PERP" {
+		t.Errorf("payment[2] market = %q, want ANIME-PERP", p2.Metadata["market"])
+	}
+	if p2.Metadata["funding_rate"] != "0.00001249988584474886" {
+		t.Errorf("payment[2] funding_rate = %q, want 0.00001249988584474886", p2.Metadata["funding_rate"])
+	}
+
+	// Payment 3: SUPER funding at 06:00 (different hour)
+	p3 := payments[3]
+	if p3.Amount != "0.880250000000" {
+		t.Errorf("payment[3] Amount = %q, want 0.880250000000", p3.Amount)
+	}
+	if p3.Metadata["market"] != "SUPER-PERP" {
+		t.Errorf("payment[3] market = %q, want SUPER-PERP", p3.Metadata["market"])
+	}
+	// Verify timestamps differ between 5am and 6am entries
+	if payments[0].Timestamp.Equal(payments[3].Timestamp) {
+		t.Error("payment[0] and payment[3] should have different timestamps (05:00 vs 06:00)")
+	}
+}
+
+// TestFetchTrades_DBError verifies error propagation from the DB client.
+func TestFetchTrades_DBError(t *testing.T) {
+	account := testAccount()
+	expectedErr := errors.New("db connection failed")
+
+	mock := &mockDBClient{
+		listOmniRawEventsFunc: func(ctx context.Context, aid uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			return nil, expectedErr
+		},
+	}
+
+	c := NewClient(mock)
+	_, _, err := c.FetchTrades(context.Background(), account, time.Time{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected wrapped db error, got %v", err)
+	}
+}
+
+// TestFetchTrades_EmptyResult verifies empty DB results produce empty slices.
+func TestFetchTrades_EmptyResult(t *testing.T) {
+	mock := &mockDBClient{
+		listOmniRawEventsFunc: func(ctx context.Context, aid uuid.UUID, eventType string, sinceMs int64) ([]*db.OmniRawEvent, error) {
+			return []*db.OmniRawEvent{}, nil
+		},
+	}
+
+	c := NewClient(mock)
+	trades, _, err := c.FetchTrades(context.Background(), testAccount(), time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(trades) != 0 {
+		t.Errorf("expected 0 trades, got %d", len(trades))
+	}
+}
+
+// Verify interface compliance at compile time.
+var _ iface.ExchangeClient = (*Client)(nil)

--- a/models/account.go
+++ b/models/account.go
@@ -21,6 +21,8 @@ type ExchangeAccount struct {
 	AccountTypeMetadata json.RawMessage `json:"account_type_metadata" db:"account_type_metadata"` // JSONB
 	WalletID            *string         `json:"wallet_id,omitempty" db:"wallet_id"`               // FK to wallets.id
 	Status              string          `json:"status" db:"status"`                               // "active", "needs_token", "disabled"
+	SyncEnabled         bool            `json:"sync_enabled" db:"sync_enabled"`
+	ProcessingEnabled   bool            `json:"processing_enabled" db:"processing_enabled"`
 	DetectedAt          *string         `json:"detected_at,omitempty" db:"detected_at"`           // When account was detected
 	LastSyncedAt        *string         `json:"last_synced_at,omitempty" db:"last_synced_at"`     // When account was last synced
 	Tags                []string        `json:"tags" db:"tags"`

--- a/models/account_state.go
+++ b/models/account_state.go
@@ -24,14 +24,28 @@ type FundingEntry struct {
 	Timestamp   int64     `json:"timestamp"` // Unix ms
 }
 
+// PendingFundingEntry tracks a funding event waiting for a matching perp position to open.
+// Held in-memory only; NOT persisted to the checkpoint. At the end of a processor run,
+// any remaining entries indicate a fail-loud error — funding could not be matched.
+type PendingFundingEntry struct {
+	EventID   uuid.UUID
+	Market    string
+	Amount    string
+	Timestamp int64
+}
+
 // AccountState represents the in-memory state of an account.
 // Built by processing all transactions chronologically.
 type AccountState struct {
-	Assets          map[string]*AssetState        `json:"assets"`
-	Positions       map[string]*PositionState     `json:"positions"`        // Open positions keyed by "marketType:baseAsset"
-	ClosedPositions []*PositionState              `json:"closed_positions"`
-	Trading         map[string]*TradingState      `json:"trading"`          // Keyed by quote asset (e.g., "USDC", "SOL")
-	HasSeenSnapshot bool                          `json:"has_seen_snapshot"` // True after first snapshot baseline applied
+	Assets          map[string]*AssetState    `json:"assets"`
+	Positions       map[string]*PositionState `json:"positions"` // Open positions keyed by "marketType:baseAsset"
+	ClosedPositions []*PositionState          `json:"closed_positions"`
+	Trading         map[string]*TradingState  `json:"trading"`           // Keyed by quote asset (e.g., "USDC", "SOL")
+	HasSeenSnapshot bool                      `json:"has_seen_snapshot"` // True after first snapshot baseline applied
+	// PendingFunding is an in-memory buffer for funding events whose matching perp position
+	// has not yet been opened. Flushed when the matching position opens. Not JSON-serialized —
+	// the processor fails loudly at the end of the run if this buffer is non-empty.
+	PendingFunding []PendingFundingEntry `json:"-"`
 }
 
 // AssetState tracks the state of a single asset (USDC, SOL, etc.)
@@ -45,20 +59,26 @@ type AssetState struct {
 
 // PositionState tracks in-memory position state (perp or spot), open or closed.
 // A position is closed when EndTime > 0.
+//
+// The EventEntries slice is the immutable history of ENTRY events (deposits,
+// buys on the current side, interest credits, etc.) for the position. It is
+// never shrunk by FIFO consumption — instead, the running "available for
+// matching" quantity is computed as (sum(EventEntries) - sum(ExitEntries)),
+// which equals the Quantity field. ExitEntries is the immutable history of
+// EXIT events (withdrawals, opposite-side trades, fees) that have been
+// matched against the entries via FIFO. Both slices are written to the DB
+// as position_events rows (direction=entry vs direction=exit).
 type PositionState struct {
 	Market             string         `json:"market"`              // e.g., "SOL" or "SOL-PERP"
 	MarketType         string         `json:"market_type"`         // "perp" or "spot"
 	Side               string         `json:"side"`                // "long" or "short"
 	Quantity           string         `json:"quantity"`            // Current position size (0 when closed)
-	TotalFees          string         `json:"total_fees"`          // Accumulated fees
-	CumulativeFunding  string         `json:"cumulative_funding"`  // Funding paid/received for this position
 	ContributingTrades []string       `json:"contributing_trades"` // Exchange trade IDs
-	EventEntries       []EventEntry   `json:"event_entries"`       // Per-event qty for FIFO allocation
+	EventEntries       []EventEntry   `json:"event_entries"`       // Immutable history of entry events
+	ExitEntries        []EventEntry   `json:"exit_entries,omitempty"` // Immutable history of exit events
 	FundingEntries     []FundingEntry `json:"funding_entries"`     // Individual funding payments
 	StartTime          int64          `json:"start_time"`          // Unix ms
 	EndTime            int64          `json:"end_time,omitempty"`  // Unix ms, 0 = still open
-	ExitEventID        uuid.UUID      `json:"exit_event_id,omitempty"`    // DB UUID of closing event
-	ExitEventType      string         `json:"exit_event_type,omitempty"`  // "trade", "interest", "transfer", etc.
 }
 
 // IsClosed returns true if the position has been fully closed

--- a/models/exchange.go
+++ b/models/exchange.go
@@ -3,9 +3,10 @@ package models
 // Exchange represents a supported exchange in the database
 // Matches the 'exchanges' table schema
 type Exchange struct {
-	ID          string `json:"id" db:"id"`
-	Name        string `json:"name" db:"name"`
-	DisplayName string `json:"display_name" db:"display_name"`
+	ID             string `json:"id" db:"id"`
+	Name           string `json:"name" db:"name"`
+	DisplayName    string `json:"display_name" db:"display_name"`
+	SettlesOnClose bool   `json:"settles_on_close" db:"settles_on_close"`
 }
 
 // ExchangeInput is used for GraphQL mutations

--- a/models/position_pnl.go
+++ b/models/position_pnl.go
@@ -6,7 +6,11 @@ import "github.com/google/uuid"
 type PositionPnLInput struct {
 	PositionID   uuid.UUID `json:"position_id"`
 	Denomination string    `json:"denomination"`
-	RealizedPnL  string    `json:"realized_pnl"` // NUMERIC(36,18) as string
+	RealizedPnL  string    `json:"realized_pnl"`  // NUMERIC(36,18) as string
+	TradePnL     string    `json:"trade_pnl"`      // NUMERIC(36,18) as string
+	FundingPnL   string    `json:"funding_pnl"`    // NUMERIC(36,18) as string
+	FeePnL       string    `json:"fee_pnl"`        // NUMERIC(36,18) as string
+	InterestPnL  string    `json:"interest_pnl"`   // NUMERIC(36,18) as string
 }
 
 // MissingPositionPnL represents a closed position that does not yet have

--- a/models/price.go
+++ b/models/price.go
@@ -36,11 +36,13 @@ type Price struct {
 	Source       string `json:"source"`
 }
 
-// UnmarshalJSON handles Hasura returning NUMERIC fields as JSON numbers.
+// UnmarshalJSON handles Hasura returning NUMERIC fields as JSON numbers
+// and BIGINT fields as strings (when HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES=true).
 func (p *Price) UnmarshalJSON(data []byte) error {
 	type Alias Price
 	aux := &struct {
-		Price interface{} `json:"price"`
+		Price     interface{} `json:"price"`
+		Timestamp interface{} `json:"timestamp"`
 		*Alias
 	}{
 		Alias: (*Alias)(p),
@@ -59,6 +61,10 @@ func (p *Price) UnmarshalJSON(data []byte) error {
 		default:
 			p.Price = fmt.Sprintf("%v", val)
 		}
+	}
+
+	if aux.Timestamp != nil {
+		p.Timestamp = parseIntField(aux.Timestamp)
 	}
 
 	return nil

--- a/models/settlement.go
+++ b/models/settlement.go
@@ -19,6 +19,7 @@ type Settlement struct {
 	Market            string    `json:"market"`        // Perp market that triggered settlement (e.g., "SOL-PERP")
 	Timestamp         time.Time `json:"timestamp"`
 	SettlementID      string    `json:"settlement_id"` // Unique identifier
+	ExternalID        string    `json:"external_id"`   // Native exchange ID for dedup (backfilled from settlement_id)
 }
 
 // UnmarshalJSON custom unmarshaler to handle BIGINT timestamp and NUMERIC amount
@@ -69,6 +70,7 @@ type SettlementInput struct {
 	Market            string    `json:"market"`
 	Timestamp         time.Time `json:"timestamp"`
 	SettlementID      string    `json:"settlement_id"`
+	ExternalID        string    `json:"external_id"` // Native exchange ID for dedup (defaults to settlement_id)
 }
 
 // SettlementFilter represents filtering options for listing settlements

--- a/models/snapshot.go
+++ b/models/snapshot.go
@@ -1,10 +1,13 @@
 package models
 
-// BalanceSnapshot represents a current spot balance
+// BalanceSnapshot represents a spot balance at a point in time.
+// Balance is a decimal string (parsed as big.Rat by consumers) so that
+// precision-sensitive math — e.g., the activity processor's interest
+// derivation — doesn't go through float64.
 type BalanceSnapshot struct {
-	Asset       string  `json:"asset"`
-	Balance     float64 `json:"balance"`
-	TimestampMs int64   `json:"timestamp_ms"` // Unix milliseconds of the snapshot
+	Asset       string `json:"asset"`
+	Balance     string `json:"balance"`
+	TimestampMs int64  `json:"timestamp_ms"` // Unix milliseconds of the snapshot
 }
 
 // HistoricalBalanceSnapshots represents a set of balance snapshots at a single timestamp.

--- a/models/trade.go
+++ b/models/trade.go
@@ -24,6 +24,8 @@ type Trade struct {
 	TradeID           string    `json:"trade_id"`
 	ExchangeAccountID uuid.UUID `json:"exchange_account_id"`
 	MarketType        string    `json:"market_type"` // "perp" or "spot"
+	TxSignature       string    `json:"tx_signature,omitempty"`
+	FeeAsset          string    `json:"fee_asset"`
 }
 
 // UnmarshalJSON custom unmarshaler to handle BIGINT timestamp (Unix milliseconds) and NUMERIC as numbers
@@ -175,6 +177,8 @@ type TradeInput struct {
 	TradeID           string    `json:"trade_id"`
 	ExchangeAccountID uuid.UUID `json:"exchange_account_id"`
 	MarketType        string    `json:"market_type"` // "perp" or "spot"
+	TxSignature       string    `json:"tx_signature,omitempty"`
+	FeeAsset          string    `json:"fee_asset"`
 }
 
 // TradeFilter represents filtering options for listing trades

--- a/models/transfer.go
+++ b/models/transfer.go
@@ -17,6 +17,7 @@ const (
 	TypeInterest  = "interest"
 	TypeReward    = "reward"
 	TypeFunding   = "funding"
+	TypeFee       = "fee"
 )
 
 // Transfer represents a unified transfer event (deposit, withdrawal, interest, etc.)
@@ -28,6 +29,7 @@ type Transfer struct {
 	Asset             string    `json:"asset"`
 	Amount            string    `json:"amount"` // Always positive; direction determined by Type
 	Timestamp         time.Time `json:"timestamp"`
+	ExternalID        string    `json:"external_id,omitempty"` // Native exchange ID for dedup (e.g., payment_id, tx hash)
 	Metadata          map[string]string `json:"metadata,omitempty"`  // Extensible metadata (e.g., market, payment_id for funding)
 }
 
@@ -43,6 +45,7 @@ type TransferInput struct {
 	Asset             string    `json:"asset"`
 	Amount            string    `json:"amount"`
 	Timestamp         time.Time `json:"timestamp"`
+	ExternalID        string    `json:"external_id,omitempty"` // Native exchange ID for dedup
 	Metadata          map[string]string `json:"metadata,omitempty"`
 }
 

--- a/models/unmarshal_test.go
+++ b/models/unmarshal_test.go
@@ -63,6 +63,24 @@ func TestPrice_UnmarshalJSON_WholeNumber(t *testing.T) {
 	}
 }
 
+func TestPrice_UnmarshalJSON_TimestampAsString(t *testing.T) {
+	// HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES=true causes bigint to come back as a string
+	data := `{"asset":"mSOL","denomination":"USDC","timestamp":"1700000000000","price":"150.25","source":"drift"}`
+	var p Price
+	if err := json.Unmarshal([]byte(data), &p); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if p.Timestamp != 1700000000000 {
+		t.Errorf("Expected timestamp 1700000000000, got %d", p.Timestamp)
+	}
+	if p.Price != "150.25" {
+		t.Errorf("Expected price '150.25', got '%s'", p.Price)
+	}
+	if p.Asset != "mSOL" {
+		t.Errorf("Expected asset mSOL, got %s", p.Asset)
+	}
+}
+
 func TestPositionEvent_UnmarshalJSON_QuantityAsFloat(t *testing.T) {
 	data := `{
 		"id": "00000000-0000-0000-0000-000000000001",


### PR DESCRIPTION
## Summary
- Drift: fillRecordId dedup key includes BaseAsset+MarketType, skip sequential 400s on historical fetch, remove cycle timeout
- HL: userFillsByTime for correct startTime, new ledger type handlers (vaultleadercommission, etc.), @N spot detection
- DB: AccountListFilter with sync/processing toggle fields, STRINGIFY_NUMERIC_TYPES price cache handling

## Test plan
- [x] All Go tests pass (pre-push hook verified)
- [x] Running locally with full stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)