### PR TITLE
fix(hyperliquid): treat vault movements as internal transfers (#184)

### DIFF
--- a/exchange/hyperliquid/client.go
+++ b/exchange/hyperliquid/client.go
@@ -1037,15 +1037,34 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		asset = "USDC"
 		amountStr = entry.Delta.Usdc
 
-	case "vaultcreate", "vaultdeposit":
-		transferType = models.TypeWithdraw
-		asset = "USDC"
-		amountStr = entry.Delta.Usdc
-
-	case "vaultdistribution":
-		transferType = models.TypeDeposit
-		asset = "USDC"
-		amountStr = entry.Delta.Usdc
+	case "vaultcreate", "vaultdeposit", "vaultdistribution", "vaultwithdraw":
+		// HL vault movements are INTERNAL to the user's own equity, NOT external
+		// cashflows (#184). A vaultDeposit/vaultCreate moves the user's USDC perp→
+		// vault; it stays their equity (now surfaced as an asset via
+		// userVaultEquities — see the exchange-gateway HL adapter). vaultDistribution
+		// (profit share paid back to the perp balance) and vaultWithdraw (principal +
+		// PnL returned) are the RETURN leg — also internal. Booking any of these as a
+		// TypeWithdraw/TypeDeposit mis-states net_deposits: the old code booked a
+		// vaultDeposit as a phantom OUTFLOW (understating net_deposits by the deposited
+		// principal while the vault equity was ALSO missing from the account value —
+		// the two nearly cancelled in the reconcile gap but the DISPLAYED portfolio was
+		// understated by the full vault equity), and booked the return as a phantom
+		// INFLOW. Treating the whole vault round-trip as an internal class-transfer
+		// (skipped, exactly like accountClassTransfer) keeps net_deposits reflecting
+		// ONLY true external cashflow, so the reconcile identity closes once the vault
+		// equity is counted as an asset AND the deposit is no longer a phantom outflow.
+		//
+		// vaultLeaderCommission (a vault LEADER's earned fee) is genuine income and is
+		// still recorded below as TypeReward — it is NOT a movement of the depositor's
+		// own principal.
+		//
+		// LIMITATION (flagged follow-up): the vault's realized PnL on a completed
+		// round-trip is no longer explicitly booked as realized/reward — the gain/loss
+		// is reflected in the returned USDC (equity) but lands in the reconcile
+		// residual rather than the realized bucket. Attributing vault PnL requires the
+		// processor to track the vault-deposit principal as a cost basis; that is out
+		// of scope here (this change is the net_deposits / phantom-flow fix).
+		return nil, nil, nil
 
 	case "cstakingtransfer":
 		// HyperStake consensus staking. Staking locks tokens out of the trading
@@ -1063,11 +1082,6 @@ func transformLedgerEntry(entry hlLedgerEntry, accountUUID uuid.UUID, walletAddr
 		// This is NOT a cashflow — the wallet's total USDC position is unchanged,
 		// just moved between trading classes. Intentionally skipped.
 		return nil, nil, nil
-
-	case "vaultwithdraw":
-		transferType = models.TypeDeposit
-		asset = "USDC"
-		amountStr = entry.Delta.NetWithdrawnUsd
 
 	case "vaultleadercommission":
 		transferType = models.TypeReward

--- a/exchange/hyperliquid/client_test.go
+++ b/exchange/hyperliquid/client_test.go
@@ -627,81 +627,54 @@ func TestTransformLedgerEntry(t *testing.T) {
 		}
 	})
 
