### PR TITLE
feat: HL pagination & interest, Lighter API refactor, DB resets

### DIFF
--- a/db/accounts.go
+++ b/db/accounts.go
@@ -18,9 +18,21 @@ type ExchangeAccountInput = models.ExchangeAccountInput
 // AccountListFilter controls which accounts ListAccounts returns.
 // Nil fields mean "don't filter on this flag". When both are nil, all
 // accounts are returned.
+//
+// OrSyncResetRequested / OrProcessorResetRequested widen the query with
+// an _or clause so that accounts with a pending reset are also returned
+// even when the corresponding enabled flag is false. Example: setting
+// SyncEnabled=true + OrSyncResetRequested=true produces:
+//
+//	_or: [{sync_enabled: {_eq: true}}, {sync_reset_requested: {_eq: true}}]
 type AccountListFilter struct {
 	SyncEnabled       *bool
 	ProcessingEnabled *bool
+
+	// When true, adds an _or branch for sync_reset_requested = true.
+	OrSyncResetRequested *bool
+	// When true, adds an _or branch for processor_reset_requested = true.
+	OrProcessorResetRequested *bool
 }
 
 // GetAccount retrieves a single exchange account by ID
@@ -70,11 +82,36 @@ func (c *Client) GetAccount(ctx context.Context, id string) (*ExchangeAccount, e
 // Pass AccountListFilter{} to get all accounts.
 func (c *Client) ListAccounts(ctx context.Context, f AccountListFilter) ([]*ExchangeAccount, error) {
 	where := map[string]interface{}{}
-	if f.SyncEnabled != nil {
+
+	// Build _or branches when a reset flag should widen the result set.
+	// e.g. SyncEnabled=true + OrSyncResetRequested=true →
+	//   _or: [{sync_enabled: {_eq: true}}, {sync_reset_requested: {_eq: true}}]
+	var orBranches []map[string]interface{}
+
+	if f.SyncEnabled != nil && f.OrSyncResetRequested != nil && *f.OrSyncResetRequested {
+		orBranches = append(orBranches,
+			map[string]interface{}{"sync_enabled": map[string]interface{}{"_eq": *f.SyncEnabled}},
+			map[string]interface{}{"sync_reset_requested": map[string]interface{}{"_eq": true}},
+		)
+	} else if f.SyncEnabled != nil {
 		where["sync_enabled"] = map[string]interface{}{"_eq": *f.SyncEnabled}
+	} else if f.OrSyncResetRequested != nil && *f.OrSyncResetRequested {
+		where["sync_reset_requested"] = map[string]interface{}{"_eq": true}
 	}
-	if f.ProcessingEnabled != nil {
+
+	if f.ProcessingEnabled != nil && f.OrProcessorResetRequested != nil && *f.OrProcessorResetRequested {
+		orBranches = append(orBranches,
+			map[string]interface{}{"processing_enabled": map[string]interface{}{"_eq": *f.ProcessingEnabled}},
+			map[string]interface{}{"processor_reset_requested": map[string]interface{}{"_eq": true}},
+		)
+	} else if f.ProcessingEnabled != nil {
 		where["processing_enabled"] = map[string]interface{}{"_eq": *f.ProcessingEnabled}
+	} else if f.OrProcessorResetRequested != nil && *f.OrProcessorResetRequested {
+		where["processor_reset_requested"] = map[string]interface{}{"_eq": true}
+	}
+
+	if len(orBranches) > 0 {
+		where["_or"] = orBranches
 	}
 
 	query := `

--- a/exchange/hyperliquid/client.go
+++ b/exchange/hyperliquid/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 	"net/http"
 	"sort"
 	"strconv"
@@ -268,6 +269,19 @@ func (c *Client) FetchDeposits(
 		}
 	}
 
+	// Fetch borrow/lend interest
+	bliEntries, err := c.fetchAllBorrowLendInterest(ctx, user, since)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch borrow/lend interest: %w", err)
+	}
+
+	for _, entry := range bliEntries {
+		transfer := transformBorrowLendInterest(entry, accountUUID)
+		if transfer != nil {
+			transfers = append(transfers, transfer)
+		}
+	}
+
 	// Sort by timestamp ascending
 	sort.Slice(transfers, func(i, j int) bool {
 		return transfers[i].Timestamp.Before(transfers[j].Timestamp)
@@ -313,21 +327,40 @@ func (c *Client) FetchBalances(
 	nowMs := time.Now().UnixMilli()
 	var balances []*models.BalanceSnapshot
 
-	// Add USDC balance from perp account value
-	accountValue, err := strconv.ParseFloat(perpState.MarginSummary.AccountValue, 64)
+	// Combine perp USDC (totalRawUsd) and spot USDC into a single snapshot.
+	// Use totalRawUsd (NOT accountValue) — accountValue includes unrealized PnL
+	// from open positions, which would cause phantom balance changes every time
+	// the market moves.
+	perpUSDC, err := strconv.ParseFloat(perpState.MarginSummary.TotalRawUsd, 64)
 	if err != nil {
-		return nil, fmt.Errorf("hyperliquid: failed to parse perp account value %q: %w", perpState.MarginSummary.AccountValue, err)
+		return nil, fmt.Errorf("hyperliquid: failed to parse perp totalRawUsd %q: %w", perpState.MarginSummary.TotalRawUsd, err)
 	}
-	if math.Abs(accountValue) > 0.000001 {
+
+	spotUSDC := 0.0
+	for _, b := range spotState.Balances {
+		if b.Coin == "USDC" {
+			spotUSDC, err = strconv.ParseFloat(b.Total, 64)
+			if err != nil {
+				return nil, fmt.Errorf("hyperliquid: failed to parse spot USDC balance %q: %w", b.Total, err)
+			}
+			break
+		}
+	}
+
+	totalUSDC := perpUSDC + spotUSDC
+	if math.Abs(totalUSDC) > 0.000001 {
 		balances = append(balances, &models.BalanceSnapshot{
 			Asset:       "USDC",
-			Balance:     perpState.MarginSummary.AccountValue,
+			Balance:     cleanDecimal(strconv.FormatFloat(totalUSDC, 'f', -1, 64)),
 			TimestampMs: nowMs,
 		})
 	}
 
-	// Add spot balances
+	// Add non-USDC spot balances
 	for _, b := range spotState.Balances {
+		if b.Coin == "USDC" {
+			continue // already combined above
+		}
 		total, err := strconv.ParseFloat(b.Total, 64)
 		if err != nil {
 			return nil, fmt.Errorf("hyperliquid: failed to parse spot balance %q for coin %s: %w", b.Total, b.Coin, err)
@@ -568,6 +601,17 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		asset = "USDC"
 		amountStr = entry.Delta.Usdc
 
+	case "cstakingtransfer":
+		// HyperStake consensus staking. Staking locks tokens out of the trading
+		// balance; unstaking returns them. Direction is indicated by isDeposit.
+		if entry.Delta.IsDeposit {
+			transferType = models.TypeWithdraw
+		} else {
+			transferType = models.TypeDeposit
+		}
+		asset = entry.Delta.Token
+		amountStr = entry.Delta.Amount
+
 	case "accountclasstransfer":
 		// Internal rebalance between the user's own spot and perp sub-accounts.
 		// This is NOT a cashflow — the wallet's total USDC position is unchanged,
@@ -575,8 +619,9 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		return nil, nil, nil
 
 	case "vaultwithdraw":
-		// Skip until we understand the full vault withdrawal flow
-		return nil, nil, nil
+		transferType = models.TypeDeposit
+		asset = "USDC"
+		amountStr = entry.Delta.NetWithdrawnUsd
 
 	case "vaultleadercommission":
 		transferType = models.TypeReward
@@ -589,6 +634,10 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		amountStr = entry.Delta.Usdc
 
 	case "send":
+		// Skip self-sends (spot<->perp within same wallet)
+		if strings.EqualFold(entry.Delta.User, walletAddress) && strings.EqualFold(entry.Delta.Destination, walletAddress) {
+			return nil, nil, nil
+		}
 		if strings.EqualFold(entry.Delta.Destination, walletAddress) {
 			transferType = models.TypeDeposit
 		} else {
@@ -597,6 +646,21 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		if entry.Delta.Token != "" {
 			asset = entry.Delta.Token
 			amountStr = entry.Delta.Amount
+			// Derive price from usdcValue / amount when available (same as spotTransfer)
+			if asset != "USDC" && entry.Delta.UsdcValue != "" && entry.Delta.UsdcValue != "0" {
+				usdcVal, uErr := strconv.ParseFloat(entry.Delta.UsdcValue, 64)
+				amt, aErr := strconv.ParseFloat(entry.Delta.Amount, 64)
+				if uErr == nil && aErr == nil && amt != 0 {
+					price := math.Abs(usdcVal / amt)
+					priceRecord = &models.PriceRecord{
+						Asset:        entry.Delta.Token,
+						Denomination: "USDC",
+						Timestamp:    time.UnixMilli(entry.Time).UTC(),
+						Price:        cleanDecimal(strconv.FormatFloat(price, 'f', -1, 64)),
+						Source:       "ledger",
+					}
+				}
+			}
 		} else {
 			asset = "USDC"
 			amountStr = entry.Delta.Usdc
@@ -616,18 +680,88 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		amount = amount[1:]
 	}
 
+	// Some ledger entries share the same hash (e.g. vaultWithdraw and
+	// vaultLeaderCommission for the same vault withdrawal). Disambiguate
+	// by appending the delta type for types that are known to collide.
+	externalID := entry.Hash
+	if deltaType == "vaultwithdraw" {
+		externalID = entry.Hash + "_" + deltaType
+	}
+
+	metadata := map[string]string{
+		"payment_id":  entry.Hash,
+		"source_type": deltaType,
+	}
+
+	// Add vault address to metadata for vault-related entries
+	if entry.Delta.Vault != "" {
+		switch deltaType {
+		case "vaultcreate", "vaultdeposit", "vaultwithdraw", "vaultdistribution", "vaultleadercommission":
+			metadata["vault_address"] = entry.Delta.Vault
+		}
+	}
+
 	return &models.TransferInput{
 		ExchangeAccountID: accountUUID,
 		Type:              transferType,
 		Asset:             asset,
 		Amount:            amount,
 		Timestamp:         time.UnixMilli(entry.Time).UTC(),
-		ExternalID:        entry.Hash,
-		Metadata: map[string]string{
-			"payment_id":  entry.Hash,
-			"source_type": deltaType,
-		},
+		ExternalID:        externalID,
+		Metadata:          metadata,
 	}, priceRecord, nil
+}
+
+// transformBorrowLendInterest converts a Hyperliquid borrow/lend interest entry to a TransferInput.
+// Net interest = supply - borrow. Positive = earned, negative = paid. Zero net is skipped.
+// Uses math/big.Rat for exact decimal arithmetic.
+func transformBorrowLendInterest(entry hlBorrowLendInterest, accountUUID uuid.UUID) *models.TransferInput {
+	supply := new(big.Rat)
+	if _, ok := supply.SetString(entry.Supply); !ok {
+		supply.SetInt64(0)
+	}
+
+	borrow := new(big.Rat)
+	if _, ok := borrow.SetString(entry.Borrow); !ok {
+		borrow.SetInt64(0)
+	}
+
+	// net = supply - borrow
+	net := new(big.Rat).Sub(supply, borrow)
+
+	if net.Sign() == 0 {
+		return nil
+	}
+
+	// Format the net amount as a decimal string
+	amount := net.FloatString(18)
+	amount = cleanDecimal(amount)
+
+	// Make amount positive — direction is determined by type
+	if strings.HasPrefix(amount, "-") {
+		amount = amount[1:]
+	}
+
+	// If after cleaning the amount is zero or dust, skip
+	if amount == "0" {
+		return nil
+	}
+
+	externalID := fmt.Sprintf("bli_%s_%d", entry.Token, entry.Time)
+
+	return &models.TransferInput{
+		ExchangeAccountID: accountUUID,
+		Type:              models.TypeInterest,
+		Asset:             entry.Token,
+		Amount:            amount,
+		Timestamp:         time.UnixMilli(entry.Time).UTC(),
+		ExternalID:        externalID,
+		Metadata: map[string]string{
+			"source_type": "borrow_lend_interest",
+			"borrow":      entry.Borrow,
+			"supply":      entry.Supply,
+		},
+	}
 }
 
 // cleanDecimal cleans a decimal string: trims trailing zeros and dots.

--- a/exchange/hyperliquid/client_test.go
+++ b/exchange/hyperliquid/client_test.go
@@ -543,21 +543,36 @@ func TestTransformLedgerEntry(t *testing.T) {
 		}
 	})
 
-	t.Run("vaultWithdraw skipped", func(t *testing.T) {
+	t.Run("vaultWithdraw as deposit", func(t *testing.T) {
 		entry := hlLedgerEntry{
 			Time: 1700000000000,
 			Hash: "0xvaultwithdraw",
 			Delta: hlLedgerDelta{
-				Type: "vaultWithdraw",
-				Usdc: "500.00",
+				Type:            "vaultWithdraw",
+				NetWithdrawnUsd: "5229.047513",
 			},
 		}
 		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if transfer != nil {
-			t.Error("expected nil transfer for vaultWithdraw")
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer for vaultWithdraw")
+		}
+		if transfer.Type != models.TypeDeposit {
+			t.Errorf("expected type %q, got %q", models.TypeDeposit, transfer.Type)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("expected asset USDC, got %q", transfer.Asset)
+		}
+		if transfer.Amount != "5229.047513" {
+			t.Errorf("expected amount 5229.047513, got %q", transfer.Amount)
+		}
+		if transfer.Metadata["source_type"] != "vaultwithdraw" {
+			t.Errorf("expected source_type vaultwithdraw, got %q", transfer.Metadata["source_type"])
+		}
+		if transfer.ExternalID != "0xvaultwithdraw_vaultwithdraw" {
+			t.Errorf("expected disambiguated external_id, got %q", transfer.ExternalID)
 		}
 	})
 
@@ -981,8 +996,19 @@ func TestFetchDepositsWithMockServer(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(entries)
+
+		reqType := body["type"].(string)
+		switch reqType {
+		case "userNonFundingLedgerUpdates":
+			json.NewEncoder(w).Encode(entries)
+		case "userBorrowLendInterest":
+			json.NewEncoder(w).Encode([]hlBorrowLendInterest{})
+		default:
+			json.NewEncoder(w).Encode([]interface{}{})
+		}
 	}))
 	defer server.Close()
 
@@ -1054,12 +1080,18 @@ func TestDiscoverAccountsWithMockServer(t *testing.T) {
 			json.NewEncoder(w).Encode(hlClearinghouseState{
 				MarginSummary: struct {
 					AccountValue string `json:"accountValue"`
+					TotalRawUsd  string `json:"totalRawUsd"`
 				}{
-					AccountValue: "5000.50",
+					AccountValue: "5500.50",
+					TotalRawUsd:  "5000.50",
 				},
 			})
 		case "spotClearinghouseState":
 			json.NewEncoder(w).Encode(hlSpotClearinghouseState{})
+		case "subAccounts":
+			w.Write([]byte("null"))
+		case "userVaultEquities":
+			w.Write([]byte("null"))
 		}
 	}))
 	defer server.Close()
@@ -1103,12 +1135,16 @@ func TestDiscoverAccountsNoActivityWithMockServer(t *testing.T) {
 			json.NewEncoder(w).Encode(hlClearinghouseState{
 				MarginSummary: struct {
 					AccountValue string `json:"accountValue"`
+					TotalRawUsd  string `json:"totalRawUsd"`
 				}{
 					AccountValue: "0.00",
+					TotalRawUsd:  "0.00",
 				},
 			})
 		case "spotClearinghouseState":
 			json.NewEncoder(w).Encode(hlSpotClearinghouseState{})
+		case "userNonFundingLedgerUpdates":
+			json.NewEncoder(w).Encode([]interface{}{})
 		}
 	}))
 	defer server.Close()
@@ -1128,6 +1164,71 @@ func TestDiscoverAccountsNoActivityWithMockServer(t *testing.T) {
 	}
 }
 
+func TestDiscoverAccountsViaLedgerHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+
+		reqType := body["type"].(string)
+		switch reqType {
+		case "clearinghouseState":
+			// Zero balance — wallet has withdrawn everything
+			json.NewEncoder(w).Encode(hlClearinghouseState{
+				MarginSummary: struct {
+					AccountValue string `json:"accountValue"`
+					TotalRawUsd  string `json:"totalRawUsd"`
+				}{
+					AccountValue: "0.00",
+					TotalRawUsd:  "0.00",
+				},
+			})
+		case "spotClearinghouseState":
+			json.NewEncoder(w).Encode(hlSpotClearinghouseState{})
+		case "userNonFundingLedgerUpdates":
+			// Has historical activity — deposited, traded, then withdrew
+			json.NewEncoder(w).Encode([]interface{}{
+				map[string]interface{}{
+					"time": 1700000000000,
+					"hash": "0xabc",
+					"delta": map[string]interface{}{
+						"type": "deposit",
+						"usdc": "1000.00",
+					},
+				},
+			})
+		case "subAccounts":
+			w.Write([]byte("null"))
+		case "userVaultEquities":
+			w.Write([]byte("null"))
+		}
+	}))
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	wallet := "0x83C362925a1821FCdB1d250Fef0b2dBab2098e98"
+	accounts, err := c.DiscoverAccounts(context.Background(), wallet)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account for wallet with historical activity, got %d", len(accounts))
+	}
+
+	acc := accounts[0]
+	if acc.AccountIdentifier != wallet {
+		t.Errorf("AccountIdentifier = %q, want %q", acc.AccountIdentifier, wallet)
+	}
+	if acc.AccountType != "main" {
+		t.Errorf("AccountType = %q, want main", acc.AccountType)
+	}
+}
+
 func TestFetchBalancesWithMockServer(t *testing.T) {
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1141,8 +1242,10 @@ func TestFetchBalancesWithMockServer(t *testing.T) {
 			json.NewEncoder(w).Encode(hlClearinghouseState{
 				MarginSummary: struct {
 					AccountValue string `json:"accountValue"`
+					TotalRawUsd  string `json:"totalRawUsd"`
 				}{
-					AccountValue: "5000.50",
+					AccountValue: "5500.50", // includes unrealized PnL — should NOT be used
+					TotalRawUsd:  "5000.50", // raw USDC margin — this is what we want
 				},
 			})
 		case "spotClearinghouseState":
@@ -1152,6 +1255,7 @@ func TestFetchBalancesWithMockServer(t *testing.T) {
 					Total string `json:"total"`
 					Hold  string `json:"hold"`
 				}{
+					{Coin: "USDC", Total: "200.25", Hold: "0"},
 					{Coin: "ETH", Total: "1.5", Hold: "0"},
 				},
 			})
@@ -1193,8 +1297,9 @@ func TestFetchBalancesWithMockServer(t *testing.T) {
 	if usdcBalance == nil {
 		t.Fatal("expected USDC balance")
 	}
-	if usdcBalance.Balance != "5000.50" {
-		t.Errorf("USDC balance = %s, want 5000.50", usdcBalance.Balance)
+	// Combined: perp totalRawUsd (5000.50) + spot USDC (200.25) = 5200.75
+	if usdcBalance.Balance != "5200.75" {
+		t.Errorf("USDC balance = %s, want 5200.75 (perp 5000.50 + spot 200.25)", usdcBalance.Balance)
 	}
 
 	if ethBalance == nil {
@@ -1938,6 +2043,242 @@ func TestTransformLedgerEntrySpotTransferWithoutUsdcValue(t *testing.T) {
 	}
 }
 
+func TestTransformBorrowLendInterest(t *testing.T) {
+	accountUUID := uuid.New()
+
+	t.Run("net positive (supply > borrow)", func(t *testing.T) {
+		entry := hlBorrowLendInterest{
+			Time:   1700000000000,
+			Token:  "USDC",
+			Borrow: "0.0",
+			Supply: "0.03754258",
+		}
+		transfer := transformBorrowLendInterest(entry, accountUUID)
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeInterest {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeInterest)
+		}
+		if transfer.Asset != "USDC" {
+			t.Errorf("Asset = %q, want USDC", transfer.Asset)
+		}
+		if transfer.Amount != "0.03754258" {
+			t.Errorf("Amount = %q, want 0.03754258", transfer.Amount)
+		}
+		if transfer.ExternalID != "bli_USDC_1700000000000" {
+			t.Errorf("ExternalID = %q, want bli_USDC_1700000000000", transfer.ExternalID)
+		}
+		if transfer.Metadata["source_type"] != "borrow_lend_interest" {
+			t.Errorf("source_type = %q, want borrow_lend_interest", transfer.Metadata["source_type"])
+		}
+		if transfer.Metadata["borrow"] != "0.0" {
+			t.Errorf("borrow metadata = %q, want 0.0", transfer.Metadata["borrow"])
+		}
+		if transfer.Metadata["supply"] != "0.03754258" {
+			t.Errorf("supply metadata = %q, want 0.03754258", transfer.Metadata["supply"])
+		}
+		if transfer.ExchangeAccountID != accountUUID {
+			t.Errorf("ExchangeAccountID = %v, want %v", transfer.ExchangeAccountID, accountUUID)
+		}
+	})
+
+	t.Run("net negative (borrow > supply)", func(t *testing.T) {
+		entry := hlBorrowLendInterest{
+			Time:   1700000000000,
+			Token:  "HYPE",
+			Borrow: "0.5",
+			Supply: "0.1",
+		}
+		transfer := transformBorrowLendInterest(entry, accountUUID)
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Type != models.TypeInterest {
+			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeInterest)
+		}
+		if transfer.Asset != "HYPE" {
+			t.Errorf("Asset = %q, want HYPE", transfer.Asset)
+		}
+		// Amount should be positive (0.4), direction is from Type
+		if transfer.Amount != "0.4" {
+			t.Errorf("Amount = %q, want 0.4", transfer.Amount)
+		}
+	})
+
+	t.Run("net zero skipped", func(t *testing.T) {
+		entry := hlBorrowLendInterest{
+			Time:   1700000000000,
+			Token:  "USDC",
+			Borrow: "0.5",
+			Supply: "0.5",
+		}
+		transfer := transformBorrowLendInterest(entry, accountUUID)
+		if transfer != nil {
+			t.Errorf("expected nil transfer for zero net interest, got %+v", transfer)
+		}
+	})
+
+	t.Run("both zero skipped", func(t *testing.T) {
+		entry := hlBorrowLendInterest{
+			Time:   1700000000000,
+			Token:  "USDC",
+			Borrow: "0.0",
+			Supply: "0.0",
+		}
+		transfer := transformBorrowLendInterest(entry, accountUUID)
+		if transfer != nil {
+			t.Errorf("expected nil transfer for zero borrow and supply, got %+v", transfer)
+		}
+	})
+
+	t.Run("non-USDC token", func(t *testing.T) {
+		entry := hlBorrowLendInterest{
+			Time:   1700000000000,
+			Token:  "HYPE",
+			Borrow: "0.0",
+			Supply: "1.23456789",
+		}
+		transfer := transformBorrowLendInterest(entry, accountUUID)
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		if transfer.Asset != "HYPE" {
+			t.Errorf("Asset = %q, want HYPE", transfer.Asset)
+		}
+		if transfer.Amount != "1.23456789" {
+			t.Errorf("Amount = %q, want 1.23456789", transfer.Amount)
+		}
+		if transfer.ExternalID != "bli_HYPE_1700000000000" {
+			t.Errorf("ExternalID = %q, want bli_HYPE_1700000000000", transfer.ExternalID)
+		}
+	})
+
+	t.Run("exact arithmetic no floating point error", func(t *testing.T) {
+		// These values would cause floating point errors if using float64
+		entry := hlBorrowLendInterest{
+			Time:   1700000000000,
+			Token:  "USDC",
+			Borrow: "0.1",
+			Supply: "0.3",
+		}
+		transfer := transformBorrowLendInterest(entry, accountUUID)
+		if transfer == nil {
+			t.Fatal("expected non-nil transfer")
+		}
+		// 0.3 - 0.1 = 0.2 exactly with big.Rat
+		if transfer.Amount != "0.2" {
+			t.Errorf("Amount = %q, want 0.2 (exact arithmetic)", transfer.Amount)
+		}
+	})
+}
+
+func TestFetchDepositsIncludesBorrowLendInterest(t *testing.T) {
+	ledgerEntries := []hlLedgerEntry{
+		{
+			Time: 1700000000000,
+			Hash: "0xaaa",
+			Delta: hlLedgerDelta{
+				Type: "deposit",
+				Usdc: "1000.00",
+			},
+		},
+	}
+
+	bliEntries := []hlBorrowLendInterest{
+		{
+			Time:   1700000001000,
+			Token:  "USDC",
+			Borrow: "0.0",
+			Supply: "0.05",
+		},
+		{
+			Time:   1700000002000,
+			Token:  "HYPE",
+			Borrow: "0.0",
+			Supply: "1.5",
+		},
+		{
+			Time:   1700000003000,
+			Token:  "USDC",
+			Borrow: "0.0",
+			Supply: "0.0", // zero — should be skipped
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+
+		reqType := body["type"].(string)
+		switch reqType {
+		case "userNonFundingLedgerUpdates":
+			json.NewEncoder(w).Encode(ledgerEntries)
+		case "userBorrowLendInterest":
+			json.NewEncoder(w).Encode(bliEntries)
+		default:
+			json.NewEncoder(w).Encode([]interface{}{})
+		}
+	}))
+	defer server.Close()
+
+	c := &Client{
+		apiURL:     server.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	accountID := uuid.New()
+	account := &models.ExchangeAccount{
+		ID:                accountID.String(),
+		AccountIdentifier: "0x1234567890abcdef1234567890abcdef12345678",
+	}
+
+	transfers, _, err := c.FetchDeposits(context.Background(), account, time.UnixMilli(1700000000000))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 1 deposit + 2 interest (the zero one is skipped) = 3
+	if len(transfers) != 3 {
+		t.Fatalf("expected 3 transfers (1 deposit + 2 interest), got %d", len(transfers))
+	}
+
+	// Verify sorted ascending
+	for i := 1; i < len(transfers); i++ {
+		if transfers[i].Timestamp.Before(transfers[i-1].Timestamp) {
+			t.Errorf("transfers not sorted: [%d] %v before [%d] %v", i, transfers[i].Timestamp, i-1, transfers[i-1].Timestamp)
+		}
+	}
+
+	// Find interest transfers
+	var interestTransfers []*models.TransferInput
+	for _, tr := range transfers {
+		if tr.Type == models.TypeInterest {
+			interestTransfers = append(interestTransfers, tr)
+		}
+	}
+	if len(interestTransfers) != 2 {
+		t.Fatalf("expected 2 interest transfers, got %d", len(interestTransfers))
+	}
+
+	// First interest: USDC
+	if interestTransfers[0].Asset != "USDC" {
+		t.Errorf("interest[0] Asset = %q, want USDC", interestTransfers[0].Asset)
+	}
+	if interestTransfers[0].Amount != "0.05" {
+		t.Errorf("interest[0] Amount = %q, want 0.05", interestTransfers[0].Amount)
+	}
+
+	// Second interest: HYPE
+	if interestTransfers[1].Asset != "HYPE" {
+		t.Errorf("interest[1] Asset = %q, want HYPE", interestTransfers[1].Asset)
+	}
+	if interestTransfers[1].Amount != "1.5" {
+		t.Errorf("interest[1] Amount = %q, want 1.5", interestTransfers[1].Amount)
+	}
+}
+
 func TestFetchDepositsReturnsPriceRecords(t *testing.T) {
 	entries := []hlLedgerEntry{
 		{
@@ -1971,8 +2312,19 @@ func TestFetchDepositsReturnsPriceRecords(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(entries)
+
+		reqType := body["type"].(string)
+		switch reqType {
+		case "userNonFundingLedgerUpdates":
+			json.NewEncoder(w).Encode(entries)
+		case "userBorrowLendInterest":
+			json.NewEncoder(w).Encode([]hlBorrowLendInterest{})
+		default:
+			json.NewEncoder(w).Encode([]interface{}{})
+		}
 	}))
 	defer server.Close()
 

--- a/exchange/hyperliquid/discovery.go
+++ b/exchange/hyperliquid/discovery.go
@@ -2,15 +2,18 @@ package hyperliquid
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/zif-terminal/lib/models"
 )
 
 // DiscoverAccounts discovers Hyperliquid accounts for a given Ethereum wallet address.
 // Checks if the address has any perp positions or spot balances indicating activity.
+// Also discovers subaccounts and vaults where the user is the leader.
 func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([]*models.DiscoverableAccount, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -68,12 +71,23 @@ func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([
 		}
 	}
 
+	// Fallback: check historical ledger activity for wallets that traded but withdrew all funds
+	if !hasActivity {
+		req := map[string]interface{}{
+			"type": "userNonFundingLedgerUpdates",
+			"user": userIdentifier,
+		}
+		var ledgerEntries []interface{}
+		if err := c.doPost(ctx, req, &ledgerEntries); err == nil && len(ledgerEntries) > 0 {
+			hasActivity = true
+		}
+	}
+
 	if !hasActivity {
 		return nil, nil
 	}
 
-	// Hyperliquid uses the wallet address directly (no subaccounts in the Drift sense)
-	return []*models.DiscoverableAccount{
+	accounts := []*models.DiscoverableAccount{
 		{
 			AccountIdentifier: userIdentifier,
 			AccountType:       "main",
@@ -82,5 +96,149 @@ func (c *Client) DiscoverAccounts(ctx context.Context, userIdentifier string) ([
 				"wallet": userIdentifier,
 			},
 		},
-	}, nil
+	}
+
+	// Discover subaccounts
+	subAccounts, err := c.discoverSubAccounts(ctx, userIdentifier)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover subaccounts: %w", err)
+	}
+	accounts = append(accounts, subAccounts...)
+
+	// Discover vaults where user is the leader
+	vaultAccounts, err := c.discoverLeaderVaults(ctx, userIdentifier)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover vaults: %w", err)
+	}
+	accounts = append(accounts, vaultAccounts...)
+
+	return accounts, nil
+}
+
+// discoverSubAccounts fetches subaccounts for the given wallet address.
+// Returns an empty slice if the user has no subaccounts.
+func (c *Client) discoverSubAccounts(ctx context.Context, walletAddress string) ([]*models.DiscoverableAccount, error) {
+	// The API returns null for no subaccounts, so we use json.RawMessage to handle both cases.
+	var raw json.RawMessage
+	err := c.doPost(ctx, map[string]string{
+		"type": "subAccounts",
+		"user": walletAddress,
+	}, &raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch subaccounts: %w", err)
+	}
+
+	// null response means no subaccounts
+	if raw == nil || string(raw) == "null" {
+		return nil, nil
+	}
+
+	var subAccounts []hlSubAccount
+	if err := json.Unmarshal(raw, &subAccounts); err != nil {
+		return nil, fmt.Errorf("failed to parse subaccounts response: %w", err)
+	}
+
+	var accounts []*models.DiscoverableAccount
+	for i, sub := range subAccounts {
+		name := sub.Name
+		if name == "" {
+			name = fmt.Sprintf("Subaccount %d", i+1)
+		}
+		accounts = append(accounts, &models.DiscoverableAccount{
+			AccountIdentifier: sub.SubAccountUser,
+			AccountType:       "sub_account",
+			Name:              name,
+			Metadata: map[string]interface{}{
+				"master_wallet":   sub.Master,
+				"subaccount_name": sub.Name,
+			},
+		})
+	}
+
+	return accounts, nil
+}
+
+// discoverLeaderVaults discovers vaults where the user is the leader.
+// Passive depositors are skipped — their cashflows are already tracked via ledger entries.
+func (c *Client) discoverLeaderVaults(ctx context.Context, walletAddress string) ([]*models.DiscoverableAccount, error) {
+	// Fetch vault equities for this user
+	var raw json.RawMessage
+	err := c.doPost(ctx, map[string]string{
+		"type": "userVaultEquities",
+		"user": walletAddress,
+	}, &raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch user vault equities: %w", err)
+	}
+
+	// null or empty response means no vault participation
+	if raw == nil || string(raw) == "null" || string(raw) == "[]" {
+		return nil, nil
+	}
+
+	var vaultEquities []hlVaultEquity
+	if err := json.Unmarshal(raw, &vaultEquities); err != nil {
+		return nil, fmt.Errorf("failed to parse vault equities response: %w", err)
+	}
+
+	var accounts []*models.DiscoverableAccount
+	for _, ve := range vaultEquities {
+		if ve.VaultAddress == "" {
+			continue
+		}
+
+		// Fetch vault details to determine leader
+		details, err := c.fetchVaultDetails(ctx, ve.VaultAddress)
+		if err != nil {
+			// Skip vaults we can't fetch details for (may be deprecated/deleted)
+			continue
+		}
+
+		// Only add vaults where the user is the leader
+		if !strings.EqualFold(details.Leader, walletAddress) {
+			continue
+		}
+
+		name := details.Name
+		if name == "" {
+			name = "Vault " + ve.VaultAddress[:8]
+		}
+
+		accounts = append(accounts, &models.DiscoverableAccount{
+			AccountIdentifier: ve.VaultAddress,
+			AccountType:       "vault",
+			Name:              name,
+			Metadata: map[string]interface{}{
+				"vault_name": details.Name,
+				"is_leader":  true,
+			},
+		})
+	}
+
+	return accounts, nil
+}
+
+// fetchVaultDetails fetches the details of a specific vault.
+func (c *Client) fetchVaultDetails(ctx context.Context, vaultAddress string) (*hlVaultDetails, error) {
+	// The vaultDetails response wraps vault info in various fields.
+	// We only need name and leader, which are at the top level.
+	var raw json.RawMessage
+	err := c.doPost(ctx, map[string]string{
+		"type":         "vaultDetails",
+		"vaultAddress": vaultAddress,
+	}, &raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch vault details for %s: %w", vaultAddress, err)
+	}
+
+	if raw == nil || string(raw) == "null" {
+		return nil, fmt.Errorf("vault %s not found", vaultAddress)
+	}
+
+	var details hlVaultDetails
+	if err := json.Unmarshal(raw, &details); err != nil {
+		return nil, fmt.Errorf("failed to parse vault details for %s: %w", vaultAddress, err)
+	}
+
+	return &details, nil
 }

--- a/exchange/hyperliquid/pagination.go
+++ b/exchange/hyperliquid/pagination.go
@@ -2,6 +2,7 @@ package hyperliquid
 
 import (
 	"context"
+	"sort"
 	"time"
 )
 
@@ -56,12 +57,67 @@ func (c *Client) fetchAllFills(ctx context.Context, user string, since time.Time
 			break
 		}
 
-		// Paginate: set startTime to last fill's timestamp + 1ms
+		// Paginate: set startTime to last fill's timestamp (not +1).
+		// Multiple fills can share the same millisecond. Using +1 would
+		// skip fills at the page boundary. We dedup by tid below.
 		lastTime := fills[len(fills)-1].Time
-		startTime = lastTime + 1
+		if lastTime == startTime {
+			// All fills on this page share the same timestamp — cannot
+			// paginate further without skipping. Move +1ms to avoid
+			// an infinite loop. Fills at this exact ms are already captured.
+			startTime = lastTime + 1
+		} else {
+			startTime = lastTime
+		}
 	}
 
-	return all, nil
+	// Supplement with userFills (most recent 2000). userFillsByTime misses
+	// certain fill types (e.g., Spot Dust Conversions) that userFills returns.
+	if ctx.Err() == nil {
+		var recentFills []hlFill
+		recentReq := map[string]interface{}{
+			"type": "userFills",
+			"user": user,
+		}
+		if err := c.doPost(ctx, recentReq, &recentFills); err == nil {
+			// Only include fills at or after the original since time
+			sinceMs := clampUnixMilli(since)
+			for _, f := range recentFills {
+				if f.Time >= sinceMs {
+					all = append(all, f)
+				}
+			}
+		}
+		// Ignore errors — userFills is supplementary
+	}
+
+	// Dedup by tid: overlapping pages and userFills may return duplicates.
+	// tid=0 fills (e.g., dust conversions) use a composite key to avoid
+	// collapsing distinct fills that share tid=0.
+	type dedupKey struct {
+		Tid  int64
+		Time int64
+		Coin string
+	}
+	seen := make(map[dedupKey]bool, len(all))
+	deduped := make([]hlFill, 0, len(all))
+	for _, f := range all {
+		k := dedupKey{Tid: f.Tid, Time: f.Time, Coin: f.Coin}
+		if f.Tid != 0 {
+			k = dedupKey{Tid: f.Tid} // non-zero tid is globally unique
+		}
+		if !seen[k] {
+			seen[k] = true
+			deduped = append(deduped, f)
+		}
+	}
+
+	// Sort by time ascending for consistent processing order.
+	sort.Slice(deduped, func(i, j int) bool {
+		return deduped[i].Time < deduped[j].Time
+	})
+
+	return deduped, nil
 }
 
 // fetchAllFunding fetches all funding entries for a user since the given time.
@@ -79,6 +135,50 @@ func (c *Client) fetchAllFunding(ctx context.Context, user string, since time.Ti
 	}
 
 	return entries, nil
+}
+
+// maxBorrowLendEntriesPerPage is the number of borrow/lend interest entries we expect before paginating.
+const maxBorrowLendEntriesPerPage = 500
+
+// fetchAllBorrowLendInterest fetches all borrow/lend interest entries for a user since the given time.
+// The API returns entries ascending by time when startTime is set.
+func (c *Client) fetchAllBorrowLendInterest(ctx context.Context, user string, since time.Time) ([]hlBorrowLendInterest, error) {
+	startTime := clampUnixMilli(since)
+	var all []hlBorrowLendInterest
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		req := map[string]interface{}{
+			"type":      "userBorrowLendInterest",
+			"user":      user,
+			"startTime": startTime,
+		}
+
+		var entries []hlBorrowLendInterest
+		if err := c.doPost(ctx, req, &entries); err != nil {
+			return nil, err
+		}
+
+		if len(entries) == 0 {
+			break
+		}
+
+		all = append(all, entries...)
+
+		// If we got fewer than threshold, we've likely got everything
+		if len(entries) < maxBorrowLendEntriesPerPage {
+			break
+		}
+
+		// Paginate by setting startTime to last entry's timestamp + 1ms
+		lastTime := entries[len(entries)-1].Time
+		startTime = lastTime + 1
+	}
+
+	return all, nil
 }
 
 // fetchAllLedgerUpdates fetches all non-funding ledger updates for a user since the given time.

--- a/exchange/hyperliquid/types.go
+++ b/exchange/hyperliquid/types.go
@@ -59,8 +59,11 @@ type hlLedgerDelta struct {
 	Nonce       int64  `json:"nonce"`       // Nonce
 	Destination string `json:"destination"` // Destination address (for withdrawals/spotTransfer)
 	User        string `json:"user"`        // Source user address (for spotTransfer outbound)
-	ToPerp      bool   `json:"toPerp"`      // Direction for accountClassTransfer (true = spot→perp)
-	UsdcValue   string `json:"usdcValue"`   // USDC value of spot transfer (for price derivation)
+	ToPerp          bool   `json:"toPerp"`          // Direction for accountClassTransfer (true = spot→perp)
+	UsdcValue       string `json:"usdcValue"`       // USDC value of spot transfer (for price derivation)
+	NetWithdrawnUsd string `json:"netWithdrawnUsd"` // Actual USDC returned to user on vaultWithdraw
+	IsDeposit       bool   `json:"isDeposit"`       // Direction for cStakingTransfer (true = stake/leave balance)
+	Vault           string `json:"vault"`           // Vault address (for vault-related entries)
 }
 
 // hlClearinghouseState represents the clearinghouse state for a user
@@ -77,6 +80,7 @@ type hlClearinghouseState struct {
 	} `json:"assetPositions"`
 	MarginSummary struct {
 		AccountValue string `json:"accountValue"`
+		TotalRawUsd  string `json:"totalRawUsd"`
 	} `json:"marginSummary"`
 }
 
@@ -88,4 +92,38 @@ type hlSpotClearinghouseState struct {
 		Total string `json:"total"`
 		Hold  string `json:"hold"`
 	} `json:"balances"`
+}
+
+// hlSubAccount represents a subaccount returned by the subAccounts API
+// Request: {"type": "subAccounts", "user": "0x..."}
+// Returns null (no subaccounts) or a list of hlSubAccount.
+type hlSubAccount struct {
+	SubAccountUser string `json:"subAccountUser"`
+	Name           string `json:"name"`
+	Master         string `json:"master"`
+}
+
+// hlBorrowLendInterest represents a single borrow/lend interest entry from Hyperliquid API
+// Request: {"type": "userBorrowLendInterest", "user": "0x...", "startTime": 0}
+// Returns hourly interest entries per token, sorted ascending by time.
+type hlBorrowLendInterest struct {
+	Time   int64  `json:"time"`   // Unix milliseconds
+	Token  string `json:"token"`  // e.g., "USDC", "HYPE"
+	Borrow string `json:"borrow"` // Interest paid (cost)
+	Supply string `json:"supply"` // Interest earned (yield)
+}
+
+// hlVaultEquity represents a vault the user participates in
+// Request: {"type": "userVaultEquities", "user": "0x..."}
+type hlVaultEquity struct {
+	VaultAddress string `json:"vaultAddress"`
+	Equity       string `json:"equity"`
+}
+
+// hlVaultDetails represents vault details from the API
+// Request: {"type": "vaultDetails", "vaultAddress": "0x..."}
+type hlVaultDetails struct {
+	Name       string `json:"name"`
+	VaultAddress string `json:"vaultAddress"`
+	Leader     string `json:"leader"`
 }

--- a/exchange/lighter/auth.go
+++ b/exchange/lighter/auth.go
@@ -1,43 +1,16 @@
 package lighter
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
-	"time"
 )
 
-// defaultTokenDuration is how long a read-only token is valid for.
-const defaultTokenDuration = 24 * time.Hour
-
-// generateReadOnlyToken creates a read-only API token for Lighter.
-// Format: ro:{account_index}:{scope}:{expiry_unix}:{random_hex}
-// scope is "single" for one account or "all" for all accounts.
-func generateReadOnlyToken(accountIndex int, scope string, expiry time.Time) (string, error) {
-	randomBytes := make([]byte, 16)
-	if _, err := rand.Read(randomBytes); err != nil {
-		return "", fmt.Errorf("failed to generate random bytes: %w", err)
-	}
-
-	token := fmt.Sprintf("ro:%d:%s:%d:%s",
-		accountIndex,
-		scope,
-		expiry.Unix(),
-		hex.EncodeToString(randomBytes),
-	)
-
-	return token, nil
-}
-
 // buildAuthToken returns the auth token to use for API requests.
-// If an API key is provided (from account metadata), it is used directly.
-// Otherwise, a read-only token is generated.
+// Lighter requires a user-issued API key stored in account_type_metadata.
+// Randomly generated tokens are not accepted by the Lighter API.
 func buildAuthToken(apiKey string, accountIndex int) (string, error) {
 	if apiKey != "" {
 		return apiKey, nil
 	}
 
-	// Generate a read-only token
-	expiry := time.Now().Add(defaultTokenDuration)
-	return generateReadOnlyToken(accountIndex, "single", expiry)
+	return "", fmt.Errorf("lighter: no API key configured for account_index %d; a user-issued read-only API key is required", accountIndex)
 }

--- a/exchange/lighter/client.go
+++ b/exchange/lighter/client.go
@@ -46,8 +46,27 @@ func (c *Client) Name() string {
 	return "lighter"
 }
 
-// doGet performs an authenticated GET request with rate limiting and retry on 429.
+// getAPIKey extracts the API key from an exchange account's metadata.
+func getAPIKey(account *models.ExchangeAccount) string {
+	if account == nil || account.AccountTypeMetadata == nil {
+		return ""
+	}
+	var meta map[string]interface{}
+	if err := json.Unmarshal(account.AccountTypeMetadata, &meta); err == nil {
+		if key, ok := meta["api_key"].(string); ok {
+			return key
+		}
+	}
+	return ""
+}
+
+// doGet performs a GET request with rate limiting and retry on 429.
 func (c *Client) doGet(ctx context.Context, url string) (json.RawMessage, error) {
+	return c.doGetWithAuth(ctx, url, "")
+}
+
+// doGetWithAuth performs a GET request with an optional auth token.
+func (c *Client) doGetWithAuth(ctx context.Context, url string, authToken string) (json.RawMessage, error) {
 	backoff := initialBackoff
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -66,6 +85,10 @@ func (c *Client) doGet(ctx context.Context, url string) (json.RawMessage, error)
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		if authToken != "" {
+			req.Header.Set("Authorization", authToken)
 		}
 
 		resp, err := c.httpClient.Do(req)
@@ -107,8 +130,14 @@ func (c *Client) doGet(ctx context.Context, url string) (json.RawMessage, error)
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, nil
 		}
-		// 400 is a client-side error — always a bug in the request we built.
+		// 400 may indicate "account not found" (code 21100) — treat as not found.
 		if resp.StatusCode == http.StatusBadRequest {
+			var errResp struct {
+				Code int `json:"code"`
+			}
+			if json.Unmarshal(body, &errResp) == nil && errResp.Code == 21100 {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("lighter: 400 bad request | url=%s | body=%s", url, string(body))
 		}
 
@@ -142,14 +171,19 @@ func (c *Client) FetchTrades(
 		return nil, nil, fmt.Errorf("invalid account_index %q: %w", account.AccountIdentifier, err)
 	}
 
-	rawTrades, err := fetchAllPages[lighterTrade](ctx, c, func(cursor string) string {
+	authToken, err := buildAuthToken(getAPIKey(account), accountIndex)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build auth token: %w", err)
+	}
+
+	rawTrades, err := fetchAllTrades(ctx, c, func(cursor string) string {
 		url := fmt.Sprintf("%s/trades?account_index=%d&sort_by=timestamp&limit=%d",
 			c.baseURL, accountIndex, defaultPageLimit)
 		if cursor != "" {
 			url += "&cursor=" + cursor
 		}
 		return url
-	})
+	}, authToken)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch trades: %w", err)
 	}
@@ -168,31 +202,41 @@ func (c *Client) FetchTrades(
 			return nil, nil, fmt.Errorf("failed to resolve market %d: %w", rt.MarketID, err)
 		}
 
-		// Determine side: if account is the bid account, they're buying; if ask, selling
+		// Determine side: if account is the bid account, they're buying; if ask, selling.
+		// Determine fee: the API field is_maker_ask tells us which side was maker.
+		// If is_maker_ask=true, ask is maker, bid is taker. If false, bid is maker, ask is taker.
 		side := "buy"
-		orderID := rt.BidOrderID
+		orderID := rt.BidIDStr
+		var fee int64
 		if rt.AskAccountID == accountIndex {
 			side = "sell"
-			orderID = rt.AskOrderID
-		}
-
-		// Determine fee: taker vs maker
-		fee := rt.MakerFee
-		if (side == "buy" && rt.IsBuyerTaker) || (side == "sell" && !rt.IsBuyerTaker) {
-			fee = rt.TakerFee
+			orderID = rt.AskIDStr
+			// Ask is our account: if is_maker_ask, we're maker; otherwise taker
+			if rt.IsMakerAsk {
+				fee = rt.MakerFee
+			} else {
+				fee = rt.TakerFee
+			}
+		} else {
+			// Bid is our account: if is_maker_ask, we're taker; otherwise maker
+			if rt.IsMakerAsk {
+				fee = rt.TakerFee
+			} else {
+				fee = rt.MakerFee
+			}
 		}
 
 		ts := time.UnixMilli(rt.Timestamp).UTC()
 
 		trades = append(trades, &models.TradeInput{
-			TradeID:           rt.TradeID,
+			TradeID:           rt.TradeIDStr,
 			OrderID:           orderID,
 			BaseAsset:         market.BaseAsset,
 			QuoteAsset:        market.QuoteAsset,
 			Side:              side,
 			Price:             cleanDecimal(rt.Price),
-			Quantity:          cleanDecimal(rt.Quantity),
-			Fee:               cleanDecimal(fee),
+			Quantity:          cleanDecimal(rt.Size),
+			Fee:               microToDecimal(fee),
 			Timestamp:         ts,
 			ExchangeAccountID: accountUUID,
 			MarketType:        market.MarketType,
@@ -241,23 +285,31 @@ func (c *Client) FetchFundingPayments(
 		return nil, fmt.Errorf("invalid account_index %q: %w", account.AccountIdentifier, err)
 	}
 
-	rawFunding, err := fetchAllPages[lighterFunding](ctx, c, func(cursor string) string {
+	authToken, err := buildAuthToken(getAPIKey(account), accountIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build auth token: %w", err)
+	}
+
+	rawFunding, err := fetchAllFunding(ctx, c, func(cursor string) string {
 		url := fmt.Sprintf("%s/positionFunding?account_index=%d&limit=%d",
 			c.baseURL, accountIndex, defaultPageLimit)
 		if cursor != "" {
 			url += "&cursor=" + cursor
 		}
 		return url
-	})
+	}, authToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch funding: %w", err)
 	}
 
-	sinceMs := since.UnixMilli()
 	payments := make([]*models.TransferInput, 0, len(rawFunding))
 
 	for _, rf := range rawFunding {
-		if !since.IsZero() && rf.Timestamp < sinceMs {
+		// Lighter funding timestamps are Unix seconds. Compare against the
+		// original `since` (which may have sub-second precision from the +1ms
+		// increment in account_syncer). Using time.Time comparison ensures a
+		// funding payment at second X is correctly skipped when since is X+1ms.
+		if !since.IsZero() && !time.Unix(rf.Timestamp, 0).After(since) {
 			continue
 		}
 
@@ -266,16 +318,18 @@ func (c *Client) FetchFundingPayments(
 			return nil, fmt.Errorf("failed to resolve market %d: %w", rf.MarketID, err)
 		}
 
+		fundingIDStr := strconv.FormatInt(rf.FundingID, 10)
+
 		payments = append(payments, &models.TransferInput{
 			ExchangeAccountID: accountUUID,
 			Type:              models.TypeFunding,
 			Asset:             market.QuoteAsset,
-			Amount:            rf.Amount,
-			Timestamp:         time.UnixMilli(rf.Timestamp).UTC(),
-			ExternalID:        rf.FundingID,
+			Amount:            cleanDecimal(rf.Change),
+			Timestamp:         time.Unix(rf.Timestamp, 0).UTC(),
+			ExternalID:        fundingIDStr,
 			Metadata: map[string]string{
 				"market":     market.Symbol + "-PERP",
-				"payment_id": rf.FundingID,
+				"payment_id": fundingIDStr,
 			},
 		})
 	}
@@ -308,27 +362,64 @@ func (c *Client) FetchDeposits(
 		return nil, nil, fmt.Errorf("invalid account_index %q: %w", account.AccountIdentifier, err)
 	}
 
+	authToken, err := buildAuthToken(getAPIKey(account), accountIndex)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build auth token: %w", err)
+	}
+
 	// Extract l1_address from account metadata or use wallet address
 	l1Address := extractL1Address(account)
 
-	rawDeposits, err := fetchAllPages[lighterDeposit](ctx, c, func(cursor string) string {
+	rawDeposits, err := fetchAllDeposits(ctx, c, func(cursor string) string {
 		url := fmt.Sprintf("%s/deposit/history?account_index=%d&l1_address=%s&filter=all&limit=%d",
 			c.baseURL, accountIndex, l1Address, defaultPageLimit)
 		if cursor != "" {
 			url += "&cursor=" + cursor
 		}
 		return url
-	})
+	}, authToken)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch deposits: %w", err)
 	}
 
+	// Fetch L2 internal transfers (spot<->perp, cross-account)
+	rawTransfers, err := fetchAllTransfers(ctx, c, func(cursor string) string {
+		url := fmt.Sprintf("%s/transfer/history?account_index=%d&limit=%d",
+			c.baseURL, accountIndex, defaultPageLimit)
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		return url
+	}, authToken)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch transfers: %w", err)
+	}
+
+	// Fetch L1 withdrawals (not captured by deposit/history)
+	rawWithdraws, err := fetchAllWithdraws(ctx, c, func(cursor string) string {
+		url := fmt.Sprintf("%s/withdraw/history?account_index=%d&limit=%d",
+			c.baseURL, accountIndex, defaultPageLimit)
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		return url
+	}, authToken)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch withdrawals: %w", err)
+	}
+
 	sinceMs := since.UnixMilli()
-	transfers := make([]*models.TransferInput, 0, len(rawDeposits))
+	transfers := make([]*models.TransferInput, 0, len(rawDeposits)+len(rawTransfers)+len(rawWithdraws))
 
 	for _, rd := range rawDeposits {
 		if !since.IsZero() && rd.Timestamp < sinceMs {
 			continue
+		}
+
+		// Resolve asset symbol from asset_id using spot order book data
+		assetSymbol, err := c.resolveAsset(ctx, rd.AssetID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("lighter: unsupported asset_id %d in deposit %s: %w", rd.AssetID, rd.DepositID, err)
 		}
 
 		// Determine deposit vs withdrawal from amount sign
@@ -339,18 +430,92 @@ func (c *Client) FetchDeposits(
 			amount = amount[1:] // Make positive
 		}
 
-		// Resolve asset from asset_id (0 = USDC on Lighter)
-		asset := "USDC"
+		transfers = append(transfers, &models.TransferInput{
+			ExchangeAccountID: accountUUID,
+			Type:              transferType,
+			Asset:             assetSymbol,
+			Amount:            cleanDecimal(amount),
+			Timestamp:         time.UnixMilli(rd.Timestamp).UTC(),
+			ExternalID:        rd.DepositID,
+			Metadata: map[string]string{
+				"deposit_id": rd.DepositID,
+				"tx_hash":    rd.TxHash,
+			},
+		})
+	}
+
+	// Process L2 internal transfers
+	for _, rt := range rawTransfers {
+		if !since.IsZero() && rt.Timestamp < sinceMs {
+			continue
+		}
+
+		// Skip self-transfers (spot<->perp within same account)
+		if rt.Type == "L2SelfTransfer" {
+			continue
+		}
+
+		assetSymbol, err := c.resolveAsset(ctx, rt.AssetID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("lighter: unsupported asset_id %d in transfer %s: %w", rt.AssetID, rt.ID, err)
+		}
+
+		var transferType string
+		switch rt.Type {
+		case "L2TransferInflow":
+			transferType = models.TypeDeposit
+		case "L2TransferOutflow", "L2StakeAssetOutflow":
+			transferType = models.TypeWithdraw
+		default:
+			continue // Unknown type, skip
+		}
+
+		amount := rt.Amount
+		if strings.HasPrefix(amount, "-") {
+			amount = amount[1:]
+		}
 
 		transfers = append(transfers, &models.TransferInput{
 			ExchangeAccountID: accountUUID,
 			Type:              transferType,
-			Asset:             asset,
+			Asset:             assetSymbol,
 			Amount:            cleanDecimal(amount),
-			Timestamp:         time.UnixMilli(rd.Timestamp).UTC(),
+			Timestamp:         time.UnixMilli(rt.Timestamp).UTC(),
+			ExternalID:        fmt.Sprintf("transfer_%s", rt.ID),
 			Metadata: map[string]string{
-				"deposit_id": rd.DepositID,
-				"tx_hash":    rd.TxHash,
+				"transfer_id":  rt.ID,
+				"tx_hash":      rt.TxHash,
+				"transfer_type": rt.Type,
+			},
+		})
+	}
+
+	// Process L1 withdrawals
+	for _, rw := range rawWithdraws {
+		if !since.IsZero() && rw.Timestamp < sinceMs {
+			continue
+		}
+
+		assetSymbol, err := c.resolveAsset(ctx, rw.AssetID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("lighter: unsupported asset_id %d in withdrawal %s: %w", rw.AssetID, rw.ID, err)
+		}
+
+		amount := rw.Amount
+		if strings.HasPrefix(amount, "-") {
+			amount = amount[1:]
+		}
+
+		transfers = append(transfers, &models.TransferInput{
+			ExchangeAccountID: accountUUID,
+			Type:              models.TypeWithdraw,
+			Asset:             assetSymbol,
+			Amount:            cleanDecimal(amount),
+			Timestamp:         time.UnixMilli(rw.Timestamp).UTC(),
+			ExternalID:        fmt.Sprintf("withdraw_%s", rw.ID),
+			Metadata: map[string]string{
+				"withdraw_id": rw.ID,
+				"l1_tx_hash":  rw.L1TxHash,
 			},
 		})
 	}
@@ -454,6 +619,23 @@ func extractL1Address(account *models.ExchangeAccount) string {
 		}
 	}
 	return ""
+}
+
+// microToDecimal converts a micro-USDC integer (1e-6 USDC) to a clean decimal string.
+func microToDecimal(v int64) string {
+	if v == 0 {
+		return "0"
+	}
+	s := fmt.Sprintf("%d.%06d", v/1000000, v%1000000)
+	if v < 0 {
+		// Handle negative: fmt already puts the sign on the integer part
+		abs := v
+		if abs < 0 {
+			abs = -abs
+		}
+		s = fmt.Sprintf("-%d.%06d", abs/1000000, abs%1000000)
+	}
+	return cleanDecimal(s)
 }
 
 // cleanDecimal cleans a decimal string: trims trailing zeros and dots.

--- a/exchange/lighter/client_test.go
+++ b/exchange/lighter/client_test.go
@@ -54,6 +54,12 @@ func TestFetchHistoricalBalanceSnapshotsReturnsNil(t *testing.T) {
 	}
 }
 
+// testAPIKeyMeta returns account_type_metadata with a dummy API key for tests.
+func testAPIKeyMeta() json.RawMessage {
+	meta, _ := json.Marshal(map[string]interface{}{"api_key": "test-key"})
+	return meta
+}
+
 // testLimiter returns a fast rate limiter for tests (no waiting).
 func testLimiter() *rateLimiter {
 	return newRateLimiter(1000, 1000)
@@ -68,53 +74,64 @@ func newTestClient(url string) *Client {
 	}
 }
 
+// serveOrderBookDetails returns an HTTP handler that serves mock order book details.
+func serveOrderBookDetails(markets []lighterOrderBookDetail, spotMarkets []lighterOrderBookDetail) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
+			Code:             200,
+			OrderBookDetails: markets,
+			SpotOrderBooks:   spotMarkets,
+		})
+	}
+}
+
 func TestFetchTradesWithMock(t *testing.T) {
 	resetMarketCache()
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
-			OrderBooks: []lighterOrderBookDetail{
-				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
-				{MarketID: 2, Symbol: "BTC", BaseAsset: "BTC", QuoteAsset: "USDC", MarketType: "perp"},
-			},
-		})
-	})
+	mux.HandleFunc("/orderBookDetails", serveOrderBookDetails(
+		[]lighterOrderBookDetail{
+			{MarketID: 1, Symbol: "ETH", MarketType: "perp"},
+			{MarketID: 2, Symbol: "BTC", MarketType: "perp"},
+		},
+		nil,
+	))
 
 	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
-			Code:    0,
-			Message: "ok",
-			Data: []lighterTrade{
+		json.NewEncoder(w).Encode(tradesResponse{
+			Code:    200,
+			Trades: []lighterTrade{
 				{
-					TradeID:      "t1",
+					TradeID:      1,
+					TradeIDStr:   "t1",
 					MarketID:     1,
 					AskAccountID: 5,
 					BidAccountID: 10,
 					Price:        "2000.50",
-					Quantity:     "1.5",
-					TakerFee:     "0.30",
-					MakerFee:     "0.10",
-					IsBuyerTaker: true,
+					Size:         "1.5",
+					TakerFee:     300000, // 0.3 USDC in micro-USDC
+					MakerFee:     100000, // 0.1 USDC in micro-USDC
+					IsMakerAsk:   true,   // ask is maker
 					Timestamp:    1700000001000,
-					AskOrderID:   "o-ask-1",
-					BidOrderID:   "o-bid-1",
+					AskIDStr:     "o-ask-1",
+					BidIDStr:     "o-bid-1",
 				},
 				{
-					TradeID:      "t2",
+					TradeID:      2,
+					TradeIDStr:   "t2",
 					MarketID:     2,
 					AskAccountID: 10,
 					BidAccountID: 99,
 					Price:        "35000.00",
-					Quantity:     "0.1",
-					TakerFee:     "0.50",
-					MakerFee:     "0.15",
-					IsBuyerTaker: false,
+					Size:         "0.1",
+					TakerFee:     500000, // 0.5 USDC
+					MakerFee:     150000, // 0.15 USDC
+					IsMakerAsk:   false,  // bid is maker, ask (account 10) is taker
 					Timestamp:    1700000000000,
-					AskOrderID:   "o-ask-2",
-					BidOrderID:   "o-bid-2",
+					AskIDStr:     "o-ask-2",
+					BidIDStr:     "o-bid-2",
 				},
 			},
 		})
@@ -127,8 +144,9 @@ func TestFetchTradesWithMock(t *testing.T) {
 
 	accountID := uuid.New()
 	account := &models.ExchangeAccount{
-		ID:                accountID.String(),
-		AccountIdentifier: "10", // account_index = 10
+		ID:                  accountID.String(),
+		AccountIdentifier:   "10", // account_index = 10
+		AccountTypeMetadata: testAPIKeyMeta(),
 	}
 
 	trades, prices, err := c.FetchTrades(context.Background(), account, time.Time{})
@@ -149,7 +167,7 @@ func TestFetchTradesWithMock(t *testing.T) {
 		t.Error("trades should be sorted ascending by timestamp")
 	}
 
-	// First trade (t2 - earlier timestamp): account 10 is ask, so sell
+	// First trade (t2 - earlier timestamp): account 10 is ask, is_maker_ask=false so ask is taker
 	sell := trades[0]
 	if sell.TradeID != "t2" {
 		t.Errorf("expected trade t2 first (earlier), got %s", sell.TradeID)
@@ -163,8 +181,9 @@ func TestFetchTradesWithMock(t *testing.T) {
 	if sell.MarketType != "perp" {
 		t.Errorf("expected perp, got %s", sell.MarketType)
 	}
+	// Account 10 is ask, is_maker_ask=false, so account is taker -> taker fee
 	if sell.Fee != "0.5" {
-		t.Errorf("expected fee 0.5 (taker, sell side, buyer is not taker), got %s", sell.Fee)
+		t.Errorf("expected fee 0.5 (taker fee for ask when is_maker_ask=false), got %s", sell.Fee)
 	}
 	if sell.OrderID != "o-ask-2" {
 		t.Errorf("expected ask order ID for sell side, got %s", sell.OrderID)
@@ -173,7 +192,7 @@ func TestFetchTradesWithMock(t *testing.T) {
 		t.Errorf("expected USDC fee asset, got %s", sell.FeeAsset)
 	}
 
-	// Second trade (t1 - later timestamp): account 10 is bid, so buy
+	// Second trade (t1 - later timestamp): account 10 is bid, is_maker_ask=true so bid is taker
 	buy := trades[1]
 	if buy.Side != "buy" {
 		t.Errorf("expected buy side for bid account, got %s", buy.Side)
@@ -181,8 +200,9 @@ func TestFetchTradesWithMock(t *testing.T) {
 	if buy.BaseAsset != "ETH" {
 		t.Errorf("expected ETH, got %s", buy.BaseAsset)
 	}
+	// Account 10 is bid, is_maker_ask=true, so bid is taker -> taker fee
 	if buy.Fee != "0.3" {
-		t.Errorf("expected fee 0.3 (taker, buy side, buyer is taker), got %s", buy.Fee)
+		t.Errorf("expected fee 0.3 (taker fee for bid when is_maker_ask=true), got %s", buy.Fee)
 	}
 	if buy.ExchangeAccountID != accountID {
 		t.Errorf("expected account ID %v, got %v", accountID, buy.ExchangeAccountID)
@@ -200,33 +220,32 @@ func TestFetchTradesSideDetermination(t *testing.T) {
 	resetMarketCache()
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
-			OrderBooks: []lighterOrderBookDetail{
-				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
-			},
-		})
-	})
+	mux.HandleFunc("/orderBookDetails", serveOrderBookDetails(
+		[]lighterOrderBookDetail{
+			{MarketID: 1, Symbol: "ETH", MarketType: "perp"},
+		},
+		nil,
+	))
 
 	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
-			Code: 0,
-			Data: []lighterTrade{
+		json.NewEncoder(w).Encode(tradesResponse{
+			Code: 200,
+			Trades: []lighterTrade{
 				{
-					TradeID:      "t-maker-buy",
+					TradeID:      1,
+					TradeIDStr:   "t-maker-buy",
 					MarketID:     1,
 					AskAccountID: 99,
-					BidAccountID: 5, // Our account is bid (buyer) and maker
+					BidAccountID: 5,      // Our account is bid (buyer)
 					Price:        "2000",
-					Quantity:     "1",
-					TakerFee:     "0.30",
-					MakerFee:     "0.10",
-					IsBuyerTaker: false, // Buyer is maker
+					Size:         "1",
+					TakerFee:     300000, // 0.3 USDC
+					MakerFee:     100000, // 0.1 USDC
+					IsMakerAsk:   false,  // bid is maker
 					Timestamp:    1700000000000,
-					AskOrderID:   "o1",
-					BidOrderID:   "o2",
+					AskIDStr:     "o1",
+					BidIDStr:     "o2",
 				},
 			},
 		})
@@ -238,8 +257,9 @@ func TestFetchTradesSideDetermination(t *testing.T) {
 	c := newTestClient(server.URL)
 
 	account := &models.ExchangeAccount{
-		ID:                uuid.New().String(),
-		AccountIdentifier: "5",
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "5",
+		AccountTypeMetadata: testAPIKeyMeta(),
 	}
 
 	trades, _, err := c.FetchTrades(context.Background(), account, time.Time{})
@@ -251,7 +271,7 @@ func TestFetchTradesSideDetermination(t *testing.T) {
 		t.Fatalf("expected 1 trade, got %d", len(trades))
 	}
 
-	// Account 5 is bid (buyer), buyer is NOT taker, so fee should be maker fee
+	// Account 5 is bid, is_maker_ask=false -> bid is maker -> maker fee
 	if trades[0].Fee != "0.1" {
 		t.Errorf("expected maker fee 0.1, got %s", trades[0].Fee)
 	}
@@ -261,33 +281,29 @@ func TestFetchFundingPaymentsWithMock(t *testing.T) {
 	resetMarketCache()
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
-			OrderBooks: []lighterOrderBookDetail{
-				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
-			},
-		})
-	})
+	mux.HandleFunc("/orderBookDetails", serveOrderBookDetails(
+		[]lighterOrderBookDetail{
+			{MarketID: 1, Symbol: "ETH", MarketType: "perp"},
+		},
+		nil,
+	))
 
 	mux.HandleFunc("/positionFunding", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(apiResponse[lighterFunding]{
-			Code: 0,
-			Data: []lighterFunding{
+		json.NewEncoder(w).Encode(fundingResponse{
+			Code: 200,
+			PositionFundings: []lighterFunding{
 				{
-					FundingID: "f1",
-					AccountID: 10,
+					FundingID: 1,
 					MarketID:  1,
-					Amount:    "-0.50",
-					Timestamp: 1700000000000,
+					Change:    "-0.50",
+					Timestamp: 1700000000, // Unix seconds
 				},
 				{
-					FundingID: "f2",
-					AccountID: 10,
+					FundingID: 2,
 					MarketID:  1,
-					Amount:    "1.25",
-					Timestamp: 1700000001000,
+					Change:    "1.25",
+					Timestamp: 1700000001, // Unix seconds
 				},
 			},
 		})
@@ -300,8 +316,9 @@ func TestFetchFundingPaymentsWithMock(t *testing.T) {
 
 	accountID := uuid.New()
 	account := &models.ExchangeAccount{
-		ID:                accountID.String(),
-		AccountIdentifier: "10",
+		ID:                  accountID.String(),
+		AccountIdentifier:   "10",
+		AccountTypeMetadata: testAPIKeyMeta(),
 	}
 
 	payments, err := c.FetchFundingPayments(context.Background(), account, time.Time{})
@@ -325,14 +342,14 @@ func TestFetchFundingPaymentsWithMock(t *testing.T) {
 	if p.Asset != "USDC" {
 		t.Errorf("Asset = %q, want USDC", p.Asset)
 	}
-	if p.Amount != "-0.50" {
-		t.Errorf("Amount = %q, want -0.50", p.Amount)
+	if p.Amount != "-0.5" {
+		t.Errorf("Amount = %q, want -0.5", p.Amount)
 	}
 	if p.Metadata["market"] != "ETH-PERP" {
 		t.Errorf("market metadata = %q, want ETH-PERP", p.Metadata["market"])
 	}
-	if p.Metadata["payment_id"] != "f1" {
-		t.Errorf("payment_id metadata = %q, want f1", p.Metadata["payment_id"])
+	if p.Metadata["payment_id"] != "1" {
+		t.Errorf("payment_id metadata = %q, want 1", p.Metadata["payment_id"])
 	}
 	if p.ExchangeAccountID != accountID {
 		t.Errorf("ExchangeAccountID = %v, want %v", p.ExchangeAccountID, accountID)
@@ -341,39 +358,48 @@ func TestFetchFundingPaymentsWithMock(t *testing.T) {
 
 func TestFetchDepositsWithMock(t *testing.T) {
 	resetMarketCache()
+	mux := http.NewServeMux()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Need orderBookDetails for asset resolution (asset_id 3 -> USDC from spot markets)
+	mux.HandleFunc("/orderBookDetails", serveOrderBookDetails(
+		nil,
+		[]lighterOrderBookDetail{
+			{MarketID: 2051, Symbol: "UNI/USDC", MarketType: "spot", BaseAssetID: 6, QuoteAssetID: 3},
+		},
+	))
+
+	mux.HandleFunc("/deposit/history", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(apiResponse[lighterDeposit]{
-			Code: 0,
-			Data: []lighterDeposit{
+		json.NewEncoder(w).Encode(depositsResponse{
+			Code: 200,
+			Deposits: []lighterDeposit{
 				{
 					DepositID: "d1",
-					AccountID: 10,
-					AssetID:   0,
-					Amount:    "1000.00",
+					AssetID:   3, // USDC
+					Amount:    "1000.000000",
 					Status:    "completed",
 					Timestamp: 1700000000000,
 					TxHash:    "0xaaa",
 				},
 				{
 					DepositID: "d2",
-					AccountID: 10,
-					AssetID:   0,
-					Amount:    "-500.00",
+					AssetID:   3, // USDC
+					Amount:    "-500.000000",
 					Status:    "completed",
 					Timestamp: 1700000001000,
 					TxHash:    "0xbbb",
 				},
 			},
 		})
-	}))
+	})
+
+	server := httptest.NewServer(mux)
 	defer server.Close()
 
 	c := newTestClient(server.URL)
 
 	accountID := uuid.New()
-	meta, _ := json.Marshal(map[string]interface{}{"l1_address": "0x1234"})
+	meta, _ := json.Marshal(map[string]interface{}{"l1_address": "0x1234", "api_key": "test-key"})
 	account := &models.ExchangeAccount{
 		ID:                  accountID.String(),
 		AccountIdentifier:   "10",
@@ -427,12 +453,13 @@ func TestFetchBalancesWithMock(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(lighterAccountResp{
+			Code: 200,
 			Accounts: []lighterAccount{
 				{
 					AccountIndex: 10,
 					L1Address:    "0x1234",
 					Assets: []lighterAsset{
-						{Symbol: "USDC", AssetID: 0, Balance: "5000.50", LockedBalance: "0"},
+						{Symbol: "USDC", AssetID: 3, Balance: "5000.50", LockedBalance: "0"},
 						{Symbol: "ETH", AssetID: 1, Balance: "1.5", LockedBalance: "0.5"},
 					},
 				},
@@ -440,7 +467,7 @@ func TestFetchBalancesWithMock(t *testing.T) {
 					AccountIndex: 20,
 					L1Address:    "0x1234",
 					Assets: []lighterAsset{
-						{Symbol: "USDC", AssetID: 0, Balance: "100", LockedBalance: "0"},
+						{Symbol: "USDC", AssetID: 3, Balance: "100", LockedBalance: "0"},
 					},
 				},
 			},
@@ -503,7 +530,7 @@ func TestDiscoverAccountsWithMock(t *testing.T) {
 				{
 					AccountIndex: 0,
 					L1Address:    "0xabcdef",
-					Status:       "active",
+					Status:       1,
 					Assets: []lighterAsset{
 						{Symbol: "USDC", Balance: "1000"},
 					},
@@ -624,14 +651,12 @@ func TestPagination(t *testing.T) {
 	resetMarketCache()
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
-			OrderBooks: []lighterOrderBookDetail{
-				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
-			},
-		})
-	})
+	mux.HandleFunc("/orderBookDetails", serveOrderBookDetails(
+		[]lighterOrderBookDetail{
+			{MarketID: 1, Symbol: "ETH", MarketType: "perp"},
+		},
+		nil,
+	))
 
 	callCount := 0
 	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
@@ -642,19 +667,19 @@ func TestPagination(t *testing.T) {
 		switch cursor {
 		case "":
 			// First page
-			json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
-				Code:       0,
+			json.NewEncoder(w).Encode(tradesResponse{
+				Code:       200,
 				NextCursor: "page2",
-				Data: []lighterTrade{
-					{TradeID: "t1", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2000", Quantity: "1", TakerFee: "0.1", MakerFee: "0.05", IsBuyerTaker: true, Timestamp: 1700000000000, BidOrderID: "o1", AskOrderID: "o2"},
+				Trades: []lighterTrade{
+					{TradeIDStr: "t1", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2000", Size: "1", TakerFee: 100000, MakerFee: 50000, IsMakerAsk: true, Timestamp: 1700000000000, BidIDStr: "o1", AskIDStr: "o2"},
 				},
 			})
 		case "page2":
 			// Second page (last)
-			json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
-				Code: 0,
-				Data: []lighterTrade{
-					{TradeID: "t2", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2001", Quantity: "2", TakerFee: "0.2", MakerFee: "0.1", IsBuyerTaker: true, Timestamp: 1700000001000, BidOrderID: "o3", AskOrderID: "o4"},
+			json.NewEncoder(w).Encode(tradesResponse{
+				Code: 200,
+				Trades: []lighterTrade{
+					{TradeIDStr: "t2", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2001", Size: "2", TakerFee: 200000, MakerFee: 100000, IsMakerAsk: true, Timestamp: 1700000001000, BidIDStr: "o3", AskIDStr: "o4"},
 				},
 			})
 		default:
@@ -668,8 +693,9 @@ func TestPagination(t *testing.T) {
 	c := newTestClient(server.URL)
 
 	account := &models.ExchangeAccount{
-		ID:                uuid.New().String(),
-		AccountIdentifier: "5",
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "5",
+		AccountTypeMetadata: testAPIKeyMeta(),
 	}
 
 	trades, _, err := c.FetchTrades(context.Background(), account, time.Time{})
@@ -694,22 +720,20 @@ func TestFetchTradesSinceFilter(t *testing.T) {
 	resetMarketCache()
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/orderBookDetails", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(lighterOrderBookDetailsResp{
-			OrderBooks: []lighterOrderBookDetail{
-				{MarketID: 1, Symbol: "ETH", BaseAsset: "ETH", QuoteAsset: "USDC", MarketType: "perp"},
-			},
-		})
-	})
+	mux.HandleFunc("/orderBookDetails", serveOrderBookDetails(
+		[]lighterOrderBookDetail{
+			{MarketID: 1, Symbol: "ETH", MarketType: "perp"},
+		},
+		nil,
+	))
 
 	mux.HandleFunc("/trades", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(apiResponse[lighterTrade]{
-			Code: 0,
-			Data: []lighterTrade{
-				{TradeID: "old", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2000", Quantity: "1", TakerFee: "0.1", MakerFee: "0.05", IsBuyerTaker: true, Timestamp: 1700000000000, BidOrderID: "o1", AskOrderID: "o2"},
-				{TradeID: "new", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2001", Quantity: "1", TakerFee: "0.1", MakerFee: "0.05", IsBuyerTaker: true, Timestamp: 1700000002000, BidOrderID: "o3", AskOrderID: "o4"},
+		json.NewEncoder(w).Encode(tradesResponse{
+			Code: 200,
+			Trades: []lighterTrade{
+				{TradeIDStr: "old", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2000", Size: "1", TakerFee: 100000, MakerFee: 50000, IsMakerAsk: true, Timestamp: 1700000000000, BidIDStr: "o1", AskIDStr: "o2"},
+				{TradeIDStr: "new", MarketID: 1, BidAccountID: 5, AskAccountID: 99, Price: "2001", Size: "1", TakerFee: 100000, MakerFee: 50000, IsMakerAsk: true, Timestamp: 1700000002000, BidIDStr: "o3", AskIDStr: "o4"},
 			},
 		})
 	})
@@ -720,8 +744,9 @@ func TestFetchTradesSinceFilter(t *testing.T) {
 	c := newTestClient(server.URL)
 
 	account := &models.ExchangeAccount{
-		ID:                uuid.New().String(),
-		AccountIdentifier: "5",
+		ID:                  uuid.New().String(),
+		AccountIdentifier:   "5",
+		AccountTypeMetadata: testAPIKeyMeta(),
 	}
 
 	since := time.UnixMilli(1700000001000)
@@ -736,6 +761,74 @@ func TestFetchTradesSinceFilter(t *testing.T) {
 
 	if trades[0].TradeID != "new" {
 		t.Errorf("expected trade 'new', got %s", trades[0].TradeID)
+	}
+}
+
+func TestFetchFundingPaymentsSinceBoundary(t *testing.T) {
+	// Regression test: a funding payment at the exact second boundary must be
+	// filtered out when since has sub-second precision (e.g., timestamp + 1ms).
+	// The Lighter API returns timestamps in Unix seconds, but the syncer adds
+	// +1ms to the last-seen timestamp. Without proper handling, the second-
+	// precision timestamp passes the filter and causes a duplicate insert.
+	resetMarketCache()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/orderBookDetails", serveOrderBookDetails(
+		[]lighterOrderBookDetail{
+			{MarketID: 1, Symbol: "ETH", MarketType: "perp"},
+		},
+		nil,
+	))
+
+	mux.HandleFunc("/positionFunding", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(fundingResponse{
+			Code: 200,
+			PositionFundings: []lighterFunding{
+				{
+					FundingID: 1,
+					MarketID:  1,
+					Change:    "-0.50",
+					Timestamp: 1700000000, // Unix seconds: exact boundary
+				},
+				{
+					FundingID: 2,
+					MarketID:  1,
+					Change:    "1.25",
+					Timestamp: 1700000001, // 1 second later: should pass
+				},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	accountID := uuid.New()
+	account := &models.ExchangeAccount{
+		ID:                  accountID.String(),
+		AccountIdentifier:   "10",
+		AccountTypeMetadata: testAPIKeyMeta(),
+	}
+
+	// since = exact timestamp + 1ms (simulates getSinceFundingPaymentTimestamp behavior)
+	since := time.Unix(1700000000, 0).Add(1 * time.Millisecond)
+
+	payments, err := c.FetchFundingPayments(context.Background(), account, since)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The funding at 1700000000 should be filtered out (it's <= since)
+	// Only the funding at 1700000001 should remain
+	if len(payments) != 1 {
+		t.Fatalf("expected 1 payment after boundary filtering, got %d", len(payments))
+	}
+
+	if payments[0].ExternalID != "2" {
+		t.Errorf("expected funding ID 2, got %s", payments[0].ExternalID)
 	}
 }
 
@@ -793,6 +886,66 @@ func TestCleanDecimal(t *testing.T) {
 		got := cleanDecimal(tt.input)
 		if got != tt.want {
 			t.Errorf("cleanDecimal(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestMicroToDecimal(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0"},
+		{100000, "0.1"},
+		{300000, "0.3"},
+		{500000, "0.5"},
+		{1000000, "1"},
+		{1500000, "1.5"},
+		{200, "0.0002"},
+		{238, "0.000238"},
+	}
+
+	for _, tt := range tests {
+		got := microToDecimal(tt.input)
+		if got != tt.want {
+			t.Errorf("microToDecimal(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsSuccessCode(t *testing.T) {
+	if !isSuccessCode(0) {
+		t.Error("code 0 should be success")
+	}
+	if !isSuccessCode(200) {
+		t.Error("code 200 should be success")
+	}
+	if isSuccessCode(21100) {
+		t.Error("code 21100 should not be success")
+	}
+	if isSuccessCode(400) {
+		t.Error("code 400 should not be success")
+	}
+}
+
+func TestDeriveBaseQuote(t *testing.T) {
+	tests := []struct {
+		symbol     string
+		marketType string
+		wantBase   string
+		wantQuote  string
+	}{
+		{"ETH", "perp", "ETH", "USDC"},
+		{"BTC", "perp", "BTC", "USDC"},
+		{"UNI/USDC", "spot", "UNI", "USDC"},
+		{"ETH/USDC", "spot", "ETH", "USDC"},
+	}
+
+	for _, tt := range tests {
+		base, quote := deriveBaseQuote(tt.symbol, tt.marketType)
+		if base != tt.wantBase || quote != tt.wantQuote {
+			t.Errorf("deriveBaseQuote(%q, %q) = (%q, %q), want (%q, %q)",
+				tt.symbol, tt.marketType, base, quote, tt.wantBase, tt.wantQuote)
 		}
 	}
 }

--- a/exchange/lighter/markets.go
+++ b/exchange/lighter/markets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -71,11 +72,14 @@ func (mc *marketCache) reload(ctx context.Context, c *Client, marketID int) (*ma
 		return nil, fmt.Errorf("failed to decode order book details: %w", err)
 	}
 
-	for _, ob := range resp.OrderBooks {
+	// Process both perp and spot order books
+	allBooks := append(resp.OrderBookDetails, resp.SpotOrderBooks...)
+	for _, ob := range allBooks {
+		base, quote := deriveBaseQuote(ob.Symbol, ob.MarketType)
 		mc.markets[ob.MarketID] = &marketInfo{
 			Symbol:     ob.Symbol,
-			BaseAsset:  ob.BaseAsset,
-			QuoteAsset: ob.QuoteAsset,
+			BaseAsset:  base,
+			QuoteAsset: quote,
 			MarketType: ob.MarketType,
 		}
 	}
@@ -88,9 +92,99 @@ func (mc *marketCache) reload(ctx context.Context, c *Client, marketID int) (*ma
 	return info, nil
 }
 
+// deriveBaseQuote derives base and quote asset from a Lighter market symbol.
+// Perp symbols are just the base asset (e.g. "ETH" -> ETH/USDC).
+// Spot symbols use "BASE/QUOTE" format (e.g. "UNI/USDC").
+func deriveBaseQuote(symbol, marketType string) (base, quote string) {
+	if marketType == "spot" {
+		parts := strings.SplitN(symbol, "/", 2)
+		if len(parts) == 2 {
+			return parts[0], parts[1]
+		}
+	}
+	// Perp markets: symbol is just the base asset, quote is always USDC
+	return symbol, "USDC"
+}
+
+// assetCache caches asset_id -> symbol mappings derived from spot order book details.
+type assetCache struct {
+	mu     sync.RWMutex
+	assets map[int]string // asset_id -> symbol
+	loaded bool
+}
+
+var globalAssetCache = &assetCache{
+	assets: make(map[int]string),
+}
+
+// get returns the symbol for a given asset_id, loading the cache if needed.
+func (ac *assetCache) get(ctx context.Context, c *Client, assetID int) (string, error) {
+	ac.mu.RLock()
+	if ac.loaded {
+		sym, ok := ac.assets[assetID]
+		ac.mu.RUnlock()
+		if ok {
+			return sym, nil
+		}
+		return "", fmt.Errorf("unknown asset_id %d", assetID)
+	}
+	ac.mu.RUnlock()
+
+	return ac.reload(ctx, c, assetID)
+}
+
+// reload fetches the full market list from the API and builds the asset map.
+func (ac *assetCache) reload(ctx context.Context, c *Client, assetID int) (string, error) {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	if ac.loaded {
+		if sym, ok := ac.assets[assetID]; ok {
+			return sym, nil
+		}
+		return "", fmt.Errorf("unknown asset_id %d", assetID)
+	}
+
+	url := c.baseURL + "/orderBookDetails"
+	body, err := c.doGet(ctx, url)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch order book details: %w", err)
+	}
+
+	if body == nil {
+		return "", fmt.Errorf("no order book details returned")
+	}
+
+	var resp lighterOrderBookDetailsResp
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("failed to decode order book details: %w", err)
+	}
+
+	// Build asset_id -> symbol map from spot markets which have explicit base/quote
+	for _, ob := range resp.SpotOrderBooks {
+		parts := strings.SplitN(ob.Symbol, "/", 2)
+		if len(parts) == 2 {
+			ac.assets[ob.BaseAssetID] = parts[0]
+			ac.assets[ob.QuoteAssetID] = parts[1]
+		}
+	}
+	ac.loaded = true
+
+	sym, ok := ac.assets[assetID]
+	if !ok {
+		return "", fmt.Errorf("unknown asset_id %d", assetID)
+	}
+	return sym, nil
+}
+
 // resolveMarket resolves a market_id to its metadata using the global cache.
 func (c *Client) resolveMarket(ctx context.Context, marketID int) (*marketInfo, error) {
 	return globalMarketCache.get(ctx, c, marketID)
+}
+
+// resolveAsset resolves an asset_id to its symbol using the global asset cache.
+func (c *Client) resolveAsset(ctx context.Context, assetID int) (string, error) {
+	return globalAssetCache.get(ctx, c, assetID)
 }
 
 // resetMarketCache resets the global market cache. Used in tests.
@@ -99,4 +193,9 @@ func resetMarketCache() {
 	defer globalMarketCache.mu.Unlock()
 	globalMarketCache.markets = make(map[int]*marketInfo)
 	globalMarketCache.loaded = false
+
+	globalAssetCache.mu.Lock()
+	defer globalAssetCache.mu.Unlock()
+	globalAssetCache.assets = make(map[int]string)
+	globalAssetCache.loaded = false
 }

--- a/exchange/lighter/pagination.go
+++ b/exchange/lighter/pagination.go
@@ -9,11 +9,15 @@ import (
 // defaultPageLimit is the number of records per page for Lighter API requests.
 const defaultPageLimit = 100
 
-// fetchAllPages fetches all pages of a paginated Lighter API endpoint using cursor-based pagination.
-// The urlFn is called with each cursor value (empty string for the first page) and returns the full URL.
-// Returns all data items across all pages.
-func fetchAllPages[T any](ctx context.Context, c *Client, urlFn func(cursor string) string) ([]T, error) {
-	var all []T
+// isSuccessCode returns true if a Lighter API response code indicates success.
+// The Lighter API uses code=200 for success (not 0).
+func isSuccessCode(code int) bool {
+	return code == 0 || code == 200
+}
+
+// fetchAllTrades fetches all pages of trades using cursor-based pagination.
+func fetchAllTrades(ctx context.Context, c *Client, urlFn func(cursor string) string, authToken string) ([]lighterTrade, error) {
+	var all []lighterTrade
 	cursor := ""
 
 	for {
@@ -22,7 +26,7 @@ func fetchAllPages[T any](ctx context.Context, c *Client, urlFn func(cursor stri
 		}
 
 		url := urlFn(cursor)
-		body, err := c.doGet(ctx, url)
+		body, err := c.doGetWithAuth(ctx, url, authToken)
 		if err != nil {
 			return nil, err
 		}
@@ -31,19 +35,182 @@ func fetchAllPages[T any](ctx context.Context, c *Client, urlFn func(cursor stri
 			break
 		}
 
-		var resp apiResponse[T]
+		var resp tradesResponse
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return nil, fmt.Errorf("failed to decode response: %w", err)
+			return nil, fmt.Errorf("failed to decode trades response: %w", err)
 		}
 
-		if resp.Code != 0 {
+		if !isSuccessCode(resp.Code) {
 			return nil, fmt.Errorf("API error code %d: %s", resp.Code, resp.Message)
 		}
 
-		all = append(all, resp.Data...)
+		all = append(all, resp.Trades...)
 
-		// Stop if no next cursor or no data returned
-		if resp.NextCursor == "" || len(resp.Data) == 0 {
+		if resp.NextCursor == "" || len(resp.Trades) == 0 {
+			break
+		}
+
+		cursor = resp.NextCursor
+	}
+
+	return all, nil
+}
+
+// fetchAllDeposits fetches all pages of deposits using cursor-based pagination.
+func fetchAllDeposits(ctx context.Context, c *Client, urlFn func(cursor string) string, authToken string) ([]lighterDeposit, error) {
+	var all []lighterDeposit
+	cursor := ""
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		url := urlFn(cursor)
+		body, err := c.doGetWithAuth(ctx, url, authToken)
+		if err != nil {
+			return nil, err
+		}
+
+		if body == nil {
+			break
+		}
+
+		var resp depositsResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to decode deposits response: %w", err)
+		}
+
+		if !isSuccessCode(resp.Code) {
+			return nil, fmt.Errorf("API error code %d: %s", resp.Code, resp.Message)
+		}
+
+		all = append(all, resp.Deposits...)
+
+		if resp.Cursor == "" || len(resp.Deposits) == 0 {
+			break
+		}
+
+		cursor = resp.Cursor
+	}
+
+	return all, nil
+}
+
+// fetchAllTransfers fetches all pages of L2 transfers using cursor-based pagination.
+func fetchAllTransfers(ctx context.Context, c *Client, urlFn func(cursor string) string, authToken string) ([]lighterTransfer, error) {
+	var all []lighterTransfer
+	cursor := ""
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		url := urlFn(cursor)
+		body, err := c.doGetWithAuth(ctx, url, authToken)
+		if err != nil {
+			return nil, err
+		}
+
+		if body == nil {
+			break
+		}
+
+		var resp transfersResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to decode transfers response: %w", err)
+		}
+
+		if !isSuccessCode(resp.Code) {
+			return nil, fmt.Errorf("API error code %d: %s", resp.Code, resp.Message)
+		}
+
+		all = append(all, resp.Transfers...)
+
+		if resp.Cursor == "" || len(resp.Transfers) == 0 {
+			break
+		}
+
+		cursor = resp.Cursor
+	}
+
+	return all, nil
+}
+
+// fetchAllWithdraws fetches all pages of L1 withdrawals using cursor-based pagination.
+func fetchAllWithdraws(ctx context.Context, c *Client, urlFn func(cursor string) string, authToken string) ([]lighterWithdraw, error) {
+	var all []lighterWithdraw
+	cursor := ""
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		url := urlFn(cursor)
+		body, err := c.doGetWithAuth(ctx, url, authToken)
+		if err != nil {
+			return nil, err
+		}
+
+		if body == nil {
+			break
+		}
+
+		var resp withdrawsResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to decode withdraws response: %w", err)
+		}
+
+		if !isSuccessCode(resp.Code) {
+			return nil, fmt.Errorf("API error code %d: %s", resp.Code, resp.Message)
+		}
+
+		all = append(all, resp.Withdraws...)
+
+		if resp.Cursor == "" || len(resp.Withdraws) == 0 {
+			break
+		}
+
+		cursor = resp.Cursor
+	}
+
+	return all, nil
+}
+
+// fetchAllFunding fetches all pages of funding payments using cursor-based pagination.
+func fetchAllFunding(ctx context.Context, c *Client, urlFn func(cursor string) string, authToken string) ([]lighterFunding, error) {
+	var all []lighterFunding
+	cursor := ""
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		url := urlFn(cursor)
+		body, err := c.doGetWithAuth(ctx, url, authToken)
+		if err != nil {
+			return nil, err
+		}
+
+		if body == nil {
+			break
+		}
+
+		var resp fundingResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to decode funding response: %w", err)
+		}
+
+		if !isSuccessCode(resp.Code) {
+			return nil, fmt.Errorf("API error code %d: %s", resp.Code, resp.Message)
+		}
+
+		all = append(all, resp.PositionFundings...)
+
+		if resp.NextCursor == "" || len(resp.PositionFundings) == 0 {
 			break
 		}
 

--- a/exchange/lighter/types.go
+++ b/exchange/lighter/types.go
@@ -2,50 +2,77 @@ package lighter
 
 // Lighter API response types
 // Base URL: https://mainnet.zklighter.elliot.ai/api/v1
+//
+// The Lighter API uses code=200 for success (not code=0). Each endpoint
+// returns its data under an endpoint-specific key (e.g. "trades", "deposits",
+// "position_fundings") rather than a generic "data" key. Cursor fields also
+// differ by endpoint ("next_cursor" for trades, "cursor" for deposits).
 
-// apiResponse is the generic envelope for paginated Lighter API responses.
-type apiResponse[T any] struct {
-	Code       int    `json:"code"`
-	Message    string `json:"message"`
-	NextCursor string `json:"next_cursor"`
-	Data       []T    `json:"data"`
+// tradesResponse is the response envelope for GET /api/v1/trades.
+type tradesResponse struct {
+	Code       int            `json:"code"`
+	Message    string         `json:"message"`
+	NextCursor string         `json:"next_cursor"`
+	Trades     []lighterTrade `json:"trades"`
 }
 
-// lighterTrade represents a single trade from GET /api/v1/trades
+// depositsResponse is the response envelope for GET /api/v1/deposit/history.
+type depositsResponse struct {
+	Code     int              `json:"code"`
+	Message  string           `json:"message"`
+	Cursor   string           `json:"cursor"`
+	Deposits []lighterDeposit `json:"deposits"`
+}
+
+// fundingResponse is the response envelope for GET /api/v1/positionFunding.
+type fundingResponse struct {
+	Code             int               `json:"code"`
+	Message          string            `json:"message"`
+	NextCursor       string            `json:"next_cursor"`
+	PositionFundings []lighterFunding  `json:"position_fundings"`
+}
+
+// lighterTrade represents a single trade from GET /api/v1/trades.
+// Field names and types match the actual API response.
 type lighterTrade struct {
-	TradeID         string `json:"trade_id"`
-	MarketID        int    `json:"market_id"`
-	AskAccountID    int    `json:"ask_account_id"`
-	BidAccountID    int    `json:"bid_account_id"`
-	Price           string `json:"price"`
-	Quantity        string `json:"quantity"`
-	TakerFee        string `json:"taker_fee"`
-	MakerFee        string `json:"maker_fee"`
-	IsBuyerTaker    bool   `json:"is_buyer_taker"`
-	Timestamp       int64  `json:"timestamp"` // Unix milliseconds
-	AskOrderID      string `json:"ask_order_id"`
-	BidOrderID      string `json:"bid_order_id"`
+	TradeID      int64  `json:"trade_id"`
+	TradeIDStr   string `json:"trade_id_str"`
+	MarketID     int    `json:"market_id"`
+	AskAccountID int    `json:"ask_account_id"`
+	BidAccountID int    `json:"bid_account_id"`
+	Price        string `json:"price"`
+	Size         string `json:"size"`
+	TakerFee     int64  `json:"taker_fee"`  // micro-USDC (divide by 1e6)
+	MakerFee     int64  `json:"maker_fee"`  // micro-USDC (divide by 1e6)
+	IsMakerAsk   bool   `json:"is_maker_ask"`
+	Timestamp    int64  `json:"timestamp"` // Unix milliseconds
+	AskID        int64  `json:"ask_id"`
+	AskIDStr     string `json:"ask_id_str"`
+	BidID        int64  `json:"bid_id"`
+	BidIDStr     string `json:"bid_id_str"`
 }
 
-// lighterFunding represents a funding payment from GET /api/v1/positionFunding
+// lighterFunding represents a funding payment from GET /api/v1/positionFunding.
+// Field names match the actual API response.
 type lighterFunding struct {
-	FundingID   string `json:"funding_id"`
-	AccountID   int    `json:"account_id"`
-	MarketID    int    `json:"market_id"`
-	Amount      string `json:"amount"` // Signed: negative = paid, positive = received
-	Timestamp   int64  `json:"timestamp"`
+	FundingID    int64  `json:"funding_id"`
+	MarketID     int    `json:"market_id"`
+	Change       string `json:"change"` // Signed: negative = paid, positive = received
+	Rate         string `json:"rate"`
+	PositionSize string `json:"position_size"`
+	PositionSide string `json:"position_side"`
+	Timestamp    int64  `json:"timestamp"` // Unix seconds
 }
 
-// lighterDeposit represents a deposit/withdrawal from GET /api/v1/deposit/history
+// lighterDeposit represents a deposit/withdrawal from GET /api/v1/deposit/history.
+// Field names match the actual API response.
 type lighterDeposit struct {
-	DepositID   string `json:"deposit_id"`
-	AccountID   int    `json:"account_id"`
-	L1Address   string `json:"l1_address"`
-	AssetID     int    `json:"asset_id"`
-	Amount      string `json:"amount"` // Positive = deposit, negative = withdrawal
-	Status      string `json:"status"` // "completed", "pending", etc.
-	Timestamp   int64  `json:"timestamp"`
-	TxHash      string `json:"tx_hash"`
+	DepositID string `json:"id"`
+	AssetID   int    `json:"asset_id"`
+	Amount    string `json:"amount"` // Positive = deposit, negative = withdrawal
+	Status    string `json:"status"` // "completed", "pending", etc.
+	Timestamp int64  `json:"timestamp"`
+	TxHash    string `json:"l1_tx_hash"`
 }
 
 // lighterAccountResp is the response from GET /api/v1/account
@@ -61,7 +88,7 @@ type lighterAccountResp struct {
 type lighterAccount struct {
 	AccountIndex    int                 `json:"account_index"`
 	L1Address       string              `json:"l1_address"`
-	Status          string              `json:"status"`
+	Status          int                 `json:"status"`
 	TotalAssetValue string              `json:"total_asset_value"`
 	Collateral      string              `json:"collateral"`
 	AvailableBalance string             `json:"available_balance"`
@@ -90,16 +117,66 @@ type lighterAsset struct {
 	LockedBalance string `json:"locked_balance"`
 }
 
-// lighterOrderBookDetail represents market metadata from the API
-type lighterOrderBookDetail struct {
-	MarketID   int    `json:"market_id"`
-	Symbol     string `json:"symbol"`
-	BaseAsset  string `json:"base_asset"`
-	QuoteAsset string `json:"quote_asset"`
-	MarketType string `json:"market_type"` // "perp" or "spot"
+// transfersResponse is the response envelope for GET /api/v1/transfer/history.
+type transfersResponse struct {
+	Code      int               `json:"code"`
+	Message   string            `json:"message"`
+	Cursor    string            `json:"cursor"`
+	Transfers []lighterTransfer `json:"transfers"`
 }
 
-// lighterOrderBookDetailsResp is the response from GET /api/v1/orderBookDetails
+// lighterTransfer represents an L2 internal transfer from GET /api/v1/transfer/history.
+type lighterTransfer struct {
+	ID               string `json:"id"`
+	AssetID          int    `json:"asset_id"`
+	Amount           string `json:"amount"`
+	Fee              string `json:"fee"`
+	Timestamp        int64  `json:"timestamp"` // Unix milliseconds
+	Type             string `json:"type"`      // L2TransferInflow, L2TransferOutflow, L2SelfTransfer, L2StakeAssetOutflow
+	FromL1Address    string `json:"from_l1_address"`
+	ToL1Address      string `json:"to_l1_address"`
+	FromAccountIndex int64  `json:"from_account_index"`
+	ToAccountIndex   int64  `json:"to_account_index"`
+	FromRoute        string `json:"from_route"`
+	ToRoute          string `json:"to_route"`
+	TxHash           string `json:"tx_hash"`
+}
+
+// withdrawsResponse is the response envelope for GET /api/v1/withdraw/history.
+type withdrawsResponse struct {
+	Code      int                `json:"code"`
+	Message   string             `json:"message"`
+	Cursor    string             `json:"cursor"`
+	Withdraws []lighterWithdraw  `json:"withdraws"`
+}
+
+// lighterWithdraw represents an L1 withdrawal from GET /api/v1/withdraw/history.
+type lighterWithdraw struct {
+	ID        string `json:"id"`
+	AssetID   int    `json:"asset_id"`
+	Amount    string `json:"amount"`
+	Timestamp int64  `json:"timestamp"` // Unix milliseconds
+	Status    string `json:"status"`    // "completed", "pending", etc.
+	Type      string `json:"type"`      // "fast", etc.
+	L1TxHash  string `json:"l1_tx_hash"`
+}
+
+// lighterOrderBookDetail represents market metadata from the API.
+// The API does not include base_asset/quote_asset fields; they are derived
+// from the symbol (e.g. "ETH" -> base=ETH, quote=USDC for perps;
+// "UNI/USDC" -> base=UNI, quote=USDC for spot).
+type lighterOrderBookDetail struct {
+	MarketID     int    `json:"market_id"`
+	Symbol       string `json:"symbol"`
+	MarketType   string `json:"market_type"` // "perp" or "spot"
+	BaseAssetID  int    `json:"base_asset_id"`
+	QuoteAssetID int    `json:"quote_asset_id"`
+}
+
+// lighterOrderBookDetailsResp is the response from GET /api/v1/orderBookDetails.
+// Perp markets are in "order_book_details", spot markets in "spot_order_book_details".
 type lighterOrderBookDetailsResp struct {
-	OrderBooks []lighterOrderBookDetail `json:"order_books"`
+	Code              int                      `json:"code"`
+	OrderBookDetails  []lighterOrderBookDetail `json:"order_book_details"`
+	SpotOrderBooks    []lighterOrderBookDetail `json:"spot_order_book_details"`
 }


### PR DESCRIPTION
## Summary
- **Hyperliquid**: Fix pagination boundary dedup, supplement userFillsByTime with userFills, skip self-sends (spot<->perp), add cStakingTransfer/vaultWithdraw handlers, borrow/lend interest sync via userBorrowLendInterest, combined perp+spot USDC snapshots using totalRawUsd, send pricing from usdcValue, subaccount+vault leader discovery, ledger-based zero-balance detection
- **Lighter**: Complete API response type refactor (5 mismatches fixed), auth header fix (no Bearer prefix), L2 transfer+withdraw history endpoints, funding timestamp boundary fix, per-wallet API key sharing
- **DB**: Account reset methods (DeleteSyncedData, DeleteProcessedData, ClearSyncReset, ClearProcessorReset), OrSyncResetRequested/OrProcessorResetRequested filter fields

## Test plan
- [x] All unit tests pass (pre-push hook verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)