### PR TITLE
perf(drift): cache earn API response across sub-accounts (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased] - Performance
+
+### Drift earn-response caching (lib#50)
+
+- `drift`: memoize the `/authority/{wallet}/snapshots/earn` payload keyed by
+  request URL (embeds baseURL + wallet authority) with a short 60s TTL, in a
+  process-wide cache. The syncer builds a fresh drift client per account, so a
+  wallet with N sub-accounts previously re-fetched the identical wallet-scoped
+  earn payload N times per sync cycle; it now fetches once and each sub-account
+  filters the shared payload to its own `accountID`. Failures are never cached.
+  Only the historical-backfill path (`FetchHistoricalBalanceSnapshots`) uses
+  earn; live current balances (`FetchBalances` → `/user/`) are unchanged, so the
+  cache cannot serve a stale current balance.
+
 ## [Unreleased] - ExchangeAccount Model Refactoring
 
 ### Breaking Changes

--- a/exchange/drift/client.go
+++ b/exchange/drift/client.go
@@ -36,7 +36,13 @@ type Client struct {
 	baseURL     string
 	httpClient  *http.Client
 	marketCache *marketCache
-	transport   httpcache.Transport
+	// earnCache memoizes the /authority/{wallet}/snapshots/earn payload so a
+	// wallet with multiple sub-accounts fetches it once per sync cycle instead
+	// of once per sub-account. It defaults to the process-wide globalEarnCache
+	// (required, because the syncer builds a fresh Client per account); tests
+	// may swap in an isolated cache.
+	earnCache *earnResponseCache
+	transport httpcache.Transport
 	// principal scopes the httpcache key per-account. Set at the top of
 	// every Fetch* method, cleared on return.
 	principal string
@@ -53,6 +59,7 @@ func NewClient() *Client {
 		baseURL:     "https://data.api.drift.trade",
 		httpClient:  &http.Client{Timeout: 30 * time.Second},
 		marketCache: newMarketCache(1 * time.Hour),
+		earnCache:   globalEarnCache,
 		transport:   tr,
 	}
 }

--- a/exchange/drift/earn_cache.go
+++ b/exchange/drift/earn_cache.go
@@ -1,0 +1,84 @@
+package drift
+
+import (
+	"sync"
+	"time"
+)
+
+// earnCacheTTL bounds how long a memoized earn payload is served.
+//
+// It must be:
+//   - short enough that a real earn change can't be served stale for long, and
+//   - long enough to cover a single sync cycle's back-to-back per-sub-account
+//     FetchHistoricalBalanceSnapshots calls (which fire within seconds of each
+//     other for every sub-account of a wallet).
+//
+// The earn endpoint (/authority/{wallet}/snapshots/earn) feeds
+// FetchHistoricalBalanceSnapshots — historical backfill snapshots, which are
+// immutable past points — NOT the live current balance (that comes from
+// /user/{accountID} in FetchBalances, which is intentionally left uncached).
+// So this cache can never serve a stale *current* balance; the short TTL is
+// defence-in-depth so that even the most-recent historical snapshot is at most
+// one TTL behind.
+const earnCacheTTL = 60 * time.Second
+
+// earnCacheEntry is a single memoized earn payload with its fetch time.
+type earnCacheEntry struct {
+	resp      *driftEarnResponse
+	fetchedAt time.Time
+}
+
+// earnResponseCache is a TTL-bounded memo of earn payloads keyed by request
+// URL. Safe for concurrent use.
+//
+// It exists to collapse the N identical earn fetches a wallet with N
+// sub-accounts would otherwise make per sync cycle: the earn endpoint returns
+// snapshots for ALL sub-accounts under a wallet, so every sub-account's
+// FetchHistoricalBalanceSnapshots call re-downloaded the same full payload and
+// then filtered it to its own accountID.
+type earnResponseCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]earnCacheEntry
+}
+
+// newEarnResponseCache creates an earn cache with the given TTL.
+func newEarnResponseCache(ttl time.Duration) *earnResponseCache {
+	return &earnResponseCache{
+		ttl:     ttl,
+		entries: make(map[string]earnCacheEntry),
+	}
+}
+
+// get returns the cached response for key when present and still fresh.
+// A stale entry is evicted and reported as a miss.
+func (ec *earnResponseCache) get(key string) (*driftEarnResponse, bool) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	entry, ok := ec.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(entry.fetchedAt) > ec.ttl {
+		delete(ec.entries, key)
+		return nil, false
+	}
+	return entry.resp, true
+}
+
+// set stores resp for key stamped at the current time.
+func (ec *earnResponseCache) set(key string, resp *driftEarnResponse) {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	ec.entries[key] = earnCacheEntry{resp: resp, fetchedAt: time.Now()}
+}
+
+// globalEarnCache memoizes earn payloads across drift Client instances.
+//
+// This MUST be package-level: the snapshot syncer constructs a FRESH drift
+// Client per account (exchange.GetClientWithDB("drift") → drift.NewClient()),
+// so an instance-scoped cache would never be shared across a wallet's
+// sub-accounts and the dedup would never fire. Keying by full request URL
+// (which embeds baseURL + wallet authority) keeps prod entries consistent and
+// prevents test servers on distinct ports from ever colliding.
+var globalEarnCache = newEarnResponseCache(earnCacheTTL)