-	t.Run("vaultCreate", func(t *testing.T) {
+	// #184: HL vault movements are internal class-transfers (not external cashflow),
+	// so vaultCreate / vaultDeposit / vaultDistribution / vaultWithdraw are SKIPPED
+	// (nil transfer), exactly like accountClassTransfer. The vault equity is surfaced
+	// as an asset by the exchange-gateway HL adapter instead. Booking these as
+	// withdraw/deposit mis-stated net_deposits (phantom outflow on deposit / phantom
+	// inflow on the return).
+	t.Run("vaultCreate skipped (#184 internal transfer)", func(t *testing.T) {
 		entry := hlLedgerEntry{
-			Time: 1700000000000,
-			Hash: "0xvaultcreate",
-			Delta: hlLedgerDelta{
-				Type: "vaultCreate",
-				Usdc: "-5000.00",
-			},
+			Time:  1700000000000,
+			Hash:  "0xvaultcreate",
+			Delta: hlLedgerDelta{Type: "vaultCreate", Usdc: "-5000.00"},
 		}
 		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if transfer == nil {
-			t.Fatal("expected non-nil transfer")
-		}
-		if transfer.Type != models.TypeWithdraw {
-			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeWithdraw)
-		}
-		if transfer.Asset != "USDC" {
-			t.Errorf("Asset = %q, want USDC", transfer.Asset)
-		}
-		if transfer.Amount != "5000" {
-			t.Errorf("Amount = %q, want 5000", transfer.Amount)
+		if transfer != nil {
+			t.Errorf("expected nil transfer for vaultCreate, got %+v", transfer)
 		}
 	})
 
-	t.Run("vaultDeposit", func(t *testing.T) {
+	t.Run("vaultDeposit skipped (#184 internal transfer)", func(t *testing.T) {
 		entry := hlLedgerEntry{
-			Time: 1700000000000,
-			Hash: "0xvaultdeposit",
-			Delta: hlLedgerDelta{
-				Type: "vaultDeposit",
-				Usdc: "-1000.00",
-			},
+			Time:  1700000000000,
+			Hash:  "0xvaultdeposit",
+			Delta: hlLedgerDelta{Type: "vaultDeposit", Usdc: "-1000.00"},
 		}
 		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if transfer == nil {
-			t.Fatal("expected non-nil transfer")
-		}
-		if transfer.Type != models.TypeWithdraw {
-			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeWithdraw)
-		}
-		if transfer.Amount != "1000" {
-			t.Errorf("Amount = %q, want 1000", transfer.Amount)
+		if transfer != nil {
+			t.Errorf("expected nil transfer for vaultDeposit, got %+v", transfer)
 		}
 	})
 
-	t.Run("vaultDistribution", func(t *testing.T) {
+	t.Run("vaultDistribution skipped (#184 internal transfer)", func(t *testing.T) {
 		entry := hlLedgerEntry{
-			Time: 1700000000000,
-			Hash: "0xvaultdist",
-			Delta: hlLedgerDelta{
-				Type: "vaultDistribution",
-				Usdc: "250.00",
-			},
+			Time:  1700000000000,
+			Hash:  "0xvaultdist",
+			Delta: hlLedgerDelta{Type: "vaultDistribution", Usdc: "250.00"},
 		}
 		transfer, _, err := transformLedgerEntry(entry, accountUUID, wallet)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if transfer == nil {
-			t.Fatal("expected non-nil transfer")
-		}
-		if transfer.Type != models.TypeDeposit {
-			t.Errorf("Type = %q, want %q", transfer.Type, models.TypeDeposit)
-		}
-		if transfer.Asset != "USDC" {
-			t.Errorf("Asset = %q, want USDC", transfer.Asset)
-		}
-		if transfer.Amount != "250" {
-			t.Errorf("Amount = %q, want 250", transfer.Amount)
+		if transfer != nil {
+			t.Errorf("expected nil transfer for vaultDistribution, got %+v", transfer)
 		}
 	})
 
@@ -724,7 +697,7 @@ func TestTransformLedgerEntry(t *testing.T) {
 		}
 	})
 
-	t.Run("vaultWithdraw as deposit", func(t *testing.T) {
+	t.Run("vaultWithdraw skipped (#184 internal transfer)", func(t *testing.T) {
 		entry := hlLedgerEntry{
 			Time: 1700000000000,
 			Hash: "0xvaultwithdraw",
@@ -737,23 +710,8 @@ func TestTransformLedgerEntry(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if transfer == nil {
-			t.Fatal("expected non-nil transfer for vaultWithdraw")
-		}
-		if transfer.Type != models.TypeDeposit {
-			t.Errorf("expected type %q, got %q", models.TypeDeposit, transfer.Type)
-		}
-		if transfer.Asset != "USDC" {
-			t.Errorf("expected asset USDC, got %q", transfer.Asset)
-		}
-		if transfer.Amount != "5229.047513" {
-			t.Errorf("expected amount 5229.047513, got %q", transfer.Amount)
-		}
-		if transfer.Metadata["source_type"] != "vaultwithdraw" {
-			t.Errorf("expected source_type vaultwithdraw, got %q", transfer.Metadata["source_type"])
-		}
-		if transfer.ExternalID != "0xvaultwithdraw_vaultwithdraw" {
-			t.Errorf("expected disambiguated external_id, got %q", transfer.ExternalID)
+		if transfer != nil {
+			t.Errorf("expected nil transfer for vaultWithdraw (#184), got %+v", transfer)
 		}
 	})
 


### PR DESCRIPTION
Part of #184 (canonical lib change; also vendored into exchange-gateway#2 so that PR builds standalone).

## Problem
`transformLedgerEntry` classified HL vault movements as external cashflow:
- `vaultCreate` / `vaultDeposit` → `TypeWithdraw` (a **phantom outflow** — understates `net_deposits` by the deposited principal)
- `vaultDistribution` → `TypeDeposit`, `vaultWithdraw` → `TypeDeposit` (phantom inflow on the return)

But a vault deposit just moves the user's own USDC perp→vault; the equity stays theirs (now surfaced as an asset via `userVaultEquities` in the gateway HL adapter). Booking it as a withdraw/deposit corrupts `net_deposits` and the reconcile identity.

## Fix
Reclassify `vaultCreate` / `vaultDeposit` / `vaultDistribution` / `vaultWithdraw` as **internal class-transfers → skipped** (`return nil, nil, nil`), exactly like the existing `accountClassTransfer` and `liquidation` handling. `net_deposits` then reflects only true external cashflow, so the reconcile identity closes once the vault equity is counted as an asset (gateway side). `vaultLeaderCommission` is left as `TypeReward` (genuine vault-leader income, not a movement of the depositor's principal).

Symmetric skip (deposit AND return) is required: skipping only the deposit while keeping the return as a deposit would make a completed round-trip inflate `net_deposits` by the withdrawn amount.

## Tests
`go build ./...`, `go vet`, and `go test ./exchange/hyperliquid/` all pass. Updated the four vault subtests in `client_test.go` to assert the entries are now skipped (nil transfer).

## Flagged follow-up
A completed vault round-trip's realized **PnL** (gain/loss) is no longer explicitly booked as `realized`/`reward` — it is reflected in the returned USDC (equity) but lands in the reconcile **residual**. Attributing vault PnL requires the processor to track the vault-deposit **principal as a cost basis**; out of scope here (this change is the net_deposits / phantom-flow fix).

## Re-vendor note ⚠️
The lib is hand-vendored (no script; consumers pin `v1.39.0`). After merge this needs a tag + re-vendor into exchange-gateway (already carried in #2), activity_processor, and the other consumers to take effect fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww1rWnKu1dcfkK57i1UmGu