### PR TITLE
feat(#240): origin-aware force-reset purge primitives (#204 rule)

### DIFF
--- a/db/accounts.go
+++ b/db/accounts.go
@@ -628,23 +628,37 @@ func (c *Client) ClearProcessorReset(ctx context.Context, accountID string) erro
 	return nil
 }
 
-// DeleteSyncedData deletes all synced data for an account: trades, transfers,
-// settlements, and spot balance snapshots. It ALSO wipes derived position data
-// (positions, position_events via cascade, and processor_checkpoints) because
-// position_events.event_id references trades/transfers/settlements without an
-// FK; leaving derived rows in place after a sync wipe creates orphans that
-// poison the cross-account missing_position_pnl walk and stall the processor.
+// DeleteSyncedData deletes the RE-FETCHABLE synced data for an account: gateway/
+// derived trades, transfers, settlements, and spot balance snapshots. It ALSO wipes
+// derived position data (positions, position_events via cascade, and
+// processor_checkpoints) because position_events.event_id references
+// trades/transfers/settlements without an FK; leaving derived rows in place after a
+// sync wipe creates orphans that poison the cross-account missing_position_pnl walk
+// and stall the processor.
 //
 // Sync reset thus becomes "wipe ingested + derived together" — mirroring what
 // processor_reset_requested does, except this path is triggered by
 // sync_reset_requested.