--- a/exchange/drift/live.go
+++ b/exchange/drift/live.go
@@ -376,6 +376,50 @@ func (c *Client) FetchBalances(
 	return balances, nil
 }
 
+// fetchEarnResponse returns the earn snapshots payload for the given URL,
+// serving a memoized copy when another sub-account of the same wallet fetched
+// it within the TTL. On a cache miss it performs the live fetch and stores the
+// successful result.
+//
+// The earn endpoint is wallet-scoped and returns snapshots for ALL sub-accounts
+// under the wallet, so the payload is identical for every sub-account — the
+// per-account filtering happens in the caller. The returned *driftEarnResponse
+// is treated as read-only by callers (they only range over it), so sharing the
+// pointer across sub-accounts is safe. Failures (transport error, non-200,
+// success=false) are never cached, so a transient error is retried by the next
+// sub-account rather than memoized.
+func (c *Client) fetchEarnResponse(ctx context.Context, url string) (*driftEarnResponse, error) {
+	if c.earnCache != nil {
+		if cached, ok := c.earnCache.get(url); ok {
+			return cached, nil
+		}
+	}
+
+	resp, err := c.doRequestWithRetry(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("earn snapshots returned status %d", resp.StatusCode)
+	}
+
+	var result driftEarnResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode earn response: %w", err)
+	}
+
+	if !result.Success {
+		return nil, fmt.Errorf("earn snapshots returned success=false")
+	}
+
+	if c.earnCache != nil {
+		c.earnCache.set(url, &result)
+	}
+	return &result, nil
+}
+
 // FetchHistoricalBalanceSnapshots returns all historical earn snapshots from Drift.
 // Each entry represents a point-in-time snapshot of all asset balances.
 // Returns snapshots sorted by timestamp ascending (oldest first).
@@ -397,23 +441,9 @@ func (c *Client) FetchHistoricalBalanceSnapshots(
 	defer func() { c.principal = "" }()
 
 	url := fmt.Sprintf("%s/authority/%s/snapshots/earn", c.baseURL, wallet)
-	resp, err := c.doRequestWithRetry(ctx, url)
+	result, err := c.fetchEarnResponse(ctx, url)
 	if err != nil {
 		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("earn snapshots returned status %d", resp.StatusCode)
-	}
-
-	var result driftEarnResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode earn response: %w", err)
-	}
-
-	if !result.Success {
-		return nil, fmt.Errorf("earn snapshots returned success=false")
 	}
 
 	_ = c.fetchMarkets(ctx)

--- a/exchange/drift/live_test.go
+++ b/exchange/drift/live_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/zif-terminal/lib/models"
 )
@@ -334,6 +336,118 @@ func TestSpotAssetToPerpSymbol(t *testing.T) {
 			t.Errorf("spotAssetToPerpSymbol(%q) = %q, want %q", c.asset, got, c.want)
 		}
 	}
+}
+
+// TestEarnResponseCache_GetSetExpiry pins the low-level cache semantics:
+// miss on empty, hit while fresh, and eviction+miss once the TTL elapses.
+func TestEarnResponseCache_GetSetExpiry(t *testing.T) {
+	cache := newEarnResponseCache(40 * time.Millisecond)
+	key := "https://data.api.drift.trade/authority/walletX/snapshots/earn"
+
+	if _, ok := cache.get(key); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	resp := &driftEarnResponse{Success: true}
+	cache.set(key, resp)
+
+	got, ok := cache.get(key)
+	if !ok {
+		t.Fatal("expected hit while fresh")
+	}
+	if got != resp {
+		t.Fatal("expected the exact cached pointer back")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if _, ok := cache.get(key); ok {
+		t.Fatal("expected miss after TTL expiry")
+	}
+}
+
+// TestDriftClient_EarnResponseCached_AcrossSubaccounts is the regression test
+// for lib#50. Two DIFFERENT Client instances (mirroring the syncer, which
+// builds a fresh drift client per account via GetClientWithDB → NewClient)
+// share a process-wide earn cache. Each fetches historical snapshots for a
+// DIFFERENT sub-account of the SAME wallet. The wallet-scoped earn endpoint
+// must be hit exactly ONCE, and each sub-account must still receive only its
+// own filtered snapshot data (no cross-account contamination).
+func TestDriftClient_EarnResponseCached_AcrossSubaccounts(t *testing.T) {
+	const wallet = "walletAAA"
+	var earnHits int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/snapshots/earn") {
+			atomic.AddInt32(&earnHits, 1)
+			_ = json.NewEncoder(w).Encode(driftEarnResponse{
+				Success: true,
+				Accounts: []driftEarnAccountSnapshot{
+					{AccountID: "sub-1", Snapshots: []driftEarnSnapshot{
+						{EpochTs: 1700000000, Assets: []driftEarnAsset{
+							{Symbol: "USDC", MarketIndex: 0, Balance: "100"},
+						}},
+					}},
+					{AccountID: "sub-2", Snapshots: []driftEarnSnapshot{
+						{EpochTs: 1700000000, Assets: []driftEarnAsset{
+							{Symbol: "SOL", MarketIndex: 1, Balance: "5"},
+						}},
+					}},
+				},
+			})
+			return
+		}
+		// Any other endpoint (e.g. /stats/markets pre-warm) is irrelevant to
+		// this test since the earn assets already carry explicit symbols.
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	// Isolate from the process-wide globalEarnCache (and from other tests) by
+	// wiring both clients to a dedicated shared cache.
+	shared := newEarnResponseCache(earnCacheTTL)
+	newClient := func() *Client {
+		c := NewClient()
+		c.baseURL = server.URL
+		c.httpClient = server.Client()
+		c.earnCache = shared
+		return c
+	}
+
+	meta := json.RawMessage(`{"authority":"` + wallet + `"}`)
+
+	c1 := newClient()
+	acct1 := &models.ExchangeAccount{ID: "id-1", AccountIdentifier: "sub-1", AccountTypeMetadata: meta}
+	snaps1, err := c1.FetchHistoricalBalanceSnapshots(context.Background(), acct1)
+	if err != nil {
+		t.Fatalf("sub-1 FetchHistoricalBalanceSnapshots failed: %v", err)
+	}
+
+	c2 := newClient()
+	acct2 := &models.ExchangeAccount{ID: "id-2", AccountIdentifier: "sub-2", AccountTypeMetadata: meta}
+	snaps2, err := c2.FetchHistoricalBalanceSnapshots(context.Background(), acct2)
+	if err != nil {
+		t.Fatalf("sub-2 FetchHistoricalBalanceSnapshots failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&earnHits); got != 1 {
+		t.Fatalf("expected earn endpoint hit exactly once (cached across sub-accounts), got %d", got)
+	}
+
+	// Each sub-account must still get ONLY its own asset.
+	assertSingleAsset := func(label string, snaps []*models.HistoricalBalanceSnapshots, wantAsset string) {
+		if len(snaps) != 1 {
+			t.Fatalf("%s: expected 1 snapshot, got %d", label, len(snaps))
+		}
+		if len(snaps[0].Balances) != 1 {
+			t.Fatalf("%s: expected 1 balance, got %d", label, len(snaps[0].Balances))
+		}
+		if snaps[0].Balances[0].Asset != wantAsset {
+			t.Fatalf("%s: expected asset %s, got %s (cross-account contamination)", label, wantAsset, snaps[0].Balances[0].Asset)
+		}
+	}
+	assertSingleAsset("sub-1", snaps1, "USDC")
+	assertSingleAsset("sub-2", snaps2, "SOL")
 }
 
 func TestDriftClient_GetWalletFromAccount(t *testing.T) {


### PR DESCRIPTION
## Problem (lib#50)

`FetchHistoricalBalanceSnapshots` fetches the Drift earn API at
`/authority/{wallet}/snapshots/earn`, which is **wallet-scoped** and returns
snapshots for **all** sub-accounts under the wallet. The snapshot syncer calls
it once per sub-account, so a wallet with N sub-accounts re-downloads the
identical full payload N times per sync cycle, then filters it to one
`accountID`.

Note: the syncer constructs a **fresh** drift client per account
(`exchange.GetClientWithDB("drift")` → `GetClient` → `drift.NewClient()`), so an
instance-scoped cache would never be shared across a wallet's sub-accounts.

## Fix

A process-wide, TTL-bounded earn cache (`earn_cache.go`) keyed by request URL
(which embeds `baseURL` + wallet authority). On the second sub-account of a
wallet, `fetchEarnResponse` serves the memoized payload instead of re-fetching;
each sub-account still filters the shared payload to its own `accountID`.

### Cache design
- **Key:** full request URL (`baseURL/authority/{wallet}/snapshots/earn`). Embeds
  the wallet authority so entries are wallet-scoped; embeds `baseURL` so test
  servers on distinct ports never collide and a baseURL change can't serve a
  stale body.
- **TTL:** 60s — long enough to cover a sync cycle's back-to-back
  per-sub-account calls (which fire within seconds), short enough that a real
  earn change can't be served stale for long. Mirrors the existing `marketCache`
  short-TTL freshness model.
- **Scope:** package-level (`globalEarnCache`), wired as the default
  `Client.earnCache` in `NewClient`. Required so dedup works across the
  fresh-per-account clients; tests can swap in an isolated cache.
- **Invalidation:** stale entries are evicted on read; failures (transport
  error, non-200, `success=false`) are **never** cached, so a transient error is
  retried by the next sub-account.

### Why it can't serve a stale balance
Earn feeds only the **historical backfill** path
(`FetchHistoricalBalanceSnapshots`) — immutable past snapshots. The **live
current balance** comes from `/user/{accountID}` in `FetchBalances`, which is
**uncached** and unchanged by this PR. So the cache cannot produce a wrong
current balance. Per-account filtering is unchanged → no cross-account
contamination.

### Call reduction
For a wallet with N sub-accounts: N identical earn fetches per sync cycle → **1**.

## Tests
- `TestEarnResponseCache_GetSetExpiry` — miss/hit/TTL-eviction of the cache.
- `TestDriftClient_EarnResponseCached_AcrossSubaccounts` — two **different**
  client instances (mirroring fresh-per-account) sharing one cache fetch two
  different sub-accounts of the same wallet; asserts the earn endpoint is hit
  **exactly once** and each sub-account receives only its own filtered data.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Deploy path
The lib is hand-vendored (see #226). This PR is the `lib`-repo source of truth.
To deploy: the same change lands in infrastructure `.loops/vendor-lib` and is
re-vendored into `exchange-gateway/vendor/` (separate infra PR), then the
gateway is rebuilt — gated on QA and batched by the loop operator. **Do not
merge/deploy standalone.**

Refs zif-terminal/lib#50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww1rWnKu1dcfkK57i1UmGu