+//
+// #204/#240 SAFETY: this is the one blunt "delete every row for the account" path,
+// and a sync reset is a RE-FETCH — safe for gateway rows (idempotently re-pulled
+// from the live feed) and derived rows (regenerated), but CATASTROPHIC for
+// origin='upload' rows, which have NO live feed (user-provided Variational/Drift
+// data and gap-fill fills). Wiping those would delete irreplaceable source of truth.
+// So the trades/transfers/settlements deletes now EXCLUDE origin IN ('upload','manual')
+// via _nin: a reprocess/re-sync can never destroy source data. (spot_balance_snapshots
+// carries no origin column and is always gateway-captured / re-fetchable, so it is
+// wiped whole.)
 func (c *Client) DeleteSyncedData(ctx context.Context, accountID uuid.UUID) error {
 	id := accountID.String()
 
-	// Delete trades
+	// Delete trades (preserve irreplaceable upload/manual source — #204/#240)
 	tradesQuery := `
 		mutation DeleteTradesForAccount($id: uuid!) {
-			delete_trades(where: { exchange_account_id: { _eq: $id } }) {
+			delete_trades(where: {
+				exchange_account_id: { _eq: $id }
+				origin: { _nin: ["upload", "manual"] }
+			}) {
 				affected_rows
 			}
 		}
@@ -659,10 +673,13 @@ func (c *Client) DeleteSyncedData(ctx context.Context, accountID uuid.UUID) erro
 		return fmt.Errorf("failed to delete trades: %w", err)
 	}
 
-	// Delete transfers
+	// Delete transfers (preserve irreplaceable upload/manual source — #204/#240)
 	transfersQuery := `
 		mutation DeleteTransfersForAccount($id: uuid!) {
-			delete_transfers(where: { exchange_account_id: { _eq: $id } }) {
+			delete_transfers(where: {
+				exchange_account_id: { _eq: $id }
+				origin: { _nin: ["upload", "manual"] }
+			}) {
 				affected_rows
 			}
 		}
@@ -677,10 +694,13 @@ func (c *Client) DeleteSyncedData(ctx context.Context, accountID uuid.UUID) erro
 		return fmt.Errorf("failed to delete transfers: %w", err)
 	}
 
-	// Delete settlements
+	// Delete settlements (preserve irreplaceable upload/manual source — #204/#240)
 	settlementsQuery := `
 		mutation DeleteSettlementsForAccount($id: uuid!) {
-			delete_settlements(where: { exchange_account_id: { _eq: $id } }) {
+			delete_settlements(where: {
+				exchange_account_id: { _eq: $id }
+				origin: { _nin: ["upload", "manual"] }
+			}) {
 				affected_rows
 			}
 		}

--- a/db/origin_guard_test.go
+++ b/db/origin_guard_test.go
@@ -1,0 +1,196 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/zif-terminal/lib/models"
+)
+
+// captureServer stands up an httptest server that records every GraphQL request
+// body it receives and replies with a permissive `data` payload covering all the
+// mutations exercised by the #204/#240 origin-aware reset primitives. Because the
+// real machinebox graphql.Client marshals {query, variables} to JSON over HTTP,
+// this lets a test assert the OUTGOING query/where-clause without reaching into
+// graphql.Request's unexported fields.
+func captureServer(t *testing.T, bodies *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*bodies = append(*bodies, string(b))
+		resp := `{"data":{
+			"delete_trades":{"affected_rows":1},
+			"delete_transfers":{"affected_rows":1},
+			"delete_settlements":{"affected_rows":1},
+			"delete_spot_balance_snapshots":{"affected_rows":1},
+			"delete_positions":{"affected_rows":1},
+			"delete_processor_checkpoints_by_pk":{"exchange_account_id":"00000000-0000-0000-0000-000000000000"},
+			"update_transfers":{"affected_rows":0},
+			"insert_transfers":{"returning":[{"id":"11111111-1111-1111-1111-111111111111","exchange_account_id":"00000000-0000-0000-0000-000000000000","type":"interest","asset":"USDC","amount":"1","timestamp":0}]}
+		}}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+}
+
+func newCapturingClient(url string) *Client {
+	return NewClient(ClientConfig{URL: url, AdminSecret: "test-secret"})
+}
+
+// mustContainAll fails the test unless every needle is present in haystack.
+func mustContainAll(t *testing.T, label, haystack string, needles ...string) {
+	t.Helper()
+	for _, n := range needles {
+		if !strings.Contains(haystack, n) {
+			t.Errorf("%s: expected query to contain %q\n--- query ---\n%s", label, n, haystack)
+		}
+	}
+}
+
+// TestDeleteDerivedTransfers_OriginAwarePurge asserts the force-reset purge
+// primitive removes derived+manual rows but carves out the drift-hack anchor.
+func TestDeleteDerivedTransfers_OriginAwarePurge(t *testing.T) {
+	var bodies []string
+	srv := captureServer(t, &bodies)
+	defer srv.Close()
+	client := newCapturingClient(srv.URL)
+
+	if _, err := client.DeleteDerivedTransfers(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("DeleteDerivedTransfers failed: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(bodies))
+	}
+	q := bodies[0]
+	// Purges the regenerable / disallowed rows...
+	mustContainAll(t, "purge", q,
+		`source: \"derived\"`,           // legacy interest signal (retained)
+		`origin: { _in: [\"derived\", \"manual\"]`, // origin-aware purge of derived+manual
+	)
+	// ...while preserving the #248 drift-hack casualty anchor.
+	mustContainAll(t, "drift-hack carve-out", q,
+		`type: { _neq: \"hack\" }`,
+		`drift-dfx-derived`,
+		`drift-hack-rule`,
+	)
+	// It must NOT blanket-delete every derived row (that would take the anchor).
+	if strings.Contains(q, `origin: { _eq: \"derived\" }`) {
+		t.Errorf("purge must not blanket-match origin=derived (would delete the drift-hack anchor)")
+	}
+}
+
+// TestDeleteSyncedData_PreservesUploadAndManual asserts the one blunt "delete
+// everything for the account" path never wipes irreplaceable upload/manual source.
+func TestDeleteSyncedData_PreservesUploadAndManual(t *testing.T) {
+	var bodies []string
+	srv := captureServer(t, &bodies)
+	defer srv.Close()
+	client := newCapturingClient(srv.URL)
+
+	if err := client.DeleteSyncedData(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("DeleteSyncedData failed: %v", err)
+	}
+
+	var tradesQ, transfersQ, settlementsQ, snapshotsQ string
+	for _, b := range bodies {
+		switch {
+		case strings.Contains(b, "delete_trades"):
+			tradesQ = b
+		case strings.Contains(b, "delete_transfers"):
+			transfersQ = b
+		case strings.Contains(b, "delete_settlements"):
+			settlementsQ = b
+		case strings.Contains(b, "delete_spot_balance_snapshots"):
+			snapshotsQ = b
+		}
+	}
+	for _, tc := range []struct {
+		name, q string
+	}{
+		{"trades", tradesQ}, {"transfers", transfersQ}, {"settlements", settlementsQ},
+	} {
+		if tc.q == "" {
+			t.Fatalf("no %s delete mutation was sent", tc.name)
+		}
+		mustContainAll(t, tc.name+" preserve-source", tc.q,
+			`origin: { _nin: [\"upload\", \"manual\"]`,
+		)
+	}
+	// spot_balance_snapshots has no origin column and is always re-fetchable, so
+	// it is wiped whole (no _nin guard). This documents the intentional asymmetry.
+	if snapshotsQ == "" {
+		t.Fatalf("no snapshots delete mutation was sent")
+	}
+	if strings.Contains(snapshotsQ, "_nin") {
+		t.Errorf("snapshots delete unexpectedly carries an origin guard: %s", snapshotsQ)
+	}
+}
+
+// TestAddTransfers_StampsOrigin asserts derived writers can mark provenance and
+// that raw-fact writers (empty Origin) never send the column (DB default applies).
+func TestAddTransfers_StampsOrigin(t *testing.T) {
+	acct := uuid.New()
+
+	// (a) Origin set → column is sent.
+	var withOrigin []string
+	srvA := captureServer(t, &withOrigin)
+	defer srvA.Close()
+	clientA := newCapturingClient(srvA.URL)
+	if _, err := clientA.AddTransfers(context.Background(), []*models.TransferInput{{
+		ExchangeAccountID: acct, Type: models.TypeInterest, Asset: "USDC",
+		Amount: "1", Timestamp: time.Now(), Origin: "derived",
+	}}); err != nil {
+		t.Fatalf("AddTransfers(origin=derived) failed: %v", err)
+	}
+	if len(withOrigin) == 0 || !containsOriginVar(withOrigin, "derived") {
+		t.Errorf("expected insert variables to carry origin=derived, bodies=%v", withOrigin)
+	}
+
+	// (b) Origin empty → column omitted (DB default 'gateway' applies).
+	var noOrigin []string
+	srvB := captureServer(t, &noOrigin)
+	defer srvB.Close()
+	clientB := newCapturingClient(srvB.URL)
+	if _, err := clientB.AddTransfers(context.Background(), []*models.TransferInput{{
+		ExchangeAccountID: acct, Type: models.TypeDeposit, Asset: "USDC",
+		Amount: "5", Timestamp: time.Now(),
+	}}); err != nil {
+		t.Fatalf("AddTransfers(no origin) failed: %v", err)
+	}
+	for _, b := range noOrigin {
+		if strings.Contains(b, "insert_transfers") && strings.Contains(b, `"origin"`) {
+			t.Errorf("raw-fact insert must not send an origin column: %s", b)
+		}
+	}
+}
+
+// containsOriginVar reports whether any insert body carries origin=want in its
+// variables payload (json-encoded).
+func containsOriginVar(bodies []string, want string) bool {
+	for _, b := range bodies {
+		if !strings.Contains(b, "insert_transfers") {
+			continue
+		}
+		var req struct {
+			Variables struct {
+				Objects []map[string]interface{} `json:"objects"`
+			} `json:"variables"`
+		}
+		if err := json.Unmarshal([]byte(b), &req); err != nil {
+			continue
+		}
+		for _, o := range req.Variables.Objects {
+			if o["origin"] == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/db/transfer.go
+++ b/db/transfer.go
@@ -143,6 +143,13 @@ func (c *Client) AddTransfers(ctx context.Context, inputs []*TransferInput) ([]*
 		if len(input.Metadata) > 0 {
 			obj["metadata"] = input.Metadata
 		}
+		// #240 provenance: only send `origin` when the caller set it, so raw
+		// exchange-fact writers keep the DB default ('gateway'). Derived writers
+		// pass Origin='derived' so the force-reset purge can regenerate them; a
+		// value of 'manual' is rejected loudly by the DB block-trigger.
+		if input.Origin != "" {
+			obj["origin"] = input.Origin
+		}
 		objects[i] = obj
 	}
 
@@ -295,14 +302,45 @@ func (c *Client) DeleteTransfersByAccountAndType(ctx context.Context, accountID 
 	return resp.DeleteTransfers.AffectedRows, nil
 }
 
-// DeleteDerivedTransfers deletes transfer records with metadata source="derived" for an account.
-// Used by the activity processor to clean up previously-derived interest before full replay.
+// DeleteDerivedTransfers purges the regenerable / disallowed transfer rows for an
+// account before a full replay. This is the #240 origin-aware force-reset primitive:
+// it removes exactly the rows a reprocess is allowed to destroy and regenerate, and
+// NEVER an irreplaceable source-of-truth row.
+//
+// PURGES:
+//   - metadata.source = "derived"  → processor-computed interest (the historical
+//     signal; these rows also carry origin='derived' once written by the updated
+//     AddTransfers path, but the metadata predicate is retained so pre-stamp rows
+//     are still caught — belt-and-suspenders for replay determinism).
+//   - origin IN ('derived','manual') → any other processor-computed row, plus any
+//     'manual' row that slipped past the DB block-trigger (e.g. a superuser booking
+//     inserted with the trigger disabled). 'manual' is disallowed and never a source
+//     of truth, so a reprocess purges it.
+//
+// PRESERVES (never deleted here):
+//   - origin IN ('gateway','upload') → raw exchange facts and user uploads. This is
+//     the whole safety point of #204/#240: a reprocess must NEVER wipe source data.
+//   - the Drift-hack casualty anchor (type='hack' or metadata.source in the
+//     drift-dfx-derived / drift-hack-rule reclaimable set). Although that anchor is
+//     origin='derived', the #248 design owns its lifecycle via the atomic
+//     ReplaceDriftHackAnchor swap + in-memory reclaim, NOT via a pre-purge. Blanket-
+//     deleting it here would resurrect the reverted #247 trap (the row vanishes at
+//     replay start, reconcileDriftHack loses its input). The carve-out below MUST
+//     stay in lock-step with processor.driftHackReclaimableSources.
 func (c *Client) DeleteDerivedTransfers(ctx context.Context, accountID uuid.UUID) (int, error) {
 	query := `
 		mutation DeleteDerivedTransfers($exchange_account_id: uuid!) {
 			delete_transfers(where: {
 				exchange_account_id: { _eq: $exchange_account_id }
-				metadata: { _contains: { source: "derived" } }
+				_or: [
+					{ metadata: { _contains: { source: "derived" } } },
+					{ _and: [
+						{ origin: { _in: ["derived", "manual"] } },
+						{ type: { _neq: "hack" } },
+						{ _not: { metadata: { _contains: { source: "drift-dfx-derived" } } } },
+						{ _not: { metadata: { _contains: { source: "drift-hack-rule" } } } }
+					] }
+				]
 			}) {
 				affected_rows
 			}

--- a/models/transfer.go
+++ b/models/transfer.go
@@ -47,6 +47,14 @@ type TransferInput struct {
 	Timestamp         time.Time `json:"timestamp"`
 	ExternalID        string    `json:"external_id,omitempty"` // Native exchange ID for dedup
 	Metadata          map[string]string `json:"metadata,omitempty"`
+	// Origin is the #240 provenance marker: gateway (raw exchange fact),
+	// upload (user-provided, no live feed), derived (processor-computed,
+	// reproducible) or manual (hand adjustment — BLOCKED at the DB layer).
+	// Empty means "let the DB default (gateway) apply" — AddTransfers only
+	// sends the column when this is non-empty, so raw-fact writers keep the
+	// default. Derived writers MUST set Origin="derived" so the origin-aware
+	// force-reset purge can regenerate them. See db.DeleteDerivedTransfers.
+	Origin string `json:"origin,omitempty"`
 }
 
 // UnmarshalJSON custom unmarshaler to handle BIGINT timestamp


### PR DESCRIPTION
## Origin-aware force-reset purge primitives (rule #204 / harness #240)

Implements the Jaison-approved force-reset purge rule at the reset-primitive layer. Companion DB guard ships in infrastructure (migration `1883000000_origin_manual_guard`).

**The rule:** every money-table row carries an `origin` (`gateway|upload|derived|manual`, added in Stage A). A force-reset / full reprocess must **purge** `derived+manual` (regenerable / disallowed) and **NEVER** wipe `gateway+upload` (irreplaceable source of truth).

### Changes
- **`models.TransferInput`**: add `Origin` provenance field.
- **`db.AddTransfers`**: stamp `origin` only when set — raw-fact writers keep the DB default (`gateway`), derived writers can now mark provenance canonically.
- **`db.DeleteDerivedTransfers`** (force-replay / `processor_reset` primitive): purge `origin IN ('derived','manual')` in addition to the legacy `metadata.source='derived'` interest signal, while **carving out the Drift-hack casualty anchor** (`type='hack'` / `drift-dfx-derived` / `drift-hack-rule`).
- **`db.DeleteSyncedData`** (the one blunt "delete every row for the account" path, `sync_reset`): **exclude `origin IN ('upload','manual')`** from the trades/transfers/settlements deletes so a re-sync can never destroy irreplaceable upload/manual source. Gateway+derived still wiped (re-fetchable/regenerable); `spot_balance_snapshots` (no `origin` column, always re-fetchable) still wiped whole.

### Drift-hack landmine (why the carve-out)
The Drift-hack anchor is `origin='derived'` but its lifecycle is owned by the #248 atomic `ReplaceDriftHackAnchor` swap + in-memory reclaim, **not** by a pre-purge. A blunt `DELETE WHERE origin='derived'` would delete it at replay start and resurrect the reverted #247 double-count trap. The purge predicate excludes it (`type <> 'hack'` + drift metadata-source exclusions), kept in lock-step with `processor.driftHackReclaimableSources`.

### Verification
- `db/origin_guard_test.go` asserts the outgoing GraphQL (httptest capture): purge matches derived+manual and carves out the drift-hack anchor; sync-reset carries the `_nin` upload/manual guard; `AddTransfers` stamps `origin` only when set.
- `go build ./...` clean; full `db` + `models` suites pass.
- Purge/preserve predicate semantics independently validated against ephemeral Postgres 16 (see infrastructure PR).

### Deploy note (not in this PR)
`activity_processor` and `exchange-gateway` hand-vendor this lib and must re-vendor + bump to pick up these primitives. The DB-level manual-write block (infrastructure migration) holds regardless, so protection is not gated on the re-vendor.

Cross-repo: references `zif-terminal/infrastructure#204` (won't auto-close).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww1rWnKu1dcfkK57i1UmGu